### PR TITLE
[embeddingapi] add use case to check XWalkView block & error redirect…

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -266,5 +266,14 @@
                 <category android:name="android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".XWalkBlockAndErrorRedirection"
+            android:label="XWalkBlockAndErrorRedirection"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/block_redirect_url.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/block_redirect_url.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<title>Navigate Page</title>
+<style type="text/css">
+  body{ font-size:30px;}
+</style>
+</head>
+<body>
+  <br/>
+  <ul>
+    <li>Click "Link To A Blocked Page" to return our own response(an cute cat image).</li>
+    <li>Click "Link To An Error Page" (not available page or internet connectivity is not available) to redirect to the settled page(baidu home page).</li>
+  </ul>
+  <br/>
+  <p><a id="create_window_block" href="http://www.baidu.com/cat" target="_self">Link To A Page Blocked</a></P>
+  <p><a id="create_window_error" href="http://www.yyunlong.com" target="_self">Link To An Error Page</a></P>
+</body>
+</html>
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -211,3 +211,14 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkView interface: load, setDownloadListener, onDownloadStart methods
+
+
+
+### 20. The [XWalkBlockAndErrorRedirection](XWalkBlockAndErrorRedirection.java) sample check whether xwalkview can block response and redirect when url or internet is not avaliable, include:
+
+* XWalkView can block response & make error redirection
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, setResourceClient methods
+* ResourceClient interface: shouldInterceptLoadRequest, onReceivedLoadError methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkBlockAndErrorRedirection.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkBlockAndErrorRedirection.java
@@ -1,0 +1,111 @@
+package org.xwalk.embedded.api.asyncsample;
+
+import java.io.InputStream;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkPreferences;
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.util.Log;
+import android.webkit.WebResourceResponse;
+
+
+public class XWalkBlockAndErrorRedirection extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private static final String TAG = XWalkBlockAndErrorRedirection.class.getName();
+
+    class ResourceClient extends XWalkResourceClient {
+
+        public ResourceClient(XWalkView xwalkView) {
+            super(xwalkView);
+        }
+
+        public void onLoadStarted(XWalkView view, String url) {
+            super.onLoadStarted(view, url);
+            Log.d(TAG, "Load Started:" + url);
+        }
+
+        public void onLoadFinished(XWalkView view, String url) {
+            super.onLoadFinished(view, url);
+            Log.d(TAG, "Load Finished:" + url);
+        }
+
+        public void onProgressChanged(XWalkView view, int progressInPercent) {
+            super.onProgressChanged(view, progressInPercent);
+            Log.d(TAG, "Loading Progress:" + progressInPercent);
+        }
+
+        public WebResourceResponse shouldInterceptLoadRequest(XWalkView view, String url) {
+            Log.d(TAG, "Intercept load request: " + url);
+            if (url.endsWith("cat")) {
+			try {
+				InputStream is = getApplicationContext().getResources().getAssets().open("cat.png");
+				WebResourceResponse response = new WebResourceResponse("image/gif", "utf-8", is);
+				return response;
+			} catch (Exception e) {
+				// TODO: handle exception
+				Log.d(TAG, "Intercept Error: "+ e.toString());
+			}
+		}
+            return super.shouldInterceptLoadRequest(view, url);            
+        }
+
+        public void onReceivedLoadError(XWalkView view, int errorCode, String description,
+                String failingUrl) {
+            Log.d(TAG, "Load Failed:" + errorCode + description);
+            mXWalkView.load("http://www.baidu.com/", null);
+        }
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        XWalkInitializer.initAsync(this, this);
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can block response.\n\n")
+	.append("Verifies XWalkView can redirect to default page when load error page.\n\n")
+        .append("Expected Result:\n\n")
+        .append("1. Test passes if click first link to show a cat image.\n\n")
+        .append("2. Test passes if click second link to show baidu homepage.\n\n");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        XWalkPreferences.setValue(XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS, true);
+        XWalkPreferences.setValue(XWalkPreferences.REMOTE_DEBUGGING, true);
+        XWalkPreferences.setValue(XWalkPreferences.JAVASCRIPT_CAN_OPEN_WINDOW, true);
+
+        setContentView(R.layout.xwview_layout);        
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mXWalkView.setResourceClient(new ResourceClient(mXWalkView));
+        mXWalkView.load("file:///android_asset/block_redirect_url.html", null);
+    }  
+}
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -266,5 +266,14 @@
                 <category android:name="android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".XWalkBlockAndErrorRedirection"
+            android:label="XWalkBlockAndErrorRedirection"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/assets/block_redirect_url.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/assets/block_redirect_url.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+<title>Navigate Page</title>
+<style type="text/css">
+  body{ font-size:30px;}
+</style>
+</head>
+<body>
+  <br/>
+  <ul>
+    <li>Click "Link To A Blocked Page" to return our own response(an cute cat image).</li>
+    <li>Click "Link To An Error Page" (not available page or internet connectivity is not available) to redirect to the settled page(baidu home page).</li>
+  </ul>
+  <br/>
+  <p><a id="create_window_block" href="http://www.baidu.com/cat" target="_self">Link To A Page Blocked</a></P>
+  <p><a id="create_window_error" href="http://www.yyunlong.com" target="_self">Link To An Error Page</a></P>
+</body>
+</html>
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -211,3 +211,14 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkView interface: load, setDownloadListener, onDownloadStart methods
+
+
+
+### 20. The [XWalkBlockAndErrorRedirection](XWalkBlockAndErrorRedirection.java) sample check whether xwalkview can block response and redirect when url or internet is not avaliable, include:
+
+* XWalkView can block response & make error redirection
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, setResourceClient methods
+* ResourceClient interface: shouldInterceptLoadRequest, onReceivedLoadError methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkBlockAndErrorRedirection.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkBlockAndErrorRedirection.java
@@ -1,0 +1,86 @@
+package org.xwalk.embedded.api.sample;
+
+import java.io.InputStream;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkPreferences;
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.util.Log;
+import android.webkit.WebResourceResponse;
+
+
+public class XWalkBlockAndErrorRedirection extends XWalkActivity{
+    private XWalkView mXWalkView;
+    private static final String TAG = XWalkBlockAndErrorRedirection.class.getName();
+
+    class ResourceClient extends XWalkResourceClient {
+
+        public ResourceClient(XWalkView xwalkView) {
+            super(xwalkView);
+        }
+
+        public void onLoadStarted(XWalkView view, String url) {
+            super.onLoadStarted(view, url);
+            Log.d(TAG, "Load Started:" + url);
+        }
+
+        public void onLoadFinished(XWalkView view, String url) {
+            super.onLoadFinished(view, url);
+            Log.d(TAG, "Load Finished:" + url);
+        }
+
+        public void onProgressChanged(XWalkView view, int progressInPercent) {
+            super.onProgressChanged(view, progressInPercent);
+            Log.d(TAG, "Loading Progress:" + progressInPercent);
+        }
+
+        public WebResourceResponse shouldInterceptLoadRequest(XWalkView view, String url) {
+            Log.d(TAG, "Intercept load request: " + url);
+            if (url.endsWith("cat")) {
+			try {
+				InputStream is = getApplicationContext().getResources().getAssets().open("cat.png");
+				WebResourceResponse response = new WebResourceResponse("image/gif", "utf-8", is);
+				return response;
+			} catch (Exception e) {
+				// TODO: handle exception
+				Log.d(TAG, "Intercept Error: "+ e.toString());
+			}
+		}
+            return super.shouldInterceptLoadRequest(view, url);            
+        }
+
+        public void onReceivedLoadError(XWalkView view, int errorCode, String description,
+                String failingUrl) {
+            Log.d(TAG, "Load Failed:" + errorCode + description);
+            mXWalkView.load("http://www.baidu.com/", null);
+        }
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can block response.\n\n")
+	.append("Verifies XWalkView can redirect to default page when load error page.\n\n")
+        .append("Expected Result:\n\n")
+        .append("1. Test passes if click first link to show a cat image.\n\n")
+        .append("2. Test passes if click second link to show baidu homepage.\n\n");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        XWalkPreferences.setValue(XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS, true);
+        XWalkPreferences.setValue(XWalkPreferences.REMOTE_DEBUGGING, true);
+        XWalkPreferences.setValue(XWalkPreferences.JAVASCRIPT_CAN_OPEN_WINDOW, true);
+
+        setContentView(R.layout.xwview_layout);        
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mXWalkView.setResourceClient(new ResourceClient(mXWalkView));
+        mXWalkView.load("file:///android_asset/block_redirect_url.html", null);
+    }  
+}


### PR DESCRIPTION
… function

-add use case to check XWalkView shouldInterceptLoadRequest & onReceivedLoadError functions
-cover the XWalkViewActivity and XWalkInitializer two ways

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4274