### PR TITLE
[apptools-deepin] Change dir to parent dir before removing the project for apptools deepin

### DIFF
--- a/apptools/apptools-linux-tests/apptools/comm.py
+++ b/apptools/apptools-linux-tests/apptools/comm.py
@@ -51,6 +51,7 @@ def setUp():
 
 
 def cleanTempData(removeFolder):
+    os.chdir(TEMP_DATA_PATH)
     removeFolder = os.path.join(TEMP_DATA_PATH, removeFolder)
     if os.path.exists(removeFolder):
         shutil.rmtree(removeFolder)


### PR DESCRIPTION
Impacted tests(approved):new 0,update 1,delete 0
Unit test platform:[Deepin]
Unit test result summary:pass 50,fail 2,block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4452