### PR TITLE
[embeddingapi] Add usecase to check onCreateInputConnection method in…

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -284,5 +284,14 @@
                 <category android:name="android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".XWalkWithInputConnection"
+            android:label="XWalkWithInputConnection"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -275,3 +275,14 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkView interface: load, saveState, restoreState methods
+
+
+
+### 26. The [XWalkWithInputConnection](XWalkWithInputConnection.java) sample check whether xwalkview can use onCreateInputConnection method, include:
+
+* XWalkView can use onCreateInputConnection method
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, onCreateInputConnection methods
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkWithInputConnection.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkWithInputConnection.java
@@ -1,0 +1,101 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.asyncsample;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkView;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputConnectionWrapper;
+import android.widget.LinearLayout;
+
+public class XWalkWithInputConnection extends Activity implements XWalkInitializer.XWalkInitListener{
+    private XWalkView mXWalkView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        XWalkInitializer.initAsync(this, this);
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can use onCreateInputConnection method.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Input some words in baidu input box.\n")
+        .append("2. Finally you just get 'HAHA'.\n\n")        
+        .append("Expected Result:\n\n")
+        .append("Test passes if you just get 'HAHA'.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+        
+        setContentView(R.layout.container);
+        LinearLayout parent = (LinearLayout) findViewById(R.id.container);
+
+        mXWalkView = new myXWalkView(this, this);
+        parent.addView(mXWalkView);
+        mXWalkView.load("http://www.baidu.com", null);
+    }
+    
+    private class myXWalkView extends XWalkView {
+
+        public myXWalkView(Context context, Activity activity) {
+            super(context, activity);
+            // TODO Auto-generated constructor stub
+        }
+
+        @Override
+        public InputConnection onCreateInputConnection(EditorInfo ei) {
+            // TODO Auto-generated method stub
+            InputConnection inputConnection = super.onCreateInputConnection(ei);
+            if (inputConnection != null) {
+                return new LimitInputConnection(inputConnection, false);
+            }
+            return null;
+        }
+    }
+    
+    private class LimitInputConnection extends InputConnectionWrapper {
+    
+        public LimitInputConnection(InputConnection target, boolean mutable) {
+            super(target, mutable);
+            // TODO Auto-generated constructor stub
+        }
+
+        @Override
+        public boolean commitText(CharSequence text, int newCursorPosition) {
+            // TODO Auto-generated method stub
+            return super.commitText("HAHA", 1);
+        }
+    }
+}
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -284,5 +284,14 @@
                 <category android:name="android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".XWalkWithInputConnection"
+            android:label="XWalkWithInputConnection"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -275,3 +275,14 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkView interface: load, saveState, restoreState methods
+
+
+
+### 26. The [XWalkWithInputConnection](XWalkWithInputConnection.java) sample check whether xwalkview can use onCreateInputConnection method, include:
+
+* XWalkView can use onCreateInputConnection method
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, onCreateInputConnection methods
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkWithInputConnection.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkWithInputConnection.java
@@ -1,0 +1,83 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.sample;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkView;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputConnectionWrapper;
+import android.widget.LinearLayout;
+
+public class XWalkWithInputConnection extends XWalkActivity {
+    private XWalkView mXWalkView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can use onCreateInputConnection method.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Input some words in baidu input box.\n")
+        .append("2. Finally you just get 'HAHA'.\n\n")        
+        .append("Expected Result:\n\n")
+        .append("Test passes if you just get 'HAHA'.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+        
+        setContentView(R.layout.container);
+        LinearLayout parent = (LinearLayout) findViewById(R.id.container);
+
+        mXWalkView = new myXWalkView(this, this);
+        parent.addView(mXWalkView);
+        mXWalkView.load("http://www.baidu.com", null);
+    }
+    
+    private class myXWalkView extends XWalkView {
+
+        public myXWalkView(Context context, Activity activity) {
+            super(context, activity);
+            // TODO Auto-generated constructor stub
+        }
+
+        @Override
+        public InputConnection onCreateInputConnection(EditorInfo ei) {
+            // TODO Auto-generated method stub
+            InputConnection inputConnection = super.onCreateInputConnection(ei);
+            if (inputConnection != null) {
+                return new LimitInputConnection(inputConnection, false);
+            }
+            return null;
+        }
+    }
+    
+    private class LimitInputConnection extends InputConnectionWrapper {
+    
+        public LimitInputConnection(InputConnection target, boolean mutable) {
+            super(target, mutable);
+            // TODO Auto-generated constructor stub
+        }
+
+        @Override
+        public boolean commitText(CharSequence text, int newCursorPosition) {
+            // TODO Auto-generated method stub
+            return super.commitText("HAHA", 1);
+        }
+    }
+}
+

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -314,6 +314,18 @@
           </steps>
           <test_script_entry test_script_expected_result="0" />
         </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithInputConnection" purpose="onCreateInputConnection() Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
       </testcase>    
     </set>
     <set name="XWalkView-Async">
@@ -618,6 +630,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithSaveState" purpose="saveState() restoreState() Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithInputConnection" purpose="onCreateInputConnections() Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -341,6 +341,19 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithInputConnection" platform="android" priority="P0" purpose="onCreateInputConnections() Test With XWalkActivity" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewUIInflation" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -669,6 +682,19 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithSaveState" platform="android" priority="P0" purpose="saveState() restoreState() Test With XWalkInitializer" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithInputConnection" platform="android" priority="P0" purpose="onCreateInputConnections() Test With XWalkInitializer" status="approved" type="functional_positive">
         <description>
           <pre_condition />
           <post_condition />


### PR DESCRIPTION
… XWalkView

-Add usecase to check onCreateInputConnection method in XWalkView
-cover the XWalkViewActivity and XWalkInitializer two ways

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4375