### PR TITLE
[misc] Update test steps for Cargo Bridge

### DIFF
--- a/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_Feature.html
@@ -41,17 +41,17 @@ Authors:
       <strong>Test steps:</strong>
     </p>
     <ol>
-      <li>Install the "cargobridge.deb" webapp and launch it. </li>
-      <li>Validate the plug-in loading. </li>
-      <li>Click the button "Play". </li>
+      <li>Install the "cargobridge.deb" webapp and launch it with command like:<br>
+          xwalk $(dirname $(realpath $(which cargobridge)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+      </li>
+      <li>Click button "Play"</li>
     </ol>
     <p>
       <strong>Expected Output:</strong>
     </p>
     <ol>
-      <li>Webapp could be launched successfully. </li>
-      <li>The plug-in load successfully. </li>
-      <li>The button is be able to click and open a new page. </li>
+      <li>Webapp could be launched successfully</li>
+      <li>Button "Play" could be clicked and new page would be created</li>
     </ol>
   </body>
 </html>

--- a/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_Link.html
@@ -41,15 +41,17 @@ Authors:
       <strong>Test steps:</strong>
     </p>
     <ol>
-      <li>Install the "cargobridge.deb" webapp and launch it. </li>
-      <li>Click the different links in the page several times. </li>
+      <li>Install the "cargobridge.deb" webapp and launch it with command like:<br>
+          xwalk $(dirname $(realpath $(which cargobridge)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+      </li>
+      <li>Click the different links in the page several times</li>
     </ol>
     <p>
       <strong>Expected Output:</strong>
     </p>
     <ol>
-      <li>Webapp could be launched successfully. </li>
-      <li>The links can be clicked and jumped correct. </li>
+      <li>Webapp could be launched successfully</li>
+      <li>The links can be clicked and jumped correct</li>
     </ol>
   </body>
 </html>

--- a/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_Name.html
@@ -41,15 +41,17 @@ Authors:
       <strong>Test steps:</strong>
     </p>
     <ol>
-      <li>Install the "cargobridge.deb" webapp and launch it. </li>
-      <li>Search "cargobridge" app shortcut in the launcher and check the app name. </li>
+      <li>Install the "cargobridge.deb" webapp and launch it with command like:<br>
+          xwalk $(dirname $(realpath $(which cargobridge)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+      </li>
+      <li>Search "cargobridge" app shortcut in the launcher and check the app name</li>
     </ol>
     <p>
       <strong>Expected Output:</strong>
     </p>
     <ol>
-      <li>Webapp could be launched successfully. </li>
-      <li>Find the app shortcut and the app name is "deepin-webapps-cargo-bridge". </li>
+      <li>Webapp could be launched successfully</li>
+      <li>Find the app shortcut and the app name is "deepin-webapps-cargo-bridge"</li>
     </ol>
   </body>
 </html>

--- a/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_UI.html
@@ -41,15 +41,17 @@ Authors:
       <strong>Test steps:</strong>
     </p>
     <ol>
-      <li>Install the "cargobridge.deb" webapp and launch it. </li>
-      <li>Validate the page layout and display. </li>
+      <li>Install the "cargobridge.deb" webapp and launch it with command like:<br>
+          xwalk $(dirname $(realpath $(which cargobridge)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+      </li>
+      <li>Validate the page layout and display</li>
     </ol>
     <p>
       <strong>Expected Output:</strong>
     </p>
     <ol>
-      <li>Webapp could be launched successfully. </li>
-      <li>The page layout normal and display correctly. </li>
+      <li>Webapp could be launched successfully</li>
+      <li>The page layout normal and display correctly</li>
     </ol>
   </body>
 </html>


### PR DESCRIPTION
Add new option "--ppapi-flash-path=xx" for launching
test app. But display nothing after launching it with
this change, issue tracked by https://crosswalk-project.org/
jira/browse/XWALK-3670

Impacted tests(approved): new 0, update 4, delete 0
Unit test platform: Crosswalk Project for Linux 15.43.350.0
Unit test result summary: pass 1, fail 3, block 0