### PR TITLE
[misc-linux] Update test page link for Xiami Muisc

### DIFF
--- a/misc/webappmanu-linux-tests/webapp/Xiami_Music_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/Xiami_Music_Feature.html
@@ -44,16 +44,14 @@ Authors:
       <li>Install the "xiamimusic.deb" webapp and launch it with command like:<br>
           xwalk $(dirname $(realpath $(which xiamimusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
-      <li>Choose a song and play. </li>
-      <li>Click the "Next Music" link. </li>
+      <li>Click the "Next Music" link</li>
     </ol>
     <p>
       <strong>Expected Output:</strong>
     </p>
     <ol>
-      <li>Webapp could be launched successfully. </li>
-      <li>The song play fine. </li>
-      <li>The song will switch to the next. </li>
+      <li>Webapp could be launched successfully, and music should be autostarted</li>
+      <li>The song will switch to the next</li>
     </ol>
   </body>
 </html>

--- a/misc/webappmanu-linux-tests/webapp/Xiami_Music_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/Xiami_Music_Link.html
@@ -44,14 +44,14 @@ Authors:
       <li>Install the "xiamimusic.deb" webapp and launch it with command like:<br>
           xwalk $(dirname $(realpath $(which xiamimusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
-      <li>Click the different links in the page several times. </li>
+      <li>Click the different links in the page several times</li>
     </ol>
     <p>
       <strong>Expected Output:</strong>
     </p>
     <ol>
-      <li>Webapp could be launched successfully. </li>
-      <li>The links can be clicked and jumped correct. </li>
+      <li>Webapp could be launched successfully, and music should be autostarted</li>
+      <li>The links can be clicked and jumped correctly</li>
     </ol>
   </body>
 </html>

--- a/misc/webappmanu-linux-tests/webapp/Xiami_Music_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/Xiami_Music_Name.html
@@ -44,14 +44,14 @@ Authors:
       <li>Install the "xiamimusic.deb" webapp and launch it with command like:<br>
           xwalk $(dirname $(realpath $(which xiamimusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
-      <li>Search "xiamimusic" app shortcut in the launcher and check the app name. </li>
+      <li>Search "xiamimusic" app shortcut in the launcher and check the app name</li>
     </ol>
     <p>
       <strong>Expected Output:</strong>
     </p>
     <ol>
-      <li>Webapp could be launched successfully. </li>
-      <li>Find the app shortcut and the app name is "deepin-webapps-xiami-music". </li>
+      <li>Webapp could be launched successfully, and music should be autostarted</li>
+      <li>Find the app shortcut and the app name is "deepin-webapps-xiami-music"</li>
     </ol>
   </body>
 </html>

--- a/misc/webappmanu-linux-tests/webapp/Xiami_Music_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/Xiami_Music_UI.html
@@ -44,14 +44,14 @@ Authors:
       <li>Install the "xiamimusic.deb" webapp and launch it with command like:<br>
           xwalk $(dirname $(realpath $(which xiamimusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
-      <li>Validate the page layout and display. </li>
+      <li>Validate the page layout and display</li>
     </ol>
     <p>
       <strong>Expected Output:</strong>
     </p>
     <ol>
-      <li>Webapp could be launched successfully. </li>
-      <li>The page layout normal and display correctly. </li>
+      <li>Webapp could be launched successfully, and music should be autostarted</li>
+      <li>The page layout is normal and display correctly</li>
     </ol>
   </body>
 </html>

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.xiamimusic/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.xiamimusic/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "deepin-webapps-xiami-music",
   "xwalk_version": "0.0.1",
-  "start_url": "http://www.xiami.com/app/webmusic/index"
+  "start_url": "http://www.xiami.com/radio"
 }


### PR DESCRIPTION
Test page issue (http://www.xiami.com/app/webmusic/index)
existed in both crosswalk and chrome, so replace it with
new page (http://www.xiami.com/radio)

Impacted tests(approved): new 0, update 4, delete 0
Unit test platform: Crosswalk Project for Linux 15.43.347.0
Unit test result summary: pass 4, fail 0, block 0

BUG=http://crosswalk-project.org/jira/browse/XWALK-4196