### PR TITLE
[apptools-android] Change dir to parent dir before removing the project for apptools android

### DIFF
--- a/apptools/apptools-android-tests/apptools/comm.py
+++ b/apptools/apptools-android-tests/apptools/comm.py
@@ -72,6 +72,7 @@ def setUp():
 
 
 def clear(pkg):
+    os.chdir(XwalkPath)
     if os.path.exists(ConstPath + "/../tools/" + pkg):
         try:
             shutil.rmtree(XwalkPath + pkg)


### PR DESCRIPTION
Impacted tests(approved):new 0,update 1,delete 0
Unit test platform:[Android]
Unit test result summary:pass 100,fail 5,block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4324