### PR TITLE
[EmbeddingApi] Add usecase to disable back button in XWalkView

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -293,5 +293,14 @@
                 <category android:name="android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".XWalkViewWithDispatchKeyEvent"
+            android:label="XWalkViewWithDispatchKeyEvent"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -286,3 +286,13 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load, onCreateInputConnection methods
 
+
+
+### 27. The [XWalkViewWithDispatchKeyEvent](XWalkViewWithDispatchKeyEvent.java) sample check whether xwalkview can use dispatchKeyEvent method, include:
+
+* XWalkView can use dispatchKeyEvent method
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, dispatchKeyEvent methods
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkViewWithDispatchKeyEvent.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkViewWithDispatchKeyEvent.java
@@ -1,0 +1,67 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.asyncsample;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.KeyEvent;
+
+
+public class XWalkViewWithDispatchKeyEvent extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        XWalkInitializer.initAsync(this, this);
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        setContentView(R.layout.xwview_layout);
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can disable back button.\n\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if case can't backwards by pressing back key.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mXWalkView.load("http://www.baidu.com/", null);
+    }
+
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+	// TODO Auto-generated method stub
+	if (event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
+	    return true;
+	}
+	return false;
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -293,5 +293,14 @@
                 <category android:name="android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".XWalkViewWithDispatchKeyEvent"
+            android:label="XWalkViewWithDispatchKeyEvent"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -286,3 +286,13 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load, onCreateInputConnection methods
 
+
+
+### 27. The [XWalkViewWithDispatchKeyEvent](XWalkViewWithDispatchKeyEvent.java) sample check whether xwalkview can use dispatchKeyEvent method, include:
+
+* XWalkView can use dispatchKeyEvent method
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, dispatchKeyEvent methods
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithDispatchKeyEvent.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithDispatchKeyEvent.java
@@ -1,0 +1,49 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.sample;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.KeyEvent;
+
+
+public class XWalkViewWithDispatchKeyEvent extends XWalkActivity {
+    private XWalkView mXWalkView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        setContentView(R.layout.xwview_layout);
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can disable back button.\n\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if case can't backwards by pressing back key.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mXWalkView.load("http://www.baidu.com/", null);
+    }
+
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+	// TODO Auto-generated method stub
+	if (event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
+	    return true;
+	}
+	return false;
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -326,7 +326,19 @@
           </steps>
           <test_script_entry test_script_expected_result="0" />
         </description>
-      </testcase>    
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithDispatchKeyEvent" purpose="dispatchKeyEvent() Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>      
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewUIInflation" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -652,7 +664,19 @@
           </steps>
           <test_script_entry test_script_expected_result="0" />
         </description>
-      </testcase>      
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithDispatchKeyEvent" purpose="dispatchKeyEvent() Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>         
     </set>    
   </suite>
 </test_definition>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -354,6 +354,19 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithDispatchKeyEvent" platform="android" priority="P0" purpose="dispatchKeyEvent() Test With XWalkActivity" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewUIInflation" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -695,6 +708,19 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithInputConnection" platform="android" priority="P0" purpose="onCreateInputConnections() Test With XWalkInitializer" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithDispatchKeyEvent" platform="android" priority="P0" purpose="dispatchKeyEvent() Test With XWalkInitializer" status="approved" type="functional_positive">
         <description>
           <pre_condition />
           <post_condition />


### PR DESCRIPTION
-Add usecase to check dispatchKeyEvent  method in XWalkView
-cover the XWalkViewActivity and XWalkInitializer two ways

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4459