### PR TITLE
[apptools-ios] Change execution_type from 'manual' to 'auto' for apptools ios

### DIFF
--- a/apptools/apptools-ios-tests/tests.full.xml
+++ b/apptools/apptools-ios-tests/tests.full.xml
@@ -3,59 +3,59 @@
 <test_definition>
   <suite category="Crosswalk App Tools" name="apptools-ios-tests">
     <set name="CLI" type="pyunit">
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_pkgName" priority="P1" purpose="iOS - Validate project can be created with validate package naming rule" status="approved" type="Functional" subcase="16">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" priority="P1" purpose="iOS - Validate project can be created with validate package naming rule" status="approved" type="Functional" subcase="16">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/pkgName.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_build" priority="P1" purpose="iOS - Validate if project is built successfully with build command" status="approved" type="Functional" subcase="2">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_build" priority="P1" purpose="iOS - Validate if project is built successfully with build command" status="approved" type="Functional" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/build.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_create" priority="P1" purpose="iOS - Validate if project is created fail when the project has been exist" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create" priority="P1" purpose="iOS - Validate if project is created fail when the project has been exist" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/create.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_version" priority="P1" purpose="iOS - Validate if version command can display version information" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_version" priority="P1" purpose="iOS - Validate if version command can display version information" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/version.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_check_log" priority="P1" purpose="iOS - Validate if log have output info and debug info" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_check_log" priority="P1" purpose="iOS - Validate if log have output info and debug info" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/check_log.py</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="common_module" type="nodeunit">
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_application" priority="P1" purpose="iOS - Validate if the config and log message are correct when create a new project" status="approved" type="Functional" subcase="7">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" priority="P1" purpose="iOS - Validate if the config and log message are correct when create a new project" status="approved" type="Functional" subcase="7">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/application.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_finite_progress" priority="P1" purpose="iOS - Validate if a finite progress can be created" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_finite_progress" priority="P1" purpose="iOS - Validate if a finite progress can be created" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/finite-progress.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_infinite_progress" priority="P1" purpose="iOS - Validate if a infinite progress can be created" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_infinite_progress" priority="P1" purpose="iOS - Validate if a infinite progress can be created" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/infinite-progress.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_logfile_output" priority="P1" purpose="iOS - Validate if output all log message include error, warning and so on to logfile" status="approved" type="Functional" subcase="5">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_logfile_output" priority="P1" purpose="iOS - Validate if output all log message include error, warning and so on to logfile" status="approved" type="Functional" subcase="5">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/logfile-output.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_output_tee" priority="P1" purpose="iOS - Validate if output all log message include error, warning and so on" status="approved" type="Functional" subcase="6">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_output_tee" priority="P1" purpose="iOS - Validate if output all log message include error, warning and so on" status="approved" type="Functional" subcase="6">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/output-tee.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_platform_base" priority="P1" purpose="iOS - Validate if platform project template can be generated and platform project can be updated to latest Crosswalk" status="approved" type="Functional" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_base" priority="P1" purpose="iOS - Validate if platform project template can be generated and platform project can be updated to latest Crosswalk" status="approved" type="Functional" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/platform-base.js</test_script_entry>
         </description>
@@ -70,12 +70,12 @@
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/platforms-manager.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_template_file" priority="P1" purpose="iOS - Validate if App Tool support create/write/read a template file" status="approved" type="Functional" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_template_file" priority="P1" purpose="iOS - Validate if App Tool support create/write/read a template file" status="approved" type="Functional" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/template-file.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_test_util" priority="P1" purpose="iOS - Validate if a temp directory/file can be created under folder test-tmp" status="approved" type="Functional" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_test_util" priority="P1" purpose="iOS - Validate if a temp directory/file can be created under folder test-tmp" status="approved" type="Functional" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/test-util.js</test_script_entry>
         </description>

--- a/apptools/apptools-ios-tests/tests.xml
+++ b/apptools/apptools-ios-tests/tests.xml
@@ -3,59 +3,59 @@
 <test_definition>
   <suite category="Crosswalk App Tools" name="apptools-ios-tests">
     <set name="CLI" type="pyunit">
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_pkgName" purpose="iOS - Validate project can be created with validate package naming rule" subcase="16">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" purpose="iOS - Validate project can be created with validate package naming rule" subcase="16">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/pkgName.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_build" purpose="iOS - Validate if project is built successfully with build command" subcase="2">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_build" purpose="iOS - Validate if project is built successfully with build command" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/build.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_create" purpose="iOS - Validate if project is created fail when the project has been exist">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create" purpose="iOS - Validate if project is created fail when the project has been exist">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/create.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_version" purpose="iOS - Validate if version command can display version information">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_version" purpose="iOS - Validate if version command can display version information">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/version.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Crosswalk_check_log" purpose="iOS - Validate if log have output info and debug info">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_check_log" purpose="iOS - Validate if log have output info and debug info">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/check_log.py</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="common_module" type="nodeunit">
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_application" purpose="iOS - Validate if the config and log message are correct when create a new project" subcase="7">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" purpose="iOS - Validate if the config and log message are correct when create a new project" subcase="7">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/application.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_finite_progress" purpose="iOS - Validate if a finite progress can be created">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_finite_progress" purpose="iOS - Validate if a finite progress can be created">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/finite-progress.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_infinite_progress" purpose="iOS - Validate if a infinite progress can be created">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_infinite_progress" purpose="iOS - Validate if a infinite progress can be created">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/infinite-progress.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_logfile_output" purpose="iOS - Validate if output all log message include error, warning and so on to logfile" subcase="5">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_logfile_output" purpose="iOS - Validate if output all log message include error, warning and so on to logfile" subcase="5">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/logfile-output.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_output_tee" purpose="iOS - Validate if output all log message include error, warning and so on" subcase="6">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_output_tee" purpose="iOS - Validate if output all log message include error, warning and so on" subcase="6">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/output-tee.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_platform_base" purpose="iOS - Validate if platform project template can be generated and platform project can be updated to latest Crosswalk" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_platform_base" purpose="iOS - Validate if platform project template can be generated and platform project can be updated to latest Crosswalk" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/platform-base.js</test_script_entry>
         </description>
@@ -70,12 +70,12 @@
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/platforms-manager.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_template_file" purpose="iOS - Validate if App Tool support create/write/read a template file" subcase="2">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_template_file" purpose="iOS - Validate if App Tool support create/write/read a template file" subcase="2">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/template-file.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="manual" id="Crosswalk_test_util" purpose="iOS - Validate if a temp directory/file can be created under folder test-tmp" subcase="3">
+      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_test_util" purpose="iOS - Validate if a temp directory/file can be created under folder test-tmp" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/test-util.js</test_script_entry>
         </description>


### PR DESCRIPTION
Change execution_type from 'manual' to 'auto', since ios has already supported testkit-lite