### PR TITLE
[webapi] Add tests for Notification.permission

### DIFF
--- a/tools/build/pack_deb.py
+++ b/tools/build/pack_deb.py
@@ -528,6 +528,14 @@ def buildPKGAPP(build_json=None):
 		if not buildSRC(BUILD_ROOT_SRC, BUILD_ROOT_PKG_APP, build_json):
 		    return False
 
+		comXML = os.path.join(BUILD_ROOT_PKG_APP, "tests.xml")
+		linuxXML = os.path.join(BUILD_ROOT_PKG_APP, "tests.linux.xml")
+		if os.path.exists(linuxXML):
+		    if not doCMD("rm -rf %s" %  comXML):
+		        return False
+		    if not doCMD("mv %s %s" %  (linuxXML, comXML)):
+		        return False
+
 		if "subapp-list" in build_json:
 		    for i_sub_app in build_json["subapp-list"].keys():
 		       if not buildSubAPP(

--- a/webapi/tct-notification-w3c-tests/notification/notification_permission.html
+++ b/webapi/tct-notification-w3c-tests/notification/notification_permission.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<title>Notification Test: permission</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://www.w3.org/TR/notifications/#dom-notification-permission">
+<meta name="assert" content="Check that the Notification.permission attribute is implemented as specified for existence, type, readonly">
+<script src="support/notifications.js"></script>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+
+<div id="log"></div>
+
+<script>
+
+test(function () {
+    assert_true("permission" in Notification, "Notification.permission attribute exists");
+}, "Check if Notification.permission attribute exists");
+
+test(function () {
+    assert_readonly(Notification, "permission", "Notification.permission attribute is readonly");
+}, "Check if Notification.permission attribute is readonly");
+
+test(function () {
+    assert_equals(typeof Notification.permission, "string", "Type of Notification.permission is string");
+}, "Check if the type of Notification.permission attribute is string");
+
+</script>

--- a/webapi/tct-notification-w3c-tests/suite.json
+++ b/webapi/tct-notification-w3c-tests/suite.json
@@ -74,7 +74,7 @@
             "copylist": {
                 "inst.deb.py": "inst.py",
                 "tests.full.xml": "tests.full.xml",
-                "tests.xml": "tests.xml"
+                "tests.linux.xml": "tests.xml"
             },
             "pkg-app": {
                 "blacklist": ["crosswalk-app-tools-deb"],

--- a/webapi/tct-notification-w3c-tests/tests.linux.xml
+++ b/webapi/tct-notification-w3c-tests/tests.linux.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="./testcase.xsl"?>
+<test_definition>
+  <suite category="W3C/HTML5 APIs" name="tct-notification-w3c-tests">
+    <set name="Notification" type="js">
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="auto" id="notification_supports" purpose="Check if notification supports">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_attribute.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="auto" id="notification_onclose_exist" purpose="Check if notification.onclose attribute exists">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_attribute.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="auto" id="notification_onclose_type" purpose="Check if the type notification.onclose attribute is object">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_attribute.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="auto" id="notification_requestPermission_exist" purpose="Check if notification.requestPermission method exists">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_requestPermission.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="auto" id="notification_requestPermission_type" purpose="Check if the type notification.requestPermission method is function">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_requestPermission.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="auto" id="notification_permission_exists" purpose="Check if Notification.permission attribute exists">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_permission.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="auto" id="notification_permission_readonly" purpose="Check if Notification.permission attribute is readonly">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_permission.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="auto" id="notification_permission_type" purpose="Check if the type of Notification.permission attribute is string">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_permission.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="auto" id="notification_constructor" purpose="Check if Notification has all valid arguments that expecting an notification is to be created">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_constructor.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="manual" id="notification_body" purpose="Check if the notification body show correct">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_body-manual.html</test_script_entry>
+        </description>
+      </testcase>
+    </set>
+  </suite>
+</test_definition>


### PR DESCRIPTION
According to the comments in https://crosswalk-project.org
/jira/browse/XWALK-4061, only constructor, permission,
requestPermission and onclose are supported, update tests
following these comments

Impacted tests(approved): new 3, update 0, delete 0
Unit test platform: Crosswalk Project for Linux 15.43.347.0
Unit test result summary: pass 3, fail 0, block 0