### PR TITLE
[embeddingapi] Update usecase for XWalkResourceClient.onDocumentLoade…

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/ResourceAndUIClientsActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/ResourceAndUIClientsActivity.java
@@ -53,6 +53,12 @@ public class ResourceAndUIClientsActivity extends Activity implements XWalkIniti
             Log.d(TAG, "Load Failed:" + description);
             super.onReceivedLoadError(view, errorCode, description, failingUrl);
         }
+
+	public void onDocumentLoadedInFrame(XWalkView view, long frameId) {
+	    // TODO Auto-generated method stub
+	    super.onDocumentLoadedInFrame(view, frameId);
+	    Log.d(TAG, "onDocumentLoadedInFrame frameId: " + frameId);
+	}
     }
 
     class UIClient extends XWalkUIClient {

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/ResourceAndUIClientsActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/ResourceAndUIClientsActivity.java
@@ -52,6 +52,12 @@ public class ResourceAndUIClientsActivity extends XWalkActivity {
             Log.d(TAG, "Load Failed:" + description);
             super.onReceivedLoadError(view, errorCode, description, failingUrl);
         }
+
+	public void onDocumentLoadedInFrame(XWalkView view, long frameId) {
+	    // TODO Auto-generated method stub
+	    super.onDocumentLoadedInFrame(view, frameId);
+	    Log.d(TAG, "onDocumentLoadedInFrame frameId: " + frameId);
+	}
     }
 
     class UIClient extends XWalkUIClient {


### PR DESCRIPTION
…dInFrame

-update embeddingapi usecase for XWalkResourceClient.onDocumentLoadedInFrame
-cover the XWalkViewActivity and XWalkInitializer two ways

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4320