### PR TITLE
[Embeddingapi] Add embeddingapi zoom feature autocase

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/assets/zoom.html
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/assets/zoom.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta name="viewport" content="width=device-width, minimum-scale=0.5, maximum-scale=2.0, initial-scale=0.5"/>
+</head>
+<body style='margin:0'>
+<div style='width:200%;height:100px;border:1px solid black'>Zoomable</div>
+</body>
+</html>

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -22,6 +22,7 @@ import org.chromium.content.browser.test.util.CallbackHelper;
 import org.chromium.content.browser.test.util.Criteria;
 import org.chromium.content.browser.test.util.CriteriaHelper;
 import org.chromium.net.test.util.TestWebServer;
+import org.chromium.ui.gfx.DeviceDisplayInfo;
 import org.xwalk.core.JavascriptInterface;
 import org.xwalk.core.XWalkDownloadListener;
 import org.xwalk.core.XWalkNavigationHistory;
@@ -812,6 +813,78 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
 			                    mimetype, contentLength);
 					}
 				});
+	    }
+	});
+    }
+
+    protected boolean canZoomInOnUiThread() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return mXWalkView.canZoomIn();
+            }
+        });
+    }
+    
+    protected boolean canZoomOutOnUiThread() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return mXWalkView.canZoomOut();
+            }
+        });
+    }
+    
+    protected void zoomInOnUiThreadAndWait() throws Throwable {
+    	final double dipScale = DeviceDisplayInfo.create(getActivity()).getDIPScale() ;
+        final float previousScale = mTestHelperBridge.getOnScaleChangedHelper().getScale() * (float)dipScale;
+        assertTrue(runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return mXWalkView.zoomIn();
+            }
+        }));
+        // The zoom level is updated asynchronously.
+        pollOnUiThread(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return previousScale != mTestHelperBridge.getOnScaleChangedHelper().getScale() * (float)dipScale;
+            }
+        });
+    }
+
+    protected void zoomOutOnUiThreadAndWait() throws Throwable {
+    	final double dipScale = DeviceDisplayInfo.create(getActivity()).getDIPScale() ;
+        final float previousScale = mTestHelperBridge.getOnScaleChangedHelper().getScale() * (float)dipScale;
+        assertTrue(runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return mXWalkView.zoomOut();
+            }
+        }));
+        // The zoom level is updated asynchronously.
+        pollOnUiThread(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return previousScale != mTestHelperBridge.getOnScaleChangedHelper().getScale() * (float)dipScale;
+            }
+        });
+    }
+    
+    protected void zoomByOnUiThreadAndWait(final float delta) throws Throwable {
+    	final double dipScale = DeviceDisplayInfo.create(getActivity()).getDIPScale() ;
+        final float previousScale = mTestHelperBridge.getOnScaleChangedHelper().getScale() * (float)dipScale;
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.zoomBy(delta);
+            }
+        });
+        // The zoom level is updated asynchronously.
+        pollOnUiThread(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return previousScale != mTestHelperBridge.getOnScaleChangedHelper().getScale() * (float)dipScale;
             }
         });
     }

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewTest.java
@@ -4,6 +4,8 @@
 
 package org.xwalk.embedding.test.v5;
 
+import java.util.concurrent.Callable;
+
 import android.graphics.Color;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 import android.annotation.SuppressLint;
@@ -131,5 +133,113 @@ public class XWalkViewTest extends XWalkViewTestBase {
             e.printStackTrace();
             assertTrue(false);
         }
+    }
+
+    @SmallTest
+    public void testOnCanZoomInAndOut() {
+        try {
+        	final float mPageMinimumScale = 0.5f;
+        	String url = "file:///android_asset/zoom.html";
+        	assertFalse("Should not be able to zoom in", canZoomInOnUiThread());
+        	loadUrlSync(url);
+            pollOnUiThread(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return mPageMinimumScale == mTestHelperBridge.getOnScaleChangedHelper().getScale();
+                }
+            });
+            assertTrue("Should be able to zoom in", canZoomInOnUiThread());
+            assertFalse("Should not be able to zoom out", canZoomOutOnUiThread());
+
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+			// TODO: handle exception
+            assertTrue(false);
+            e.printStackTrace();
+		}
+    }
+    
+    @SmallTest
+    public void testOnZoomByLimited() {
+        try {
+        	final float MAXIMUM_SCALE = 2.0f;
+        	final float mPageMinimumScale = 0.5f;
+        	String url = "file:///android_asset/zoom.html";
+        	assertFalse("Should not be able to zoom in", canZoomInOnUiThread());
+        	loadUrlSync(url);
+            pollOnUiThread(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return mPageMinimumScale == mTestHelperBridge.getOnScaleChangedHelper().getScale();
+                }
+            });
+            
+            zoomByOnUiThreadAndWait(4.0f);
+            pollOnUiThread(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return MAXIMUM_SCALE == mTestHelperBridge.getOnScaleChangedHelper().getScale();
+                }
+            });
+            
+            zoomByOnUiThreadAndWait(0.5f);
+            pollOnUiThread(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return MAXIMUM_SCALE * 0.5f == mTestHelperBridge.getOnScaleChangedHelper().getScale();
+                }
+            });
+
+            zoomByOnUiThreadAndWait(0.01f);
+            pollOnUiThread(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return mPageMinimumScale == mTestHelperBridge.getOnScaleChangedHelper().getScale();
+                }
+            });
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+			// TODO: handle exception
+            assertTrue(false);
+            e.printStackTrace();
+		}
+    }
+    
+    @SmallTest
+    public void testOnZoomInAndOut() {
+        try {
+        	final float mPageMinimumScale = 0.5f;
+        	String url = "file:///android_asset/zoom.html";
+        	assertFalse("Should not be able to zoom in", canZoomInOnUiThread());
+        	loadUrlSync(url);
+            pollOnUiThread(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return mPageMinimumScale == mTestHelperBridge.getOnScaleChangedHelper().getScale();
+                }
+            });
+
+            while (canZoomInOnUiThread()) {
+                zoomInOnUiThreadAndWait();
+            }
+            assertTrue("Should be able to zoom out", canZoomOutOnUiThread());
+
+            while (canZoomOutOnUiThread()) {
+                zoomOutOnUiThreadAndWait();
+            }
+            assertTrue("Should be able to zoom in", canZoomInOnUiThread());
+            
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+			// TODO: handle exception
+            assertTrue(false);
+            e.printStackTrace();
+		}
     }
 }

--- a/embeddingapi/embedding-api-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-api-android-tests/tests.full.xml
@@ -83,7 +83,7 @@
           <test_script_entry>org.xwalk.embedding.test.v4.XWalkResourceClientTest</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="7">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="10">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-api-android-tests/tests_v5.xml
+++ b/embeddingapi/embedding-api-android-tests/tests_v5.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite name="webapi-embeddingapi-xwalk-tests" category="Android embedding APIs">
     <set name="EmbeddingApiTest" type="androidunit" location="device">
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="7">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="10">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/assets/zoom.html
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/assets/zoom.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta name="viewport" content="width=device-width, minimum-scale=0.5, maximum-scale=2.0, initial-scale=0.5"/>
+</head>
+<body style='margin:0'>
+<div style='width:200%;height:100px;border:1px solid black'>Zoomable</div>
+</body>
+</html>

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -22,6 +22,7 @@ import org.chromium.content.browser.test.util.CallbackHelper;
 import org.chromium.content.browser.test.util.Criteria;
 import org.chromium.content.browser.test.util.CriteriaHelper;
 import org.chromium.net.test.util.TestWebServer;
+import org.chromium.ui.gfx.DeviceDisplayInfo;
 import org.xwalk.core.JavascriptInterface;
 import org.xwalk.core.XWalkDownloadListener;
 import org.xwalk.core.XWalkNavigationHistory;
@@ -812,6 +813,78 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
 			                    mimetype, contentLength);
 					}
 				});
+            }
+        });
+    }
+
+    protected boolean canZoomInOnUiThread() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return mXWalkView.canZoomIn();
+            }
+        });
+    }
+    
+    protected boolean canZoomOutOnUiThread() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return mXWalkView.canZoomOut();
+            }
+        });
+    }
+    
+    protected void zoomInOnUiThreadAndWait() throws Throwable {
+    	final double dipScale = DeviceDisplayInfo.create(getActivity()).getDIPScale() ;
+        final float previousScale = mTestHelperBridge.getOnScaleChangedHelper().getScale() * (float)dipScale;
+        assertTrue(runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return mXWalkView.zoomIn();
+            }
+        }));
+        // The zoom level is updated asynchronously.
+        pollOnUiThread(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return previousScale != mTestHelperBridge.getOnScaleChangedHelper().getScale() * (float)dipScale;
+            }
+        });
+    }
+
+    protected void zoomOutOnUiThreadAndWait() throws Throwable {
+    	final double dipScale = DeviceDisplayInfo.create(getActivity()).getDIPScale() ;
+        final float previousScale = mTestHelperBridge.getOnScaleChangedHelper().getScale() * (float)dipScale;
+        assertTrue(runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return mXWalkView.zoomOut();
+            }
+        }));
+        // The zoom level is updated asynchronously.
+        pollOnUiThread(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return previousScale != mTestHelperBridge.getOnScaleChangedHelper().getScale() * (float)dipScale;
+            }
+        });
+    }
+    
+    protected void zoomByOnUiThreadAndWait(final float delta) throws Throwable {
+    	final double dipScale = DeviceDisplayInfo.create(getActivity()).getDIPScale() ;
+        final float previousScale = mTestHelperBridge.getOnScaleChangedHelper().getScale() * (float)dipScale;
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.zoomBy(delta);
+            }
+        });
+        // The zoom level is updated asynchronously.
+        pollOnUiThread(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return previousScale != mTestHelperBridge.getOnScaleChangedHelper().getScale() * (float)dipScale;
             }
         });
     }

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewTest.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewTest.java
@@ -4,6 +4,8 @@
 
 package org.xwalk.embedding.test.v5;
 
+import java.util.concurrent.Callable;
+
 import android.graphics.Color;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 import android.annotation.SuppressLint;
@@ -131,5 +133,113 @@ public class XWalkViewTest extends XWalkViewTestBase {
             e.printStackTrace();
             assertTrue(false);
         }
+    }
+
+    @SmallTest
+    public void testOnCanZoomInAndOut() {
+        try {
+        	final float mPageMinimumScale = 0.5f;
+        	String url = "file:///android_asset/zoom.html";
+        	assertFalse("Should not be able to zoom in", canZoomInOnUiThread());
+        	loadUrlSync(url);
+            pollOnUiThread(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return mPageMinimumScale == mTestHelperBridge.getOnScaleChangedHelper().getScale();
+                }
+            });
+            assertTrue("Should be able to zoom in", canZoomInOnUiThread());
+            assertFalse("Should not be able to zoom out", canZoomOutOnUiThread());
+
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+			// TODO: handle exception
+            assertTrue(false);
+            e.printStackTrace();
+		}
+    }
+    
+    @SmallTest
+    public void testOnZoomByLimited() {
+        try {
+        	final float MAXIMUM_SCALE = 2.0f;
+        	final float mPageMinimumScale = 0.5f;
+        	String url = "file:///android_asset/zoom.html";
+        	assertFalse("Should not be able to zoom in", canZoomInOnUiThread());
+        	loadUrlSync(url);
+            pollOnUiThread(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return mPageMinimumScale == mTestHelperBridge.getOnScaleChangedHelper().getScale();
+                }
+            });
+            
+            zoomByOnUiThreadAndWait(4.0f);
+            pollOnUiThread(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return MAXIMUM_SCALE == mTestHelperBridge.getOnScaleChangedHelper().getScale();
+                }
+            });
+            
+            zoomByOnUiThreadAndWait(0.5f);
+            pollOnUiThread(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return MAXIMUM_SCALE * 0.5f == mTestHelperBridge.getOnScaleChangedHelper().getScale();
+                }
+            });
+
+            zoomByOnUiThreadAndWait(0.01f);
+            pollOnUiThread(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return mPageMinimumScale == mTestHelperBridge.getOnScaleChangedHelper().getScale();
+                }
+            });
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+			// TODO: handle exception
+            assertTrue(false);
+            e.printStackTrace();
+		}
+    }
+    
+    @SmallTest
+    public void testOnZoomInAndOut() {
+        try {
+        	final float mPageMinimumScale = 0.5f;
+        	String url = "file:///android_asset/zoom.html";
+        	assertFalse("Should not be able to zoom in", canZoomInOnUiThread());
+        	loadUrlSync(url);
+            pollOnUiThread(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return mPageMinimumScale == mTestHelperBridge.getOnScaleChangedHelper().getScale();
+                }
+            });
+
+            while (canZoomInOnUiThread()) {
+                zoomInOnUiThreadAndWait();
+            }
+            assertTrue("Should be able to zoom out", canZoomOutOnUiThread());
+
+            while (canZoomOutOnUiThread()) {
+                zoomOutOnUiThreadAndWait();
+            }
+            assertTrue("Should be able to zoom in", canZoomInOnUiThread());
+            
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+			// TODO: handle exception
+            assertTrue(false);
+            e.printStackTrace();
+		}
     }
 }

--- a/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
@@ -83,7 +83,7 @@
           <test_script_entry>org.xwalk.embedding.test.v4.XWalkResourceClientTest</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="7">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="10">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/tests_v5.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests_v5.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite name="webapi-embeddingapi-xwalk-tests" category="Android embedding APIs">
     <set name="EmbeddingApiTest" type="androidunit" location="device">
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="7">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="10">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewTest</test_script_entry>
         </description>


### PR DESCRIPTION
https://crosswalk-project.org/jira/browse/XWALK-4169
https://crosswalk-project.org/jira/browse/XWALK-4170
https://crosswalk-project.org/jira/browse/XWALK-4171

-add embeddingapi autocase for XWalkView zoomIn, zoomOut, zoomBy features
-cover the XWalkViewActivity and XWalkInitializer two ways

Impacted tests(approved): new 3, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 3, fail 0, block 0