### PR TITLE
[usecase-linux] Update usecase for externalurl

### DIFF
--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.externalurl/index.html
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.externalurl/index.html
@@ -38,13 +38,13 @@ Authors:
   </head>
   <body>
     <div>
-      <a href="https://crosswalk-project.org/">Internal URL</a><br>
-      <a href="http://www.baidu.com">External URL</a>
+      <a href="./res/index.html">URL in scope</a><br>
+      <a href="https://crosswalk-project.org/">URL out of scope</a>
     </div>
     <h2>Test Steps:</h2>
     <ol>
-      <li>Click "Internal URL" link</li>
-      <li>Click "External URL" link</li>
+      <li>Click "URL in scope" link</li>
+      <li>Click "URL out of scope" link</li>
     </ol>
     <h2>Expected Result:</h2>
     <ol>

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.externalurl/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.externalurl/manifest.json
@@ -9,6 +9,6 @@
             "density": "1.0"
         }
     ],
-    "scope": "https://crosswalk-project.org/",
+    "scope": "/res/",
     "start_url": "index.html"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.externalurl/res/index.html
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.externalurl/res/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8">
+    <title>Crosswalk Sample App</title>
+  </head>
+  <body>
+    <p>This is a Crosswalk Sample Application</p>
+  </body>
+</html>

--- a/usecase/usecase-wrt-linux-tests/samples/ExternalURL/index.html
+++ b/usecase/usecase-wrt-linux-tests/samples/ExternalURL/index.html
@@ -47,8 +47,8 @@ Authors:
   <h2>Test Steps:</h2>
   <ol>
     <li>Install the webapp 'externalurl.deb' and launch it</li>
-    <li>Click the link "Internal URL"</li>
-    <li>Click the link "External URL"</li>
+    <li>Click the link "URL in scope"</li>
+    <li>Click the link "URL out of scope"</li>
   </ol>
   <h2>Expected Result:</h2>
   <ol>


### PR DESCRIPTION
Cross-origin URL in scope is not valid as feature
description. Update scope section of manifest
following it.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Linux 15.43.347.0
Unit test result summary: pass 1, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4151