### PR TITLE
[Embeddingapi] Add autocase about selecting xwalkview language

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -889,6 +889,15 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
         });
     }
 
+    protected void setAcceptLanguages(final String languages) {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.setAcceptLanguages(languages);
+            }
+        });
+    }
+
     public static final String ABOUT_TITLE = "About the Google";
 
     protected String addAboutPageToTestServer(TestWebServer webServer) {

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewTest.java
@@ -242,4 +242,21 @@ public class XWalkViewTest extends XWalkViewTestBase {
             e.printStackTrace();
 		}
     }
+
+    @SmallTest
+    public void testSetAcceptLanuages() throws Throwable {
+        String result;
+        final String script = "navigator.languages";
+        final String[] languages = {"en;q=0.7", "zh-cn", "da,en-gb;q=0.8,en;q=0.7"};
+        final String[] expectedLanguages = {"[\"en;q=0.7\"]", "[\"zh-cn\"]", "[\"da\",\"en-gb;q=0.8\",\"en;q=0.7\"]"};
+
+        result = executeJavaScriptAndWaitForResult(script);
+        assertNotNull(result);
+
+        for (int i = 0; i < languages.length; i++) {
+            setAcceptLanguages(languages[i]);
+            result = executeJavaScriptAndWaitForResult(script);
+            assertEquals(expectedLanguages[i], result);
+        }
+    }
 }

--- a/embeddingapi/embedding-api-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-api-android-tests/tests.full.xml
@@ -83,7 +83,7 @@
           <test_script_entry>org.xwalk.embedding.test.v4.XWalkResourceClientTest</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="10">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="11">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-api-android-tests/tests_v5.xml
+++ b/embeddingapi/embedding-api-android-tests/tests_v5.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite name="webapi-embeddingapi-xwalk-tests" category="Android embedding APIs">
     <set name="EmbeddingApiTest" type="androidunit" location="device">
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="10">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="11">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -889,6 +889,15 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
         });
     }
 
+    protected void setAcceptLanguages(final String languages) {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.setAcceptLanguages(languages);
+            }
+        });
+    }
+
     public static final String ABOUT_TITLE = "About the Google";
 
     protected String addAboutPageToTestServer(TestWebServer webServer) {

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewTest.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewTest.java
@@ -242,4 +242,21 @@ public class XWalkViewTest extends XWalkViewTestBase {
             e.printStackTrace();
 		}
     }
+
+    @SmallTest
+    public void testSetAcceptLanuages() throws Throwable {
+        String result;
+        final String script = "navigator.languages";
+        final String[] languages = {"en;q=0.7", "zh-cn", "da,en-gb;q=0.8,en;q=0.7"};
+        final String[] expectedLanguages = {"[\"en;q=0.7\"]", "[\"zh-cn\"]", "[\"da\",\"en-gb;q=0.8\",\"en;q=0.7\"]"};
+
+        result = executeJavaScriptAndWaitForResult(script);
+        assertNotNull(result);
+
+        for (int i = 0; i < languages.length; i++) {
+            setAcceptLanguages(languages[i]);
+            result = executeJavaScriptAndWaitForResult(script);
+            assertEquals(expectedLanguages[i], result);
+        }
+    }
 }

--- a/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
@@ -83,7 +83,7 @@
           <test_script_entry>org.xwalk.embedding.test.v4.XWalkResourceClientTest</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="10">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="11">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/tests_v5.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests_v5.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite name="webapi-embeddingapi-xwalk-tests" category="Android embedding APIs">
     <set name="EmbeddingApiTest" type="androidunit" location="device">
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="10">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="11">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewTest</test_script_entry>
         </description>


### PR DESCRIPTION
-Add autocase to check XWalkView.setAcceptLanguages api
-cover the XWalkViewActivity and XWalkInitializer two ways

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4350