### PR TITLE
[webapi] Update qunit, khronos harnesses.

### DIFF
--- a/webapi/tct-webgl-nonw3c-tests/webgl/khronos/COPYING
+++ b/webapi/tct-webgl-nonw3c-tests/webgl/khronos/COPYING
@@ -10,6 +10,10 @@ readPixelsBadArgs.html
 - <img id="img" src="http://www.opengl.org/img/opengl_logo.jpg" style="display:none;">
 + <img id="img" src="http://127.0.0.1:8080/opt/tct-webgl-nonw3c-tests/webgl/khronos/resources/opengl_logo.jpg" style="display:none;">
 
+Add completion_callback handle to js-test-pre.js.
+
+Add completion_callback handle to unit.js.
+
 These tests are copyright by the Khronos Group under MIT License:
 https://www.khronos.org/registry/webgl/sdk/tests/test-guidelines.md
 

--- a/webapi/tct-webgl-nonw3c-tests/webgl/khronos/resources/js-test-pre.js
+++ b/webapi/tct-webgl-nonw3c-tests/webgl/khronos/resources/js-test-pre.js
@@ -20,6 +20,25 @@
 ** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
+var caseName = document.title;
+var subcaseIndex = 1;
+
+function KhronosTest(name) {
+  this.name = name;
+  this.status = null;
+  this.message = null;
+}
+
+var khronosTests = [];
+var khronosTestMsg = null;
+
+function Status() {
+  this.status = null;
+  this.message = null;
+}
+
+var statusObj = new Status();
+statusObj.status = 0;
 
 (function() {
   var testHarnessInitialized = false;
@@ -63,6 +82,10 @@ function reportTestResultsToHarness(success, msg) {
 }
 
 function notifyFinishedToHarness() {
+  if (window.parent.completion_callback) {
+    window.parent.completion_callback(khronosTests, statusObj);
+  }
+
   if (window.parent.webglTestHarness) {
     window.parent.webglTestHarness.notifyFinished(window.location.pathname);
   }
@@ -73,6 +96,11 @@ function description(msg)
     initTestingHarness();
     if (msg === undefined) {
       msg = document.title;
+    }
+    else {
+      if (document.title.length === 0) {
+        caseName = msg;
+      }
     }
     // For MSIE 6 compatibility
     var span = document.createElement("span");
@@ -98,12 +126,29 @@ function escapeHTML(text)
 
 function testPassed(msg)
 {
+    //console.log("webgl function testPassed:" + msg)
+    if (msg !== "successfullyParsed is true") {
+      var ktest = new KhronosTest(caseName + "/" + subcaseIndex);
+      ktest.status = 0;
+      ktest.message = escapeHTML(msg);
+      khronosTests.push(ktest);
+      subcaseIndex++;
+    }
+
     reportTestResultsToHarness(true, msg);
     debug('<span><span class="pass">PASS</span> ' + escapeHTML(msg) + '</span>');
 }
 
 function testFailed(msg)
 {
+    if (msg.indexOf("successfullyParsed should be true") === -1) {
+        var ktest = new KhronosTest(caseName + "/" + subcaseIndex);
+        ktest.status = 1;
+        ktest.message = escapeHTML(msg);
+        khronosTests.push(ktest);
+        subcaseIndex++;
+    }
+
     reportTestResultsToHarness(false, msg);
     debug('<span><span class="fail">FAIL</span> ' + escapeHTML(msg) + '</span>');
 }

--- a/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/COPYING
+++ b/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/COPYING
@@ -3,6 +3,8 @@ https://github.com/johnmccutchan/ecmascript_simd(commit 68644ec611cbf97453afc595
 without any modification.
 
 All the tests in load_stroe_test.html come from https://github.com/johnmccutchan/ecmascript_simd/src/ecmascript_simd_tests.js
-with out any modification.
+with modification:
+
+Add completion_callback handle to qunit.js.
 
 Please see the LICENSE.txt for the license terms and conditions.

--- a/webapi/webapi-webcl-nonw3c-tests/webcl/khronos/COPYING
+++ b/webapi/webapi-webcl-nonw3c-tests/webcl/khronos/COPYING
@@ -1,5 +1,10 @@
 All test cases in this folder come from
 https://github.com/KhronosGroup/WebCL-conformance
+with modification:
+
+Add exception handle to js-test-post.js.
+
+Add completion_callback handle to js-test-pre.js.
 
 These tests are copyright by the Khronos Group under MIT License:
 https://www.khronos.org/registry/webgl/sdk/tests/test-guidelines.md

--- a/webapi/webapi-webcl-nonw3c-tests/webcl/khronos/resources/js-test-post.js
+++ b/webapi/webapi-webcl-nonw3c-tests/webcl/khronos/resources/js-test-post.js
@@ -22,6 +22,13 @@
 */
 
 shouldBe("successfullyParsed", "true", true);
-webcl.releaseAll();
+
+try {
+  webcl.releaseAll();
+}
+catch (e) {
+  console.log(e.name);
+}
+
 debug('<br /><span class="pass">TEST COMPLETE</span>');
 notifyFinishedToHarness()

--- a/webapi/webapi-webcl-nonw3c-tests/webcl/khronos/resources/js-test-pre.js
+++ b/webapi/webapi-webcl-nonw3c-tests/webcl/khronos/resources/js-test-pre.js
@@ -22,6 +22,25 @@
 */
 
 // Modified by Samsung Electronics Corporation for WebCL
+var caseName = document.title;
+var subcaseIndex = 1;
+
+function KhronosTest(name) {
+  this.name = name;
+  this.status = null;
+  this.message = null;
+}
+
+var khronosTests = [];
+var khronosTestMsg = null;
+
+function Status() {
+  this.status = null;
+  this.message = null;
+}
+
+var statusObj = new Status();
+statusObj.status = 0;
 
 (function() {
   var testHarnessInitialized = false;
@@ -92,6 +111,10 @@ function getTestCaseCount() {
 }
 
 function notifyFinishedToHarness() {
+  if (window.parent.completion_callback) {
+    window.parent.completion_callback(khronosTests, statusObj);
+  }
+
   if (window.parent.webclTestHarness) {
     window.parent.webclTestHarness.notifyFinished(window.location.pathname);
   }
@@ -102,6 +125,11 @@ function description(msg)
     initTestingHarness();
     if (msg === undefined) {
       msg = document.title;
+    }
+    else {
+      if (document.title.length === 0) {
+        caseName = msg;
+      }
     }
     // For MSIE 6 compatibility
     var span = document.createElement("span");
@@ -127,6 +155,14 @@ function escapeHTML(text)
 
 function testPassed(msg)
 {
+    if (msg !== "successfullyParsed is true") {
+        var ktest = new KhronosTest(caseName + "/" + subcaseIndex);
+        ktest.status = 0;
+        ktest.message = escapeHTML(msg);
+        khronosTests.push(ktest);
+        subcaseIndex++;
+    }
+
     reportTestResultsToHarness(true, msg);
     var tid = getTestCaseCount();
     if (tid)
@@ -137,6 +173,14 @@ function testPassed(msg)
 
 function testFailed(msg)
 {
+    if (msg.indexOf("successfullyParsed should be true") === -1) {
+        var ktest = new KhronosTest(caseName + "/" + subcaseIndex);
+        ktest.status = 1;
+        ktest.message = escapeHTML(msg);
+        khronosTests.push(ktest);
+        subcaseIndex++;
+    }
+
     reportTestResultsToHarness(false, msg);
     var tid = getTestCaseCount();
     if (tid)


### PR DESCRIPTION
Support running those webapi cases of tct-webgl-nonw3c-tests,
webapi-simd-nonw3c-tests, and webapi-webcl-nonw3c-tests automatically
on Web Testing Service.