### PR TITLE
[wrt] Add test for WebSocket

### DIFF
--- a/wrt/wrt-internetstdmanu-android-tests/internetstdmanu/Crosswalk_WebSocket_userAgent.html
+++ b/wrt/wrt-internetstdmanu-android-tests/internetstdmanu/Crosswalk_WebSocket_userAgent.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+    Xu,Jianfeng <jianfengx.xu@intel.com>
+
+-->
+
+<html>
+<head>
+  <title>Crosswalk_WebSocket_userAgent</title>
+</head>
+<body>
+  <p>
+    <strong>Precondition:</strong>
+  </p>
+  <ol>
+    <li>Build and start a server which support WebSocket.</li>
+    <li>Install tinyweb_service.apk.</li>
+    <li>Open TinywebTestService App and click start button to start service.</li>
+  </ol>
+  <p>
+    <strong>Expected Output:</strong>
+  </p>
+  <ol>
+    <li>The user agent content is shown below and contains the information such as device model, android version and Crosswalk version.</li>
+  </ol>
+  <div id="log"></div>
+  <script>
+    var SERVER_NAME = "127.0.0.1";
+    var _PORT = 8081;
+    var _URL = "ws://" + SERVER_NAME + ":" + _PORT;
+    var wsocket;
+    function CreateWebSocket() {
+      if (window["WebSocket"]) {
+        wsocket = new WebSocket(_URL, 'fragmentation-test');
+      }
+      else if (window["MozWebSocket"]) {
+        wsocket = new MozWebSocket(_URL);
+      }
+      return wsocket;
+    }
+    wsocket = CreateWebSocket();
+    wsocket.onopen = function () {
+      wsocket.send("Hello");
+    };
+    wsocket.onmessage = function (evt) {
+      document.getElementById("log").innerHTML = navigator.userAgent;
+    };
+  </script>
+</body>
+</html>

--- a/wrt/wrt-internetstdmanu-android-tests/tests.full.xml
+++ b/wrt/wrt-internetstdmanu-android-tests/tests.full.xml
@@ -332,6 +332,14 @@
           <test_script_entry>/opt/wrt-internetstdmanu-android-tests/internetstdmanu/Crosswalk_Cookie_XwalkRuntimeLib_Update.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk WRT/Internet Standard/WebSocket" execution_type="manual" id="Crosswalk_WebSocket_userAgent" priority="P2" purpose="Validate User-Agent is not empty when connecting via websocket." status="approved" type="Functional">
+        <description>
+          <pre_condition>
+            1.Make sure WebSocket server is enabled.
+            </pre_condition>
+          <test_script_entry>/opt/wrt-internetstdmanu-android-tests/internetstdmanu/Crosswalk_WebSocket_userAgent.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/wrt/wrt-internetstdmanu-android-tests/tests.xml
+++ b/wrt/wrt-internetstdmanu-android-tests/tests.xml
@@ -332,6 +332,14 @@
           <test_script_entry>/opt/wrt-internetstdmanu-android-tests/internetstdmanu/Crosswalk_Cookie_XwalkRuntimeLib_Update.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk WRT/Internet Standard/WebSocket" execution_type="manual" id="Crosswalk_WebSocket_userAgent" purpose="Validate User-Agent is not empty when connecting via websocket.">
+        <description>
+          <pre_condition>
+            1.Make sure WebSocket server is enabled.
+            </pre_condition>
+          <test_script_entry>/opt/wrt-internetstdmanu-android-tests/internetstdmanu/Crosswalk_WebSocket_userAgent.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
This test check if User-Agent is not empty when connecting via websocket
Create WebSocket same as https://github.com/crosswalk-project/crosswalk-test-suite/blob/master/webapi/tct-websocket-w3c-tests/websocket/support/websocket.js

Impacted TCs num(approved): New 1, Update 0, Delete 0
Unit test Platform: Crosswalk Project for Android 15.43.347
Unit test result summary: Pass 1, Fail 0, Blocked 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-3076