### PR TITLE
Add ref tests for 3dtransforms

### DIFF
--- a/webapi/tct-3dtransforms-css3-tests/3dtransforms/csswg/COPYING
+++ b/webapi/tct-3dtransforms-css3-tests/3dtransforms/csswg/COPYING
@@ -8,6 +8,11 @@ with some modification:
    'assert_not_equals(document.getElementById("test").style.transfor' to
    'assert_not_equals(document.getElementById("test").style.transform'
 
+3. Modify transform-3d-rotateY-stair-above-001.xht,transform-3d-rotateY-stair-below-001.xht,
+          ref-filled-green-100px-square.xht,reference/transform-3d-rotateY-stair-above-ref-001.xht          
+   '<style type="text/css"><![CDATA[' to '<style type="text/css">'
+   ']]></style>' to '</style>'
+
 These tests are copyright by W3C and/or the author listed in the test
 file. The tests are dual-licensed under the W3C Test Suite License:
 http://www.w3.org/Consortium/Legal/2008/04-testsuite-license

--- a/webapi/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht
+++ b/webapi/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht
@@ -3,14 +3,14 @@
  <head>
   <title>CSS Reftest Reference</title>
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <style type="text/css"><![CDATA[
+  <style type="text/css">
   div
   {
   background-color: green;
   height: 100px;
   width: 100px;
   }
-  ]]></style>
+  </style>
  </head>
  <body>
   <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>

--- a/webapi/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transform-3d-rotateY-stair-above-ref-001.xht
+++ b/webapi/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transform-3d-rotateY-stair-above-ref-001.xht
@@ -3,13 +3,13 @@
  <head>
   <title>CSS Reftest Reference</title>
   <link rel="author" title="Apple" href="http://www.apple.com/"/>
-  <style type="text/css"><![CDATA[
+  <style type="text/css">
 div {
   background-color: green;
   height: 200px;
   width: 200px;
 }
-  ]]></style>
+  </style>
  </head>
  <body>
 <div></div>

--- a/webapi/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-3d-rotateY-stair-above-001.xht
+++ b/webapi/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-3d-rotateY-stair-above-001.xht
@@ -8,7 +8,7 @@
   <meta name="flags" content="" />
   <meta name="assert" content="A rotateY transform with perspective
   should result in a trapezoid."/>
-  <style type="text/css"><![CDATA[
+  <style type="text/css">
 div {
   height: 150px;
   width: 150px;
@@ -53,7 +53,7 @@ div {
 .stairs {
   height: 180px;
 }
-  ]]></style>
+  </style>
  </head>
  <body>
 <div class="background">

--- a/webapi/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-3d-rotateY-stair-below-001.xht
+++ b/webapi/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-3d-rotateY-stair-below-001.xht
@@ -8,7 +8,7 @@
   <meta name="flags" content="" />
   <meta name="assert" content="A rotateY transform with perspective
   should result in a trapezoid."/>
-  <style type="text/css"><![CDATA[
+  <style type="text/css">
 div {
   height: 150px;
   width: 150px;
@@ -53,7 +53,7 @@ div {
 .stairs {
   height: 180px;
 }
-  ]]></style>
+  </style>
  </head>
  <body>
 <div class="background">

--- a/webapi/tct-3dtransforms-css3-tests/tests.full.xml
+++ b/webapi/tct-3dtransforms-css3-tests/tests.full.xml
@@ -3,210 +3,6 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="tct-3dtransforms-css3-tests">
     <set name="3DTransforms" type="js">
-      <testcase purpose="When the value of backface visibility property is 'hidden' then the back side of a transformed element is invisible when facing the viewer" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="backface-visibility-hidden-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/backface-visibility-hidden-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check if rotateX 90 degrees with perspective make it invisible" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css3-transform-perspective">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css3-transform-perspective.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that box width should be equal to projection width if transform rotateY applied" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css3-transform-rotateY">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css3-transform-rotateY.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This transform rotates a tall rectangle by 90 degrees then applies a 3D rotation in the X axis" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-rotate-2d-3d-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-rotate-2d-3d-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that rotate the 2:1 rectangle on X-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotate3d-X-negative">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-X-negative.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that rotate3d a 2:1 rectangle on X-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotate3d-X-positive">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-X-positive.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that rotate3d a 2:1 rectangle on Y-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotate3d-Y-negative">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Y-negative.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that rotate3d a 2:1 rectangle on Y-axis for -60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotate3d-Y-positive">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Y-positive.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that rotate3d a vertical rectangle for -90 degree on Z-axis will cover the horizontal red rectangle" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotate3d-Z-negative">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Z-negative.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that box width should be equal to projection width if transform rotateZ applied" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotate3d-Z-positive">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Z-positive.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that rotate a 2:1 rectangle on X-axis for -60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotateX-negative">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateX-negative.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that rotate a 2:1 rectangle on X-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotateX-positive">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateX-positive.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that rotate a 2:1 rectangle on Y-axis for -60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotateY-negative">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateY-negative.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that rotate a 2:1 rectangle on Y-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotateY-positive">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateY-positive.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that rotate a vertical rectangle for -90 degree on Z-axis will cover the horizontal red rectangle" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotateZ-negative">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateZ-negative.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateZ" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that rotate a vertical rectangle for 90 degree on Z-axis will cover the horizontal red rectangle" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotateZ-positive">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateZ-positive.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateZ" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that rotate the nested div with transform-style preserve-3d and rotated parent div for -60 degree on Y-axis then and rotated child div for 120 degree so at this time the parent and child should have equal width then child div could cover the red box" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-transform-style">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-transform-style.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
       <testcase purpose="Check the existence of transform" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="auto" priority="P1" id="Css-transform-property-existence-001">
         <description>
           <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-property-existence.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
@@ -274,18 +70,6 @@
         <specs>
           <spec>
             <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="3D transforms can not be applied to anonymous block boxes" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transforms-3d-on-anonymous-block-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transforms-3d-on-anonymous-block-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
             <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
             <spec_statement/>
           </spec>
@@ -447,990 +231,6 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="The 'perspective-origin' property set 'center' computes to 50% for the vertical position." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="The 'perspective-origin' property set 'center' computes to 50% for the horizontal position." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-002">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-002.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="The 'perspective-origin' property set 'bottom' computes to 100% for the vertical position." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-003">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-003.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="The 'perspective-origin' property set 'top' computes to 0% for the vertical position." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-004">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-004.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="The 'perspective-origin' property set 'left' computes to 0% for the horizontal position." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-005">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-005.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="The 'perspective-origin' property set 'right' computes to 100% for the horizontal position." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-006">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-006.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Asserts that origin 'x1' visually moves the objects '-x1*d/(d-1)'" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-x">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-x.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Asserts that origin '(x y)' visually moves the objects '(-x -y)*d/(d-1)'" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-xy">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-xy.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Asserts that points on the z=0 plane are unchanged" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-translateZ-0">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-translateZ-0.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Asserts that the scaling is proportional to d/(d - Z) for a negative Z" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-translateZ-negative">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-translateZ-negative.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="translateZ" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Asserts that the scaling is proportional to d/(d - Z) for a positive Z" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-translateZ-positive">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-translateZ-positive.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="translateZ" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Rotate 45 degree in x axis" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="rotate_x_45deg">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotate_x_45deg.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Rotate 45 degree in y axis" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="rotate_y_45deg">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotate_y_45deg.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="When the value of transform is 'rotateY(90deg)' the foward side of a transformed element disappears." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="rotateY">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotateY.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that a very simple case of backface-visibility causes the element to disappear: rotateX(180deg) is specified on the same element that has backface-visibility: hidden." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that if an element has 'backface-visibility: hidden' and is rotated 180deg" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-002">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-002.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is identical to transform3d-backface-visibility-001.html" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-003">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-003.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that if a parent and child are in the same 3D rendering context and a 60deg rotation on the parent combines with a 60deg rotation on the child to make a 120deg rotation" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-004">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-004.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that if an element is not transformed but its parent is rotated 180deg in a different rendering context the child's 'backface-visibility: hidden' does not make it disappear. " type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-005">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-005.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is the same as transform3d-backface-visibility-005.html except that the parent has 'transform-style: preserve-3d'." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-006">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-006.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is the same as transform3d-backface-visibility-001.html except it uses scalez(-1) instead of rotatex(180deg)." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-007">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-007.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="When 'backface-visiblity' is set to visible the back side of a transformed element is visible." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-008">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-008.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that applying a simple 3D transform to a bitmap image works properly." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-image-scale-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-image-scale-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="scale3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is the same as transform3d-image-scale-001.html but using an SVG image instead of a bitmap." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-image-scale-002">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-image-scale-002.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="scale3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is part 1 of a series that tests that various matrix3d()s are equivalent to other transform functions." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-matrix3d-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="matrix3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is part 2 of a series that tests that various matrix3d()s are equivalent to other transform functions." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-matrix3d-002">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-002.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="matrix3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is part 3 of a series that tests that various matrix3d()s are equivalent to other transform functions." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-matrix3d-003">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-003.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="matrix3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is part 4 of a series that tests that various matrix3d()s are equivalent to other transform functions." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-matrix3d-004">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-004.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="matrix3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is part 5 of a series that tests that various matrix3d()s are equivalent to other transform functions." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-matrix3d-005">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-005.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="matrix3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that the perspective() transform works the same as an equivalent 'perspective' property" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that 'perspective: inherit' works the same as specifying that perspective to start with" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-002">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-002.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that 'perspective' affects only the element's children" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="Transform3d-perspective-003">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-003.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that 'perspective: none' actually results in no perspective being applied to children" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-004">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-004.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that 'perspective: 0px' behaves the same as no perspective being specified at all (it's a parse error)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-005">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-005.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests the 'perspective' property in a very simple case such that the reference can be constructed without using CSS transforms" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-006">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-006.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that tables are correctly affected by perspective on their parent" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-007">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-007.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that perspective on a table only affects its children" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-008">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-008.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that 'perspective' and 'perspective-origin' have the same effect as an appropriately calculated sequence of translate() and perspective()" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-009">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-009.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that 'perspective-origin: 0 0' is the same as 'perspective-origin: top left' different from no 'perspective-origin' and different from no perspective or no transform" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-origin-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-origin-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that if preserve-3d is specified so four 45deg rotations equal one 180deg rotation" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is the first in a series of four tests that test that translations work correctly when combined with margins or translations on various elements" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-002">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-002.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is the second in a series of four tests that test that translations work correctly when combined with margins or translations on various elements when preserve-3d is enabled" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-003">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-003.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is the third in a series of four tests that test that translations work correctly when combined with margins or translations on various elements when preserve-3d is enabled" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-004">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-004.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is the fourth in a series of four tests that test that translations work correctly when combined with margins or translations on various elements when preserve-3d is enabled" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-005">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-005.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="rotatex(45deg) or rotatex(-45deg) by itself should both just scale down the element by a factor of sqrt(2) (and perhaps shift it depending on 'transform-origin')" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-006">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-006.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is identical to transform3d-preserve3d-006.html except with rotatey() instead of Rotatex()" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-007">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-007.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is identical to transform3d-preserve3d-006.html except that it has 'transform-style: preserve-3d; overflow: hidden' specified on the parent element" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-008">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-008.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is identical to Transform3d-preserve3d-008.html except with 'overflow: auto' instead of 'hidden'" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-009">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-009.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that two rotations of 22.5deg properly add when preserve-3d is used" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-010">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-010.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that when preserve-3d is specified a 90-degree rotation on the parent plus a 90-degree rotation on the child cancel out" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-011">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-011.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that two 90-degree rotations with  the default 'transform-style: flat' do not add together to form a 180-degree rotation" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-012">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-012.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is identical to transform3d-preserve3d-008.html" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-013">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-013.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that rotate3d(1 0  0 45deg) is the same as rotatex(45deg)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotate3d-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotate3d-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that rotate3d(0 1  0 45deg) is the same as rotatey(45deg)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotate3d-002">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotate3d-002.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that rotatex(45deg) rotatey(360deg)  rotatex(360deg) is the same as rotatex(45deg)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotatex-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that perspective() has some effect when combined with rotatex()" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotatex-perspective-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-perspective-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that 'perspective' has some effect when combined with rotatex()" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotatex-perspective-002">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-perspective-002.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests for a real-world implementation" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotatex-perspective-003">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-perspective-003.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that rotateX(45deg) has the same effect (with perspective) with a top left origin and a top right origin" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotatex-transformorigin-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-transformorigin-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that rotateY(45deg) rotateY(360deg) has the same effect as just rotateY(45deg)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotatey-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatey-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="A rotateY  transform 1 with perspective should result in a trapezoid" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform-3d-rotateY-stair-above-001.xht">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-3d-rotateY-stair-above-001.xht</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="A rotateY  transform 2 with perspective should result in a trapezoid" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform-3d-rotateY-stair-below-001.xht">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-3d-rotateY-stair-below-001.xht</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that scale3d(2  2  2) on some text has the same effect as scaleX(2) scaleY(2)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that rotatex(90deg) scale3d(2 1 2) rotatex(-90deg) is the same as scalex(2) scaley(2)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-002">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-002.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is the same as transform3d-scale-001.html except that it uses scaleX(2) scaleY(2) scaleZ(2) instead of scale3D(2 2 2)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-003">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-003.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that scale3d(2 2 0) being singular causes the contents not to display" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-004">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-004.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that rotateX(90deg) scale3d(1 1 2) rotateX(-90deg) is the same as scaleY(2)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-005">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-005.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is identical to transform3d-scale-005-ref.html except with scaleZ(2) instead of Scale3d(1 1 2)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-006">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-006.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that rotateX(180deg) scaleZ(-1) is the same as scaleY(-1)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-007">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-007.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="The red box here is translated in the negative  Z-direction so it should render beneath the lime box even though it comes later in DOM order" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-sorting-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-sorting-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="The red box here is translated to the same extent as the lime box so they should render in stacking context order:the lime box is on top" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-sorting-002">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-sorting-002.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="The red box here is translated to above the lime box but they aren't in the same 3D rendering context so they should be drawn in DOM order regardless: lime box on top" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-sorting-003">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-sorting-003.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This is the same as transform3d-sorting-003.html" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-sorting-004">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-sorting-004.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that if a parent has 'transform-style: preserve-3d' it's in the same rendering context as its children" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-sorting-005">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-sorting-005.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that when two boxes intersect in a simple fashion" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-sorting-006">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-sorting-006.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that translate3d() before and after rotatex() is the same as an equivalent 'transform-origin'" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-translate3d-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-translate3d-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="translate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This tests that translatez(+-10px) before and after rotatex() is the same as an equivalent 'transform-origin' and different from translatez(+-20px)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-translatez-001">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-translatez-001.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="translateZ" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check that transform property with rotate function and one parameter" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transforms-rotateY-degree-60">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transforms-rotateY-degree-60.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="The transformed div should establishe a 3D rendering context" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transofrmed-preserve-3d-1">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transofrmed-preserve-3d-1.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="The transformed div should rotateX by 180 degrees" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transofrmed-rotateX-3">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transofrmed-rotateX-3.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="The transformed div should rotate 90 degrees" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transofrmed-rotateY-1">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transofrmed-rotateY-1.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="The red. green and blue rectangles are forming a cycle which should be detected and rendered using Newell Algorithm's" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="ttwf-css-3d-polygon-cycle">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ttwf-css-3d-polygon-cycle.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="transform" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
-            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
       <testcase purpose="Check if the element backface-visibility is 'visible'" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="auto" priority="P1" id="CSS33Dtransform_backface-visibility">
         <description>
           <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/CSS33Dtransform_backface-visibility.html</test_script_entry>
@@ -1499,6 +299,1306 @@
           <spec>
             <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transforms-20120911/#transform-style</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that perspective() has some effect when combined with rotatex()" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotatex-perspective-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-perspective-001.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that 'perspective' has some effect when combined with rotatex()" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotatex-perspective-002">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-perspective-002.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+    </set>
+    <set name="3DTransforms-ref" type="ref" ui-auto="wd">
+      <testcase purpose="When the value of backface visibility property is 'hidden' then the back side of a transformed element is invisible when facing the viewer" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="backface-visibility-hidden-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/backface-visibility-hidden-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/backface-visibility-hidden-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if rotateX 90 degrees with perspective make it invisible" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css3-transform-perspective">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css3-transform-perspective.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css3-transform-perspective-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that box width should be equal to projection width if transform rotateY applied" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css3-transform-rotateY">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css3-transform-rotateY.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css3-transform-rotateY-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This transform rotates a tall rectangle by 90 degrees then applies a 3D rotation in the X axis" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-rotate-2d-3d-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-rotate-2d-3d-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-rotate-2d-3d-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that rotate the 2:1 rectangle on X-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotate3d-X-negative">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-X-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateX-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that rotate3d a 2:1 rectangle on X-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotate3d-X-positive">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-X-positive.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateX-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that rotate3d a 2:1 rectangle on Y-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotate3d-Y-negative">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Y-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateY-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that rotate3d a 2:1 rectangle on Y-axis for -60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotate3d-Y-positive">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Y-positive.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateY-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that rotate3d a vertical rectangle for -90 degree on Z-axis will cover the horizontal red rectangle" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotate3d-Z-negative">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Z-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateZ-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that box width should be equal to projection width if transform rotateZ applied" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotate3d-Z-positive">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Z-positive.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateZ-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that rotate a 2:1 rectangle on X-axis for -60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotateX-negative">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateX-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateX-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that rotate a 2:1 rectangle on X-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotateX-positive">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateX-positive.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateX-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that rotate a 2:1 rectangle on Y-axis for -60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotateY-negative">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateY-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateY-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that rotate a 2:1 rectangle on Y-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotateY-positive">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateY-positive.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateY-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that rotate a vertical rectangle for -90 degree on Z-axis will cover the horizontal red rectangle" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotateZ-negative">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateZ-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateZ-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateZ" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that rotate a vertical rectangle for 90 degree on Z-axis will cover the horizontal red rectangle" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-rotateZ-positive">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateZ-positive.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateZ-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateZ" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that rotate the nested div with transform-style preserve-3d and rotated parent div for -60 degree on Y-axis then and rotated child div for 120 degree so at this time the parent and child should have equal width then child div could cover the red box" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transform-3d-transform-style">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-transform-style.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-transform-style-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="3D transforms can not be applied to anonymous block boxes" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="css-transforms-3d-on-anonymous-block-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transforms-3d-on-anonymous-block-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transforms-3d-anonymous-block-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="The 'perspective-origin' property set 'center' computes to 50% for the vertical position." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="The 'perspective-origin' property set 'center' computes to 50% for the horizontal position." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-002">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-002.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="The 'perspective-origin' property set 'bottom' computes to 100% for the vertical position." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-003">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-003.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="The 'perspective-origin' property set 'top' computes to 0% for the vertical position." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-004">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-004.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="The 'perspective-origin' property set 'left' computes to 0% for the horizontal position." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-005">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-005.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="The 'perspective-origin' property set 'right' computes to 100% for the horizontal position." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-006">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-006.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Asserts that origin 'x1' visually moves the objects '-x1*d/(d-1)'" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-x">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-x.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/perspective-origin-reftest.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Asserts that origin '(x y)' visually moves the objects '(-x -y)*d/(d-1)'" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-origin-xy">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-xy.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/perspective-reftest.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Asserts that points on the z=0 plane are unchanged" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-translateZ-0">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-translateZ-0.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/perspective-reftest.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Asserts that the scaling is proportional to d/(d - Z) for a negative Z" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-translateZ-negative">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-translateZ-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/perspective-reftest.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="translateZ" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Asserts that the scaling is proportional to d/(d - Z) for a positive Z" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="perspective-translateZ-positive">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-translateZ-positive.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/perspective-reftest.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="translateZ" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Rotate 45 degree in x axis" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="rotate_x_45deg">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotate_x_45deg.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotate_x_45deg-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Rotate 45 degree in y axis" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="rotate_y_45deg">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotate_y_45deg.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotate_y_45deg-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="When the value of transform is 'rotateY(90deg)' the foward side of a transformed element disappears." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="rotateY">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotateY.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/rotateY-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that a very simple case of backface-visibility causes the element to disappear: rotateX(180deg) is specified on the same element that has backface-visibility: hidden." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that if an element has 'backface-visibility: hidden' and is rotated 180deg" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-002">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-002.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is identical to transform3d-backface-visibility-001.html" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-003">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-003.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that if a parent and child are in the same 3D rendering context and a 60deg rotation on the parent combines with a 60deg rotation on the child to make a 120deg rotation" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-004">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-004.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that if an element is not transformed but its parent is rotated 180deg in a different rendering context the child's 'backface-visibility: hidden' does not make it disappear. " type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-005">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-005.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is the same as transform3d-backface-visibility-005.html except that the parent has 'transform-style: preserve-3d'." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-006">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-006.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is the same as transform3d-backface-visibility-001.html except it uses scalez(-1) instead of rotatex(180deg)." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-007">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-007.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="When 'backface-visiblity' is set to visible the back side of a transformed element is visible." type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-backface-visibility-008">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-008.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="backface-visibility" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that applying a simple 3D transform to a bitmap image works properly." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-image-scale-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-image-scale-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="scale3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is the same as transform3d-image-scale-001.html but using an SVG image instead of a bitmap." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-image-scale-002">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-image-scale-002.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="scale3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is part 1 of a series that tests that various matrix3d()s are equivalent to other transform functions." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-matrix3d-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="matrix3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is part 2 of a series that tests that various matrix3d()s are equivalent to other transform functions." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-matrix3d-002">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-002.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-002-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="matrix3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is part 3 of a series that tests that various matrix3d()s are equivalent to other transform functions." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-matrix3d-003">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-003.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-003-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="matrix3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is part 4 of a series that tests that various matrix3d()s are equivalent to other transform functions." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-matrix3d-004">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-004.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-004-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="matrix3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is part 5 of a series that tests that various matrix3d()s are equivalent to other transform functions." type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-matrix3d-005">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-005.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-matrix3d-005-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="matrix3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that the perspective() transform works the same as an equivalent 'perspective' property" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that 'perspective: inherit' works the same as specifying that perspective to start with" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-002">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-002.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that 'perspective' affects only the element's children" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="Transform3d-perspective-003">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-003.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that 'perspective: none' actually results in no perspective being applied to children" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-004">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-004.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that 'perspective: 0px' behaves the same as no perspective being specified at all (it's a parse error)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-005">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-005.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests the 'perspective' property in a very simple case such that the reference can be constructed without using CSS transforms" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-006">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-006.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that tables are correctly affected by perspective on their parent" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-007">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-007.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that perspective on a table only affects its children" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-008">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-008.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that 'perspective' and 'perspective-origin' have the same effect as an appropriately calculated sequence of translate() and perspective()" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-009">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-009.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-009-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that 'perspective-origin: 0 0' is the same as 'perspective-origin: top left' different from no 'perspective-origin' and different from no perspective or no transform" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-perspective-origin-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-origin-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-perspective-origin-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="perspective-origin" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that if preserve-3d is specified so four 45deg rotations equal one 180deg rotation" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is the first in a series of four tests that test that translations work correctly when combined with margins or translations on various elements" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-002">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-002.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is the second in a series of four tests that test that translations work correctly when combined with margins or translations on various elements when preserve-3d is enabled" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-003">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-003.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is the third in a series of four tests that test that translations work correctly when combined with margins or translations on various elements when preserve-3d is enabled" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-004">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-004.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is the fourth in a series of four tests that test that translations work correctly when combined with margins or translations on various elements when preserve-3d is enabled" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-005">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-005.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="rotatex(45deg) or rotatex(-45deg) by itself should both just scale down the element by a factor of sqrt(2) (and perhaps shift it depending on 'transform-origin')" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-006">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-006.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is identical to transform3d-preserve3d-006.html except with rotatey() instead of Rotatex()" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-007">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-007.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is identical to transform3d-preserve3d-006.html except that it has 'transform-style: preserve-3d; overflow: hidden' specified on the parent element" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-008">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-008.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is identical to Transform3d-preserve3d-008.html except with 'overflow: auto' instead of 'hidden'" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-009">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-009.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that two rotations of 22.5deg properly add when preserve-3d is used" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-010">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-010.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that when preserve-3d is specified a 90-degree rotation on the parent plus a 90-degree rotation on the child cancel out" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-011">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-011.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that two 90-degree rotations with  the default 'transform-style: flat' do not add together to form a 180-degree rotation" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-012">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-012.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-blank-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is identical to transform3d-preserve3d-008.html" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-preserve3d-013">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-013.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-013-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that rotate3d(1 0  0 45deg) is the same as rotatex(45deg)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotate3d-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotate3d-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that rotate3d(0 1  0 45deg) is the same as rotatey(45deg)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotate3d-002">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotate3d-002.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatey-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that rotatex(45deg) rotatey(360deg)  rotatex(360deg) is the same as rotatex(45deg)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotatex-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests for a real-world implementation" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotatex-perspective-003">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-perspective-003.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-perspective-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that rotateX(45deg) has the same effect (with perspective) with a top left origin and a top right origin" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotatex-transformorigin-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-transformorigin-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatex-transformorigin-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that rotateY(45deg) rotateY(360deg) has the same effect as just rotateY(45deg)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-rotatey-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatey-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-rotatey-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="A rotateY  transform 1 with perspective should result in a trapezoid" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform-3d-rotateY-stair-above-001.xht">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-3d-rotateY-stair-above-001.xht</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transform-3d-rotateY-stair-above-ref-001.xht</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="A rotateY  transform 2 with perspective should result in a trapezoid" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform-3d-rotateY-stair-below-001.xht">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-3d-rotateY-stair-below-001.xht</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transform-3d-rotateY-stair-above-ref-001.xht</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that scale3d(2  2  2) on some text has the same effect as scaleX(2) scaleY(2)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that rotatex(90deg) scale3d(2 1 2) rotatex(-90deg) is the same as scalex(2) scaley(2)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-002">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-002.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is the same as transform3d-scale-001.html except that it uses scaleX(2) scaleY(2) scaleZ(2) instead of scale3D(2 2 2)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-003">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-003.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that scale3d(2 2 0) being singular causes the contents not to display" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-004">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-004.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-blank-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that rotateX(90deg) scale3d(1 1 2) rotateX(-90deg) is the same as scaleY(2)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-005">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-005.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-005-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is identical to transform3d-scale-005-ref.html except with scaleZ(2) instead of Scale3d(1 1 2)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-006">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-006.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-005-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that rotateX(180deg) scaleZ(-1) is the same as scaleY(-1)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-scale-007">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-007.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-007-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="scale3D" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="The red box here is translated in the negative  Z-direction so it should render beneath the lime box even though it comes later in DOM order" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-sorting-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-sorting-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="The red box here is translated to the same extent as the lime box so they should render in stacking context order:the lime box is on top" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-sorting-002">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-sorting-002.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="The red box here is translated to above the lime box but they aren't in the same 3D rendering context so they should be drawn in DOM order regardless: lime box on top" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-sorting-003">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-sorting-003.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This is the same as transform3d-sorting-003.html" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-sorting-004">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-sorting-004.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that if a parent has 'transform-style: preserve-3d' it's in the same rendering context as its children" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-sorting-005">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-sorting-005.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-lime-square-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that when two boxes intersect in a simple fashion" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-sorting-006">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-sorting-006.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-sorting-006-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that translate3d() before and after rotatex() is the same as an equivalent 'transform-origin'" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-translate3d-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-translate3d-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-translate3d-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="translate3d" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This tests that translatez(+-10px) before and after rotatex() is the same as an equivalent 'transform-origin' and different from translatez(+-20px)" type="compliance" status="designed" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transform3d-translatez-001">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-translatez-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-translatez-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="translateZ" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check that transform property with rotate function and one parameter" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transforms-rotateY-degree-60">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transforms-rotateY-degree-60.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transforms-rotateY-degree-60-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="The transformed div should establishe a 3D rendering context" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transofrmed-preserve-3d-1">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transofrmed-preserve-3d-1.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transofrmed-preserve-3d-1-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform-style" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="The transformed div should rotateX by 180 degrees" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transofrmed-rotateX-3">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transofrmed-rotateX-3.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transofrmed-rotateX-3-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateX" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="The transformed div should rotate 90 degrees" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="transofrmed-rotateY-1">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transofrmed-rotateY-1.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transofrmed-rotateY-1-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="rotateY" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="The red. green and blue rectangles are forming a cycle which should be detected and rendered using Newell Algorithm's" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" priority="P2" id="ttwf-css-3d-polygon-cycle">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ttwf-css-3d-polygon-cycle.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/ttwf-css-3d-polygon-cycle-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="transform" interface="CSS" specification="CSS 3D Transforms Module Level 3 (Partial)" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/csswg/css-transforms/#three-d-transform-functions</spec_url>
             <spec_statement/>
           </spec>
         </specs>

--- a/webapi/tct-3dtransforms-css3-tests/tests.xml
+++ b/webapi/tct-3dtransforms-css3-tests/tests.xml
@@ -3,91 +3,6 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="tct-3dtransforms-css3-tests">
     <set name="3DTransforms" type="js">
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="backface-visibility-hidden-001" purpose="When the value of backface visibility property is 'hidden' then the back side of a transformed element is invisible when facing the viewer">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/backface-visibility-hidden-001.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css3-transform-perspective" purpose="Check if rotateX 90 degrees with perspective make it invisible">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css3-transform-perspective.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css3-transform-rotateY" purpose="Check that box width should be equal to projection width if transform rotateY applied">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css3-transform-rotateY.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-rotate-2d-3d-001" purpose="This transform rotates a tall rectangle by 90 degrees then applies a 3D rotation in the X axis">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-rotate-2d-3d-001.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotate3d-X-negative" purpose="Check that rotate the 2:1 rectangle on X-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-X-negative.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotate3d-X-positive" purpose="Check that rotate3d a 2:1 rectangle on X-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-X-positive.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotate3d-Y-negative" purpose="Check that rotate3d a 2:1 rectangle on Y-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Y-negative.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotate3d-Y-positive" purpose="Check that rotate3d a 2:1 rectangle on Y-axis for -60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Y-positive.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotate3d-Z-negative" purpose="Check that rotate3d a vertical rectangle for -90 degree on Z-axis will cover the horizontal red rectangle">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Z-negative.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotate3d-Z-positive" purpose="Check that box width should be equal to projection width if transform rotateZ applied">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Z-positive.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotateX-negative" purpose="Check that rotate a 2:1 rectangle on X-axis for -60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateX-negative.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotateX-positive" purpose="Check that rotate a 2:1 rectangle on X-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateX-positive.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotateY-negative" purpose="Check that rotate a 2:1 rectangle on Y-axis for -60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateY-negative.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotateY-positive" purpose="Check that rotate a 2:1 rectangle on Y-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateY-positive.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotateZ-negative" purpose="Check that rotate a vertical rectangle for -90 degree on Z-axis will cover the horizontal red rectangle">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateZ-negative.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotateZ-positive" purpose="Check that rotate a vertical rectangle for 90 degree on Z-axis will cover the horizontal red rectangle">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateZ-positive.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-transform-style" purpose="Check that rotate the nested div with transform-style preserve-3d and rotated parent div for -60 degree on Y-axis then and rotated child div for 120 degree so at this time the parent and child should have equal width then child div could cover the red box">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-transform-style.html</test_script_entry>
-        </description>
-      </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="auto" id="Css-transform-property-existence-001" purpose="Check the existence of transform">
         <description>
           <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-property-existence.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
@@ -116,11 +31,6 @@
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="auto" id="Css-transform-property-existence-006" purpose="Check the existence of backface-visibility">
         <description>
           <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-property-existence.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transforms-3d-on-anonymous-block-001" purpose="3D transforms can not be applied to anonymous block boxes">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transforms-3d-on-anonymous-block-001.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="auto" id="Css-transform-style-evaluation-validation-001" purpose="transform: Check bad-format multi-expr input.">
@@ -188,126 +98,6 @@
           <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-style-evaluation-validation.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-001" purpose="The 'perspective-origin' property set 'center' computes to 50% for the vertical position.">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-001.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-002" purpose="The 'perspective-origin' property set 'center' computes to 50% for the horizontal position.">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-002.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-003" purpose="The 'perspective-origin' property set 'bottom' computes to 100% for the vertical position.">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-003.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-004" purpose="The 'perspective-origin' property set 'top' computes to 0% for the vertical position.">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-004.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-005" purpose="The 'perspective-origin' property set 'left' computes to 0% for the horizontal position.">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-005.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-006" purpose="The 'perspective-origin' property set 'right' computes to 100% for the horizontal position.">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-006.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-x" purpose="Asserts that origin 'x1' visually moves the objects '-x1*d/(d-1)'">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-x.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-xy" purpose="Asserts that origin '(x y)' visually moves the objects '(-x -y)*d/(d-1)'">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-xy.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-translateZ-0" purpose="Asserts that points on the z=0 plane are unchanged">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-translateZ-0.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-translateZ-negative" purpose="Asserts that the scaling is proportional to d/(d - Z) for a negative Z">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-translateZ-negative.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-translateZ-positive" purpose="Asserts that the scaling is proportional to d/(d - Z) for a positive Z">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-translateZ-positive.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="rotate_x_45deg" purpose="Rotate 45 degree in x axis">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotate_x_45deg.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="rotate_y_45deg" purpose="Rotate 45 degree in y axis">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotate_y_45deg.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="rotateY" purpose="When the value of transform is 'rotateY(90deg)' the foward side of a transformed element disappears.">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotateY.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transform3d-backface-visibility-008" purpose="When 'backface-visiblity' is set to visible the back side of a transformed element is visible.">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-008.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transform3d-preserve3d-012" purpose="This tests that two 90-degree rotations with  the default 'transform-style: flat' do not add together to form a 180-degree rotation">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-012.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transform-3d-rotateY-stair-above-001.xht" purpose="A rotateY  transform 1 with perspective should result in a trapezoid">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-3d-rotateY-stair-above-001.xht</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transform-3d-rotateY-stair-below-001.xht" purpose="A rotateY  transform 2 with perspective should result in a trapezoid">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-3d-rotateY-stair-below-001.xht</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transform3d-scale-004" purpose="This tests that scale3d(2 2 0) being singular causes the contents not to display">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-004.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transforms-rotateY-degree-60" purpose="Check that transform property with rotate function and one parameter">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transforms-rotateY-degree-60.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transofrmed-preserve-3d-1" purpose="The transformed div should establishe a 3D rendering context">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transofrmed-preserve-3d-1.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transofrmed-rotateX-3" purpose="The transformed div should rotateX by 180 degrees">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transofrmed-rotateX-3.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transofrmed-rotateY-1" purpose="The transformed div should rotate 90 degrees">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transofrmed-rotateY-1.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="ttwf-css-3d-polygon-cycle" purpose="The red. green and blue rectangles are forming a cycle which should be detected and rendered using Newell Algorithm's">
-        <description>
-          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ttwf-css-3d-polygon-cycle.html</test_script_entry>
-        </description>
-      </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="auto" id="CSS33Dtransform_backface-visibility" purpose="Check if the element backface-visibility is 'visible'">
         <description>
           <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/CSS33Dtransform_backface-visibility.html</test_script_entry>
@@ -336,6 +126,260 @@
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="auto" id="CSS33Dtransform_transform-style" purpose="Check if the element transform-style is 'preserve-3d'">
         <description>
           <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/CSS33Dtransform_transform-style.html</test_script_entry>
+        </description>
+      </testcase>
+    </set>
+    <set name="3DTransforms-ref" type="ref" ui-auto="wd">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="backface-visibility-hidden-001" purpose="When the value of backface visibility property is 'hidden' then the back side of a transformed element is invisible when facing the viewer">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/backface-visibility-hidden-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/backface-visibility-hidden-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css3-transform-perspective" purpose="Check if rotateX 90 degrees with perspective make it invisible">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css3-transform-perspective.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css3-transform-perspective-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css3-transform-rotateY" purpose="Check that box width should be equal to projection width if transform rotateY applied">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css3-transform-rotateY.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css3-transform-rotateY-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-rotate-2d-3d-001" purpose="This transform rotates a tall rectangle by 90 degrees then applies a 3D rotation in the X axis">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-rotate-2d-3d-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-rotate-2d-3d-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotate3d-X-negative" purpose="Check that rotate the 2:1 rectangle on X-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-X-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateX-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotate3d-X-positive" purpose="Check that rotate3d a 2:1 rectangle on X-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-X-positive.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateX-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotate3d-Y-negative" purpose="Check that rotate3d a 2:1 rectangle on Y-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Y-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateY-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotate3d-Y-positive" purpose="Check that rotate3d a 2:1 rectangle on Y-axis for -60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Y-positive.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateY-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotate3d-Z-negative" purpose="Check that rotate3d a vertical rectangle for -90 degree on Z-axis will cover the horizontal red rectangle">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Z-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateZ-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotate3d-Z-positive" purpose="Check that box width should be equal to projection width if transform rotateZ applied">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotate3d-Z-positive.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateZ-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotateX-negative" purpose="Check that rotate a 2:1 rectangle on X-axis for -60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateX-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateX-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotateX-positive" purpose="Check that rotate a 2:1 rectangle on X-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateX-positive.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateX-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotateY-negative" purpose="Check that rotate a 2:1 rectangle on Y-axis for -60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateY-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateY-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotateY-positive" purpose="Check that rotate a 2:1 rectangle on Y-axis for 60 degree we will get a square and completely cover the red square and here we use border due to the rectangle not be rotated would cover the red square">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateY-positive.html</test_script_entry>
+         <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateY-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotateZ-negative" purpose="Check that rotate a vertical rectangle for -90 degree on Z-axis will cover the horizontal red rectangle">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateZ-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateZ-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-rotateZ-positive" purpose="Check that rotate a vertical rectangle for 90 degree on Z-axis will cover the horizontal red rectangle">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-rotateZ-positive.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-rotateZ-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transform-3d-transform-style" purpose="Check that rotate the nested div with transform-style preserve-3d and rotated parent div for -60 degree on Y-axis then and rotated child div for 120 degree so at this time the parent and child should have equal width then child div could cover the red box">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transform-3d-transform-style.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transform-3d-transform-style-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="css-transforms-3d-on-anonymous-block-001" purpose="3D transforms can not be applied to anonymous block boxes">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/css-transforms-3d-on-anonymous-block-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/css-transforms-3d-anonymous-block-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="ttwf-css-3d-polygon-cycle" purpose="The red. green and blue rectangles are forming a cycle which should be detected and rendered using Newell Algorithm's">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ttwf-css-3d-polygon-cycle.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/ttwf-css-3d-polygon-cycle-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-001" purpose="The 'perspective-origin' property set 'center' computes to 50% for the vertical position.">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-001.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-002" purpose="The 'perspective-origin' property set 'center' computes to 50% for the horizontal position.">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-002.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-003" purpose="The 'perspective-origin' property set 'bottom' computes to 100% for the vertical position.">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-003.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-004" purpose="The 'perspective-origin' property set 'top' computes to 0% for the vertical position.">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-004.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-005" purpose="The 'perspective-origin' property set 'left' computes to 0% for the horizontal position.">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-005.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-006" purpose="The 'perspective-origin' property set 'right' computes to 100% for the horizontal position.">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-006.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-x" purpose="Asserts that origin 'x1' visually moves the objects '-x1*d/(d-1)'">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-x.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/perspective-origin-reftest.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-origin-xy" purpose="Asserts that origin '(x y)' visually moves the objects '(-x -y)*d/(d-1)'">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-origin-xy.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/perspective-reftest.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-translateZ-0" purpose="Asserts that points on the z=0 plane are unchanged">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-translateZ-0.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/perspective-reftest.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-translateZ-negative" purpose="Asserts that the scaling is proportional to d/(d - Z) for a negative Z">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-translateZ-negative.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/perspective-reftest.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="perspective-translateZ-positive" purpose="Asserts that the scaling is proportional to d/(d - Z) for a positive Z">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/perspective-translateZ-positive.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/perspective-reftest.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="rotate_x_45deg" purpose="Rotate 45 degree in x axis">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotate_x_45deg.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotate_x_45deg-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="rotate_y_45deg" purpose="Rotate 45 degree in y axis">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotate_y_45deg.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotate_y_45deg-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="rotateY" purpose="When the value of transform is 'rotateY(90deg)' the foward side of a transformed element disappears.">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/rotateY.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/rotateY-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transform3d-backface-visibility-008" purpose="When 'backface-visiblity' is set to visible the back side of a transformed element is visible.">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-backface-visibility-008.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/ref-filled-green-100px-square.xht</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transform3d-preserve3d-012" purpose="This tests that two 90-degree rotations with  the default 'transform-style: flat' do not add together to form a 180-degree rotation">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-preserve3d-012.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-blank-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transform-3d-rotateY-stair-above-001.xht" purpose="A rotateY  transform 1 with perspective should result in a trapezoid">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-3d-rotateY-stair-above-001.xht</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transform-3d-rotateY-stair-above-ref-001.xht</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transform-3d-rotateY-stair-below-001.xht" purpose="A rotateY  transform 2 with perspective should result in a trapezoid">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-3d-rotateY-stair-below-001.xht</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transform-3d-rotateY-stair-above-ref-001.xht</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transform3d-scale-004" purpose="This tests that scale3d(2 2 0) being singular causes the contents not to display">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform3d-scale-004.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transform-blank-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transforms-rotateY-degree-60" purpose="Check that transform property with rotate function and one parameter">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transforms-rotateY-degree-60.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transforms-rotateY-degree-60-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transofrmed-preserve-3d-1" purpose="The transformed div should establishe a 3D rendering context">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transofrmed-preserve-3d-1.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transofrmed-preserve-3d-1-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transofrmed-rotateX-3" purpose="The transformed div should rotateX by 180 degrees">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transofrmed-rotateX-3.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transofrmed-rotateX-3-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="manual" id="transofrmed-rotateY-1" purpose="The transformed div should rotate 90 degrees">
+        <description>
+          <test_script_entry>/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/transofrmed-rotateY-1.html</test_script_entry>
+          <refer_test_script_entry timeout="90">/opt/tct-3dtransforms-css3-tests/3dtransforms/csswg/reference/transofrmed-rotateY-1-ref.html</refer_test_script_entry>
         </description>
       </testcase>
     </set>


### PR DESCRIPTION
Fail analysis: Actual pic is different with expected pic when crosswalk
render pics. For example: css-transform-3d-rotate3d-X-negative.html,
there is a red border outside black border, but the ref has not.

Impacted tests(approved): new 0, update 40, delete 0
Unit test platform: Crosswalk Project for Android 15.44.361.0
Unit test result summary: pass 38, fail 29, block 0