### PR TITLE
[Crosswalk14][embeddingapi] Modify ShouldOverrideUrlLoading test case

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi/assets/navigate.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/assets/navigate.html
@@ -8,13 +8,11 @@
 <body>
   <br/>
   <ul>
-    <li>Click "Link To Another Page In Blank" to go to an aother page.</li>
     <li>Click "Link To Another Page In Self" to go to an aother page.</li>
     <li>Click "Link To Another Page In Parent" to go to an aother page.</li>
     <li>Click "Link To Another Page In Top" to go to an aother page.</li>
   </ul>
   <br/>
-  <p><a id="create_window_a_blank" href="openedWindow.html" target="_blank">Link To one Page In Blank</a></P>
   <p><a id="create_window_a_self" href="openedWindow.html" target="_self">Link To one Page In Self</a></P>
   <p><a id="create_window_a_parent" href="openedWindow.html" target="_parent">Link To one Page In Parent</a></P>
   <p><a id="create_window_a_top" href="openedWindow.html" target="_top">Link To one Page In Top</a></P>


### PR DESCRIPTION
-remove loading the external link with '_blank' target test part
-load link with '_blank' target won't trigger shouldOverrideUrlLoading method

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-3897