### PR TITLE
[embeddingapi] Add autocase for XWalkResourceClient.onDocumentLoadedI…

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/OnDocumentLoadedInFrameHelper.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/OnDocumentLoadedInFrameHelper.java
@@ -1,0 +1,19 @@
+package org.xwalk.embedding.base;
+
+import org.chromium.content.browser.test.util.CallbackHelper;
+
+public class OnDocumentLoadedInFrameHelper extends CallbackHelper{
+
+    private long mFrameId;
+
+    public long getFrameId() {
+        assert getCallCount() > 0;
+        return mFrameId;
+    }
+
+    public void notifyCalled(long frameId) {
+        mFrameId = frameId;
+        notifyCalled();
+    }    
+}
+

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestHelperBridge.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestHelperBridge.java
@@ -39,6 +39,7 @@ public class TestHelperBridge {
     private final OpenFileChooserHelper mOpenFileChooserHelper;
     private final OnConsoleMessageHelper mOnConsoleMessageHelper;
     private final OnDownloadStartHelper mOnDownloadStartHelper;
+    private final OnDocumentLoadedInFrameHelper mOnDocumentLoadedInFrameHelper;
 
     TestHelperBridge() {
         mOnPageStartedHelper = new OnPageStartedHelper();
@@ -62,6 +63,7 @@ public class TestHelperBridge {
         mOpenFileChooserHelper = new OpenFileChooserHelper();
         mOnConsoleMessageHelper = new OnConsoleMessageHelper();
 	mOnDownloadStartHelper = new OnDownloadStartHelper();
+        mOnDocumentLoadedInFrameHelper = new OnDocumentLoadedInFrameHelper();
     }
 
     public WebResourceResponse shouldInterceptLoadRequest(String url) {
@@ -244,5 +246,13 @@ public class TestHelperBridge {
             String contentDisposition, String mimetype, long contentLength) {
         mOnDownloadStartHelper.notifyCalled(url, userAgent, contentDisposition,
                 mimetype, contentLength);
+    }
+
+    public void onDocumentLoadedInFrame(long frameId) {
+        mOnDocumentLoadedInFrameHelper.notifyCalled(frameId);
+    }
+    
+    public OnDocumentLoadedInFrameHelper getOnDocumentLoadedInFrameHelper() {
+        return mOnDocumentLoadedInFrameHelper;
     }
 }

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestXWalkResourceClientBase.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestXWalkResourceClientBase.java
@@ -51,4 +51,9 @@ public class TestXWalkResourceClientBase extends XWalkResourceClient{
             ValueCallback<Boolean> callback, SslError error) {
         mInnerContentsClient.onReceivedSsl();
     }
+
+    @Override
+    public void onDocumentLoadedInFrame(XWalkView view, long frameId) {
+        mInnerContentsClient.onDocumentLoadedInFrame(frameId);
+    }
 }

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -107,7 +107,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
     protected void setUp() throws Exception {
         super.setUp();
         mainActivity = (MainActivity) getActivity();
-
+	mWebServer = TestWebServer.start();
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkResourceClientTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkResourceClientTest.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedding.test.v5;
+
+
+import org.xwalk.embedding.base.OnDocumentLoadedInFrameHelper;
+import org.xwalk.embedding.base.XWalkViewTestBase;
+import org.xwalk.embedding.util.CommonResources;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+public class XWalkResourceClientTest extends XWalkViewTestBase {
+
+    @SmallTest
+    public void testOnDocumentLoadedInFrame() throws Throwable {
+        OnDocumentLoadedInFrameHelper mOnDocumentLoadedInFrameHelper = mTestHelperBridge.getOnDocumentLoadedInFrameHelper();
+        String path = "/test.html";
+        String pageContent = CommonResources.makeHtmlPageFrom("<title>Test</title>",
+                "<div> The title is: Test </div>");
+        final String url = addPageToTestServer(mWebServer, path, pageContent);
+
+        loadUrlSync(url);
+        assertEquals(1, mOnDocumentLoadedInFrameHelper.getFrameId());
+        assertEquals(1, mOnDocumentLoadedInFrameHelper.getCallCount());
+    }
+}
+

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkUIClientTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkUIClientTest.java
@@ -7,7 +7,6 @@ package org.xwalk.embedding.test.v5;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.chromium.net.test.util.TestWebServer;
 import org.xwalk.embedding.base.OnDownloadStartHelper;
 import org.xwalk.embedding.base.OnConsoleMessageHelper;
 import org.xwalk.embedding.base.XWalkViewTestBase;
@@ -207,8 +206,6 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
 
     @SmallTest
     public void testOnDownloadStart() throws Throwable {
-    	setUp();
-    	
     	OnDownloadStartHelper mDownloadStartHelper = mTestHelperBridge.getOnDownloadStartHelper();
         final String data = "download data";
         final String contentDisposition = "attachment;filename=\"download.txt\"";
@@ -220,9 +217,9 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
         downloadHeaders.add(Pair.create("Content-Length", Integer.toString(data.length())));
 
         setDownloadListener();
-        TestWebServer webServer = TestWebServer.start();
+
         try {
-            final String pageUrl = webServer.setResponse("/download.txt", data, downloadHeaders);
+            final String pageUrl = mWebServer.setResponse("/download.txt", data, downloadHeaders);
             final int callCount = mDownloadStartHelper.getCallCount();
             loadUrlAsync(pageUrl);
             mDownloadStartHelper.waitForCallback(callCount);
@@ -232,11 +229,9 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
             assertEquals(mimeType, mDownloadStartHelper.getMimeType());
             assertEquals(data.length(), mDownloadStartHelper.getContentLength());
         } catch (Exception e) {
-			// TODO Auto-generated catch block
+	    // TODO Auto-generated catch block
             assertFalse(true);
-			e.printStackTrace();
-		} finally {
-            webServer.shutdown();
-        } 
+	    e.printStackTrace();
+	}
     }
 }

--- a/embeddingapi/embedding-api-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-api-android-tests/tests.full.xml
@@ -93,6 +93,11 @@
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkUIClientTest</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkResourceClientTest" platform="android" priority="P1" purpose="Check if the methods of XWalkResourceClientTest interface can be executed correctly." status="approved" type="functional_positive" subcase="1">
+        <description>
+          <test_script_entry>org.xwalk.embedding.test.v5.XWalkResourceClientTest</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/embeddingapi/embedding-api-android-tests/tests_v5.xml
+++ b/embeddingapi/embedding-api-android-tests/tests_v5.xml
@@ -13,6 +13,11 @@
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkUIClientTest</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkResourceClientTest" purpose="Check if the methods of XWalkResourceClientTest interface can be executed correctly." subcase="1">
+        <description>
+          <test_script_entry>org.xwalk.embedding.test.v5.XWalkResourceClientTest</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/OnDocumentLoadedInFrameHelper.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/OnDocumentLoadedInFrameHelper.java
@@ -1,0 +1,19 @@
+package org.xwalk.embedding.base;
+
+import org.chromium.content.browser.test.util.CallbackHelper;
+
+public class OnDocumentLoadedInFrameHelper extends CallbackHelper{
+
+    private long mFrameId;
+
+    public long getFrameId() {
+        assert getCallCount() > 0;
+        return mFrameId;
+    }
+
+    public void notifyCalled(long frameId) {
+        mFrameId = frameId;
+        notifyCalled();
+    }    
+}
+

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestHelperBridge.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestHelperBridge.java
@@ -39,6 +39,7 @@ public class TestHelperBridge {
     private final OpenFileChooserHelper mOpenFileChooserHelper;
     private final OnConsoleMessageHelper mOnConsoleMessageHelper;
     private final OnDownloadStartHelper mOnDownloadStartHelper;
+    private final OnDocumentLoadedInFrameHelper mOnDocumentLoadedInFrameHelper;
 
     TestHelperBridge() {
         mOnPageStartedHelper = new OnPageStartedHelper();
@@ -62,6 +63,7 @@ public class TestHelperBridge {
         mOpenFileChooserHelper = new OpenFileChooserHelper();
         mOnConsoleMessageHelper = new OnConsoleMessageHelper();
 	mOnDownloadStartHelper = new OnDownloadStartHelper();
+        mOnDocumentLoadedInFrameHelper = new OnDocumentLoadedInFrameHelper();
     }
 
     public WebResourceResponse shouldInterceptLoadRequest(String url) {
@@ -244,5 +246,13 @@ public class TestHelperBridge {
             String contentDisposition, String mimetype, long contentLength) {
         mOnDownloadStartHelper.notifyCalled(url, userAgent, contentDisposition,
                 mimetype, contentLength);
+    }
+
+    public void onDocumentLoadedInFrame(long frameId) {
+        mOnDocumentLoadedInFrameHelper.notifyCalled(frameId);
+    }
+    
+    public OnDocumentLoadedInFrameHelper getOnDocumentLoadedInFrameHelper() {
+        return mOnDocumentLoadedInFrameHelper;
     }
 }

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestXWalkResourceClientBase.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestXWalkResourceClientBase.java
@@ -51,4 +51,9 @@ public class TestXWalkResourceClientBase extends XWalkResourceClient{
             ValueCallback<Boolean> callback, SslError error) {
         mInnerContentsClient.onReceivedSsl();
     }
+
+    @Override
+    public void onDocumentLoadedInFrame(XWalkView view, long frameId) {
+        mInnerContentsClient.onDocumentLoadedInFrame(frameId);
+    }
 }

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -107,7 +107,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
     protected void setUp() throws Exception {
         super.setUp();
         mainActivity = (MainActivity) getActivity();
-
+	mWebServer = TestWebServer.start();
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkResourceClientTest.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkResourceClientTest.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedding.test.v5;
+
+
+import org.xwalk.embedding.base.OnDocumentLoadedInFrameHelper;
+import org.xwalk.embedding.base.XWalkViewTestBase;
+import org.xwalk.embedding.util.CommonResources;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+public class XWalkResourceClientTest extends XWalkViewTestBase {
+
+    @SmallTest
+    public void testOnDocumentLoadedInFrame() throws Throwable {
+        OnDocumentLoadedInFrameHelper mOnDocumentLoadedInFrameHelper = mTestHelperBridge.getOnDocumentLoadedInFrameHelper();
+        String path = "/test.html";
+        String pageContent = CommonResources.makeHtmlPageFrom("<title>Test</title>",
+                "<div> The title is: Test </div>");
+        final String url = addPageToTestServer(mWebServer, path, pageContent);
+
+        loadUrlSync(url);
+        assertEquals(1, mOnDocumentLoadedInFrameHelper.getFrameId());
+        assertEquals(1, mOnDocumentLoadedInFrameHelper.getCallCount());
+    }
+}
+

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkUIClientTest.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkUIClientTest.java
@@ -7,7 +7,6 @@ package org.xwalk.embedding.test.v5;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.chromium.net.test.util.TestWebServer;
 import org.xwalk.embedding.base.OnDownloadStartHelper;
 import org.xwalk.embedding.base.OnConsoleMessageHelper;
 import org.xwalk.embedding.base.XWalkViewTestBase;
@@ -207,8 +206,6 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
 
     @SmallTest
     public void testOnDownloadStart() throws Throwable {
-    	setUp();
-    	
     	OnDownloadStartHelper mDownloadStartHelper = mTestHelperBridge.getOnDownloadStartHelper();
         final String data = "download data";
         final String contentDisposition = "attachment;filename=\"download.txt\"";
@@ -220,9 +217,9 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
         downloadHeaders.add(Pair.create("Content-Length", Integer.toString(data.length())));
 
         setDownloadListener();
-        TestWebServer webServer = TestWebServer.start();
+
         try {
-            final String pageUrl = webServer.setResponse("/download.txt", data, downloadHeaders);
+            final String pageUrl = mWebServer.setResponse("/download.txt", data, downloadHeaders);
             final int callCount = mDownloadStartHelper.getCallCount();
             loadUrlAsync(pageUrl);
             mDownloadStartHelper.waitForCallback(callCount);
@@ -232,11 +229,9 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
             assertEquals(mimeType, mDownloadStartHelper.getMimeType());
             assertEquals(data.length(), mDownloadStartHelper.getContentLength());
         } catch (Exception e) {
-			// TODO Auto-generated catch block
+	    // TODO Auto-generated catch block
             assertFalse(true);
-			e.printStackTrace();
-		} finally {
-            webServer.shutdown();
-        } 
+	    e.printStackTrace();
+	}
     }
 }

--- a/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
@@ -93,6 +93,11 @@
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkUIClientTest</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkResourceClientTest" platform="android" priority="P1" purpose="Check if the methods of XWalkResourceClientTest interface can be executed correctly." status="approved" type="functional_positive" subcase="1">
+        <description>
+          <test_script_entry>org.xwalk.embedding.test.v5.XWalkResourceClientTest</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/embeddingapi/embedding-asyncapi-android-tests/tests_v5.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests_v5.xml
@@ -13,6 +13,11 @@
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkUIClientTest</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkResourceClientTest" purpose="Check if the methods of XWalkResourceClientTest interface can be executed correctly." subcase="1">
+        <description>
+          <test_script_entry>org.xwalk.embedding.test.v5.XWalkResourceClientTest</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
…nFrame

-add embeddingapi autocase for XWalkResourceClient.onDocumentLoadedInFrame
-modify testOnDownloadStart testcase
-cover the XWalkViewActivity and XWalkInitializer two ways

Impacted tests(approved): new 1, update 1, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4320