### PR TITLE
[apptools] Add nodeunit cases for apptools

### DIFF
--- a/apptools/apptools-android-tests/tests.full.xml
+++ b/apptools/apptools-android-tests/tests.full.xml
@@ -3,22 +3,22 @@
 <test_definition>
   <suite category="Crosswalk App Tools" name="apptools-android-tests">
     <set name="CLI" type="pyunit">
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_no_sdk" priority="P1" purpose="Android - Validate if App Tool can not work well with create option and no android sdk" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_no_sdk" priority="P1" purpose="Android - Validate if project is created fail without android sdk" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/create_no_sdk.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_basic" priority="P1" purpose="Android - Validate if App Tool can work well with create" status="approved" type="Functional" subcase="2">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_basic" priority="P1" purpose="Android - Validate if the default main activity is 'MainActivity' and project is created fail when the project has been exist" status="approved" type="Functional" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/create_basic.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" priority="P1" purpose="Android - Validate if the App Tool rules about package name" status="approved" type="Functional" subcase="16">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" priority="P1" purpose="Android - Validate project can be created with validate package naming rule" status="approved" type="Functional" subcase="16">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/pkgName.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_build" priority="P1" purpose="Android - Validate if App Tool can work well with build option" status="approved" type="Functional" subcase="4">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_build" priority="P1" purpose="Android - Validate if project is built successfully with build command" status="approved" type="Functional" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/build.py</test_script_entry>
         </description>
@@ -38,7 +38,7 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/create_version.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_update" priority="P1" purpose="Android - Validate if App Tool can work well with update option" status="approved" type="Functional" subcase="10">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_update" priority="P1" purpose="Android - Validate if project can be updated successfully with update command" status="approved" type="Functional" subcase="10">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/update.py</test_script_entry>
         </description>
@@ -60,47 +60,57 @@
       </testcase>
     </set>
     <set name="common_module" type="nodeunit">
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_platform" priority="P1" purpose="Android - Validate if valid and invalid Crosswalk version" status="approved" type="Functional" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_platform" priority="P1" purpose="Android - Validate if Crosswalk version is valid or invalid" status="approved" type="Functional" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/android/test/android-platform.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_project_deps" priority="P1" purpose="Android - Validate if pick the last Crosswalk tools and download it" status="approved" type="Functional" subcase="5">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_project_deps" priority="P1" purpose="Android - Validate if Crosswalk is lastest version and download it" status="approved" type="Functional" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/android/test/android-dependencies.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_sdk" priority="P1" purpose="Android - Validate if the detail info about Android SDK" status="approved" type="Functional" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_sdk" priority="P1" purpose="Android - Validate if the detail info about Android SDK can be showed" status="approved" type="Functional" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/android/test/android-sdk.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_targets" priority="P1" purpose="Android - Validate if available Android targets" status="approved" type="Functional" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_targets" priority="P1" purpose="Android - Validate if Android targets are available" status="approved" type="Functional" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/android/test/android-targets.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" priority="P1" purpose="Android - Validate if the config and log message when create a new project" status="approved" type="Functional" subcase="7">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" priority="P1" purpose="Android - Validate if the config and log message are correct when create a new project" status="approved" type="Functional" subcase="7">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/application.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_command_parser" priority="P1" purpose="Android - Validate if the all commands parser" status="approved" type="Functional" subcase="6">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_command_parser" priority="P1" purpose="Android - Validate if parsing and validation of command-line arguments are correct" status="approved" type="Functional" subcase="5">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/command-parser.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_downloader" priority="P1" purpose="Android - Validate if support http and https to download data" status="approved" type="Functional" subcase="4">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_downloader" priority="P1" purpose="Android - Validate if App Tool support http and https to download data" status="approved" type="Functional" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/downloader.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_finite_progress" priority="P1" purpose="Android - Validate if create a finite progress" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_download_handler" priority="P1" purpose="Android - Validate if App Tool can handle downloading to a temp file" status="approved" type="Functional">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/download-handler.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_finite_progress" priority="P1" purpose="Android - Validate if a finite progress can be created" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/finite-progress.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_infinite_progress" priority="P1" purpose="Android - Validate if create a infinite progress" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_index_parser" priority="P1" purpose="Android - Validate if Crosswalk is lastest version when download different channel" status="approved" type="Functional" subcase="6">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/index-parser.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_infinite_progress" priority="P1" purpose="Android - Validate if a infinite progress can be created" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/infinite-progress.js</test_script_entry>
         </description>
@@ -110,7 +120,7 @@
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/logfile-output.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_main" priority="P1" purpose="Android - Validate if create/build/update a project and print the help/version info" status="approved" type="Functional" subcase="6">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_main" priority="P1" purpose="Android - Validate if a project can be created/built/updated and can print the help/version info" status="approved" type="Functional" subcase="6">
         <description>
           <test_script_entry timeout="600">/opt/apptools-android-tests/tools/crosswalk-app-tools/test/main.js</test_script_entry>
         </description>
@@ -120,17 +130,27 @@
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/output-tee.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_base" priority="P1" purpose="Android - Validate if base platform info and subclass" status="approved" type="Functional" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_base" priority="P1" purpose="Android - Validate if platform project template can be generated and platform project can be updated to latest Crosswalk" status="approved" type="Functional" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/platform-base.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_template_file" priority="P1" purpose="Android - Validate if support create/write/read a template file" status="approved" type="Functional" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_info" priority="P1" purpose="Android - Validate if App Tool support instantiate platform backend and can print the info of platform" status="approved" type="Functional" subcase="3">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/platform-info.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platforms_manager" priority="P1" purpose="Android - Validate if App Tool support load default backend for loaded platform" status="approved" type="Functional">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/platforms-manager.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_template_file" priority="P1" purpose="Android - Validate if App Tool support create/write/read a template file" status="approved" type="Functional" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/template-file.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_test_util" priority="P1" purpose="Android - Validate if create a temp directory/file under folder test-tmp" status="approved" type="Functional" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_test_util" priority="P1" purpose="Android - Validate if a temp directory/file can be created under folder test-tmp" status="approved" type="Functional" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/test-util.js</test_script_entry>
         </description>

--- a/apptools/apptools-android-tests/tests.xml
+++ b/apptools/apptools-android-tests/tests.xml
@@ -3,22 +3,22 @@
 <test_definition>
   <suite category="Crosswalk App Tools" name="apptools-android-tests">
     <set name="CLI" type="pyunit">
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_no_sdk" purpose="Android - Validate if App Tool can not work well with create option and no android sdk">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_no_sdk" purpose="Android - Validate if project is created fail without android sdk">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/create_no_sdk.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_basic" purpose="Android - Validate if App Tool can work well with create" subcase="2">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_basic" purpose="Android - Validate if the default main activity is 'MainActivity' and project is created fail when the project has been exist" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/create_basic.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" purpose="Android - Validate if the App Tool rules about package name" subcase="16">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" purpose="Android - Validate project can be created with validate package naming rule" subcase="16">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/pkgName.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_build" purpose="Android - Validate if App Tool can work well with build option" subcase="4">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_build" purpose="Android - Validate if project is built successfully with build command" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/build.py</test_script_entry>
         </description>
@@ -38,7 +38,7 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/create_version.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_update" purpose="Android - Validate if App Tool can work well with update option" subcase="10">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_update" purpose="Android - Validate if project can be updated successfully with update command" subcase="10">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/update.py</test_script_entry>
         </description>
@@ -55,47 +55,57 @@
       </testcase>
     </set>
     <set name="common_module" type="nodeunit">
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_platform" purpose="Android - Validate if valid and invalid Crosswalk version" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_platform" purpose="Android - Validate if Crosswalk version is valid or invalid" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/android/test/android-platform.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_project_deps" purpose="Android - Validate if pick the last Crosswalk tools and download it" subcase="5">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_project_deps" purpose="Android - Validate if Crosswalk is lastest version and download it" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/android/test/android-dependencies.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_sdk" purpose="Android - Validate if the detail info about Android SDK" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_sdk" purpose="Android - Validate if the detail info about Android SDK can be showed" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/android/test/android-sdk.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_targets" purpose="Android - Validate if available Android targets" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_android_targets" purpose="Android - Validate if Android targets are available" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/android/test/android-targets.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" purpose="Android - Validate if the config and log message when create a new project" subcase="7">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" purpose="Android - Validate if the config and log message are correct when create a new project" subcase="7">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/application.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_command_parser" purpose="Android - Validate if the all commands parser" subcase="6">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_command_parser" purpose="Android - Validate if parsing and validation of command-line arguments are correct" subcase="5">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/command-parser.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_downloader" purpose="Android - Validate if support http and https to download data" subcase="4">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_downloader" purpose="Android - Validate if App Tool support http and https to download data" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/downloader.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_finite_progress" purpose="Android - Validate if create a finite progress">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_download_handler" purpose="Android - Validate if App Tool can handle downloading to a temp file">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/download-handler.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_finite_progress" purpose="Android - Validate if a finite progress can be created">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/finite-progress.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_infinite_progress" purpose="Android - Validate if create a infinite progress">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_index_parser" purpose="Android - Validate if Crosswalk is lastest version when download different channel" subcase="6">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/index-parser.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_infinite_progress" purpose="Android - Validate if a infinite progress can be created">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/infinite-progress.js</test_script_entry>
         </description>
@@ -105,7 +115,7 @@
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/logfile-output.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_main" purpose="Android - Validate if create/build/update a project and print the help/version info" subcase="6">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_main" purpose="Android - Validate if a project can be created/built/updated and can print the help/version info" subcase="6">
         <description>
           <test_script_entry timeout="600">/opt/apptools-android-tests/tools/crosswalk-app-tools/test/main.js</test_script_entry>
         </description>
@@ -115,17 +125,27 @@
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/output-tee.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_base" purpose="Android - Validate if base platform info and subclass" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_base" purpose="Android - Validate if platform project template can be generated and platform project can be updated to latest Crosswalk" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/platform-base.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_template_file" purpose="Android - Validate if support create/write/read a template file" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_info" purpose="Android - Validate if App Tool support instantiate platform backend and can print the info of platform" subcase="3">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/platform-info.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platforms_manager" purpose="Android - Validate if App Tool support load default backend for loaded platform">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/platforms-manager.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_template_file" purpose="Android - Validate if App Tool support create/write/read a template file" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/template-file.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_test_util" purpose="Android - Validate if create a temp directory/file under folder test-tmp" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_test_util" purpose="Android - Validate if a temp directory/file can be created under folder test-tmp" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-android-tests/tools/crosswalk-app-tools/test/test-util.js</test_script_entry>
         </description>

--- a/apptools/apptools-ios-tests/apptools/create.py
+++ b/apptools/apptools-ios-tests/apptools/create.py
@@ -34,12 +34,6 @@ import commands
 import comm
 
 class TestCrosswalkApptoolsFunctions(unittest.TestCase):
-    def test_normal(self):
-        comm.setUp()
-        os.chdir(comm.XwalkPath)
-        comm.create(self)
-        comm.clear("org.xwalk.test")
-
     def test_dir_exist(self):
         comm.setUp()
         os.chdir(comm.XwalkPath)

--- a/apptools/apptools-ios-tests/tests.full.xml
+++ b/apptools/apptools-ios-tests/tests.full.xml
@@ -3,17 +3,17 @@
 <test_definition>
   <suite category="Crosswalk App Tools" name="apptools-ios-tests">
     <set name="CLI" type="pyunit">
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_pkgName" priority="P1" purpose="iOS - Validate if the App Tool rules about package name" status="approved" type="Functional" subcase="16">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_pkgName" priority="P1" purpose="iOS - Validate project can be created with validate package naming rule" status="approved" type="Functional" subcase="16">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/pkgName.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_build" priority="P1" purpose="iOS - Validate if App Tool can work well with build option" status="approved" type="Functional" subcase="2">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_build" priority="P1" purpose="iOS - Validate if project is built successfully with build command" status="approved" type="Functional" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/build.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_create" priority="P1" purpose="iOS - Validate if App Tool can work well with create option" status="approved" type="Functional" subcase="2">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_create" priority="P1" purpose="iOS - Validate if project is created fail when the project has been exist" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/create.py</test_script_entry>
         </description>
@@ -25,17 +25,17 @@
       </testcase>
     </set>
     <set name="common_module" type="nodeunit">
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_application" priority="P1" purpose="iOS - Validate if the config and log message when create a new project" status="approved" type="Functional" subcase="7">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_application" priority="P1" purpose="iOS - Validate if the config and log message are correct when create a new project" status="approved" type="Functional" subcase="7">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/application.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_finite_progress" priority="P1" purpose="iOS - Validate if create a finite progress" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_finite_progress" priority="P1" purpose="iOS - Validate if a finite progress can be created" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/finite-progress.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_infinite_progress" priority="P1" purpose="iOS - Validate if create a infinite progress" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_infinite_progress" priority="P1" purpose="iOS - Validate if a infinite progress can be created" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/infinite-progress.js</test_script_entry>
         </description>
@@ -50,17 +50,27 @@
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/output-tee.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_platform_base" priority="P1" purpose="iOS - Validate if base platform info and subclass" status="approved" type="Functional" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_platform_base" priority="P1" purpose="iOS - Validate if platform project template can be generated and platform project can be updated to latest Crosswalk" status="approved" type="Functional" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/platform-base.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_template_file" priority="P1" purpose="iOS - Validate if support create/write/read a template file" status="approved" type="Functional" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_info" priority="P1" purpose="iOS - Validate if App Tool support instantiate platform backend and can print the info of platform" status="approved" type="Functional" subcase="3">
+        <description>
+          <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/platform-info.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platforms_manager" priority="P1" purpose="iOS - Validate if App Tool support load default backend for loaded platform" status="approved" type="Functional">
+        <description>
+          <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/platforms-manager.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_template_file" priority="P1" purpose="iOS - Validate if App Tool support create/write/read a template file" status="approved" type="Functional" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/template-file.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_test_util" priority="P1" purpose="iOS - Validate if create a temp directory/file under folder test-tmp" status="approved" type="Functional" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_test_util" priority="P1" purpose="iOS - Validate if a temp directory/file can be created under folder test-tmp" status="approved" type="Functional" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/test-util.js</test_script_entry>
         </description>

--- a/apptools/apptools-ios-tests/tests.xml
+++ b/apptools/apptools-ios-tests/tests.xml
@@ -3,17 +3,17 @@
 <test_definition>
   <suite category="Crosswalk App Tools" name="apptools-ios-tests">
     <set name="CLI" type="pyunit">
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_pkgName" purpose="iOS - Validate if the App Tool rules about package name" subcase="16">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_pkgName" purpose="iOS - Validate project can be created with validate package naming rule" subcase="16">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/pkgName.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_build" purpose="iOS - Validate if App Tool can work well with build option" subcase="2">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_build" purpose="iOS - Validate if project is built successfully with build command" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/build.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_create" purpose="iOS - Validate if App Tool can work well with create option" subcase="2">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_create" purpose="iOS - Validate if project is created fail when the project has been exist">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/create.py</test_script_entry>
         </description>
@@ -25,17 +25,17 @@
       </testcase>
     </set>
     <set name="common_module" type="nodeunit">
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_application" purpose="iOS - Validate if the config and log message when create a new project" subcase="7">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_application" purpose="iOS - Validate if the config and log message are correct when create a new project" subcase="7">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/application.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_finite_progress" purpose="iOS - Validate if create a finite progress">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_finite_progress" purpose="iOS - Validate if a finite progress can be created">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/finite-progress.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_infinite_progress" purpose="iOS - Validate if create a infinite progress">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_infinite_progress" purpose="iOS - Validate if a infinite progress can be created">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/infinite-progress.js</test_script_entry>
         </description>
@@ -50,17 +50,27 @@
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/output-tee.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_platform_base" purpose="iOS - Validate if base platform info and subclass" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_platform_base" purpose="iOS - Validate if platform project template can be generated and platform project can be updated to latest Crosswalk" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/platform-base.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_template_file" purpose="iOS - Validate if support create/write/read a template file" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_info" purpose="iOS - Validate if App Tool support instantiate platform backend and can print the info of platform" subcase="3">
+        <description>
+          <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/platform-info.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platforms_manager" purpose="iOS - Validate if App Tool support load default backend for loaded platform">
+        <description>
+          <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/platforms-manager.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_template_file" purpose="iOS - Validate if App Tool support create/write/read a template file" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/template-file.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_test_util" purpose="iOS - Validate if create a temp directory/file under folder test-tmp" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_test_util" purpose="iOS - Validate if a temp directory/file can be created under folder test-tmp" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/test-util.js</test_script_entry>
         </description>

--- a/apptools/apptools-linux-tests/apptools/create.py
+++ b/apptools/apptools-linux-tests/apptools/create.py
@@ -35,10 +35,6 @@ import commands
 import comm
 
 class TestCrosswalkApptoolsFunctions(unittest.TestCase):
-    def test_normal(self):
-        comm.create(self)
-        comm.cleanTempData(comm.TEST_PROJECT_COMM)
-
     def test_dir_exist(self):
         try:
             comm.setUp()

--- a/apptools/apptools-linux-tests/tests.full.xml
+++ b/apptools/apptools-linux-tests/tests.full.xml
@@ -3,17 +3,17 @@
 <test_definition>
   <suite category="Crosswalk App Tools" name="apptools-linux-tests">
     <set name="apptools" type="pyunit">
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create" priority="P1" purpose="Linux - Validate if App Tool can work well with create option" status="approved" type="Functional" subcase="2">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create" priority="P1" purpose="Linux - Validate if project is created fail when the project has been exist" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/apptools/create.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_build" priority="P1" purpose="Linux - Validate if App Tool can work well with build option" status="approved" type="Functional" subcase="1">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_build" priority="P1" purpose="Linux - Validate if project is built successfully with build command" status="approved" type="Functional" subcase="1">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/apptools/build.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" priority="P1" purpose="Linux - Validate if the App Tool rules about package name" status="approved" type="Functional" subcase="17">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" priority="P1" purpose="Linux - Validate project can be created with validate package naming rule" status="approved" type="Functional" subcase="17">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/apptools/pkgName.py</test_script_entry>
         </description>
@@ -25,17 +25,17 @@
       </testcase>
     </set>
     <set name="common_module" type="nodeunit">
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" priority="P1" purpose="Linux - Validate if the config and log message when create a new project" status="approved" type="Functional" subcase="7">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" priority="P1" purpose="Linux - Validate if the config and log message are correct when create a new project" status="approved" type="Functional" subcase="7">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/application.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_finite_progress" priority="P1" purpose="Linux - Validate if create a finite progress" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_finite_progress" priority="P1" purpose="Linux - Validate if a finite progress can be created" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/finite-progress.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_infinite_progress" priority="P1" purpose="Linux - Validate if create a infinite progress" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_infinite_progress" priority="P1" purpose="Linux - Validate if a infinite progress can be created" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/infinite-progress.js</test_script_entry>
         </description>
@@ -50,17 +50,27 @@
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/output-tee.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_base" priority="P1" purpose="Linux - Validate if base platform info and subclass" status="approved" type="Functional" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_base" priority="P1" purpose="Linux - Validate if platform project template can be generated and platform project can be updated to latest Crosswalk" status="approved" type="Functional" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/platform-base.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_template_file" priority="P1" purpose="Linux - Validate if support create/write/read a template file" status="approved" type="Functional" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_info" priority="P1" purpose="Linux - Validate if App Tool support instantiate platform backend and can print the info of platform" status="approved" type="Functional" subcase="3">
+        <description>
+          <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/platform-info.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platforms_manager" priority="P1" purpose="Linux - Validate if App Tool support load default backend for loaded platform" status="approved" type="Functional">
+        <description>
+          <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/platforms-manager.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_template_file" priority="P1" purpose="Linux - Validate if App Tool support create/write/read a template file" status="approved" type="Functional" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/template-file.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_test_util" priority="P1" purpose="Linux - Validate if create a temp directory/file under folder test-tmp" status="approved" type="Functional" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_test_util" priority="P1" purpose="Linux - Validate if a temp directory/file can be created under folder test-tmp" status="approved" type="Functional" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/test-util.js</test_script_entry>
         </description>

--- a/apptools/apptools-linux-tests/tests.xml
+++ b/apptools/apptools-linux-tests/tests.xml
@@ -3,17 +3,17 @@
 <test_definition>
   <suite category="Crosswalk App Tools" name="apptools-linux-tests">
     <set name="apptools" type="pyunit">
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create" purpose="Linux - Validate if App Tool can work well with create option" subcase="2">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create" purpose="Linux - Validate if project is created fail when the project has been exist">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/apptools/create.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_build" purpose="Linux - Validate if App Tool can work well with build option" subcase="1">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_build" purpose="Linux - Validate if project is built successfully with build command" subcase="1">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/apptools/build.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" purpose="Linux - Validate if the App Tool rules about package name" subcase="17">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" purpose="Linux - Validate project can be created with validate package naming rule" subcase="17">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/apptools/pkgName.py</test_script_entry>
         </description>
@@ -25,17 +25,17 @@
       </testcase>
     </set>
     <set name="common_module" type="nodeunit">
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" purpose="Linux - Validate if the config and log message when create a new project" subcase="7">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" purpose="Linux - Validate if the config and log message are correct when create a new project" subcase="7">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/application.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_finite_progress" purpose="Linux - Validate if create a finite progress">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_finite_progress" purpose="Linux - Validate if a finite progress can be created">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/finite-progress.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_infinite_progress" purpose="Linux - Validate if create a infinite progress">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_infinite_progress" purpose="Linux - Validate if a infinite progress can be created">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/infinite-progress.js</test_script_entry>
         </description>
@@ -50,17 +50,27 @@
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/output-tee.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_base" purpose="Linux - Validate if base platform info and subclass" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_base" purpose="Linux - Validate if platform project template can be generated and platform project can be updated to latest Crosswalk" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/platform-base.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_template_file" purpose="Linux - Validate if support create/write/read a template file" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_info" purpose="Linux - Validate if App Tool support instantiate platform backend and can print the info of platform" subcase="3">
+        <description>
+          <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/platform-info.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platforms_manager" purpose="Linux - Validate if App Tool support load default backend for loaded platform">
+        <description>
+          <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/platforms-manager.js</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_template_file" purpose="Linux - Validate if App Tool support create/write/read a template file" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/template-file.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_test_util" purpose="Linux - Validate if create a temp directory/file under folder test-tmp" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_test_util" purpose="Linux - Validate if a temp directory/file can be created under folder test-tmp" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/test-util.js</test_script_entry>
         </description>


### PR DESCRIPTION
Due to the test case test_normal is duplicate with test_pkgName_positive1 and the testsuit of crosswalk-app-tools is updated, so delete them

Impacted tests(approved):new 19,update 19,delete 6
Unit test platform:[Android]
Unit test result summary:pass 38,fail 0,block 0