### PR TITLE
[misc-linux] Update test steps for Webapp Manu

### DIFF
--- a/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_Feature.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "cargobridge.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which cargobridge)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which cargobridge)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Click button "Play"</li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_Link.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "cargobridge.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which cargobridge)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which cargobridge)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Click the different links in the page several times</li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_Name.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "cargobridge.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which cargobridge)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which cargobridge)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Search "cargobridge" app shortcut in the launcher and check the app name</li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/Cargo_Bridge_UI.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "cargobridge.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which cargobridge)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which cargobridge)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Validate the page layout and display</li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Dbank_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/Dbank_Feature.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "dbankonlinestorage.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which dbankonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which dbankonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Use the huawei account login in the web system. </li>
       <li>Click the "Upload File" button to upload a file. </li>

--- a/misc/webappmanu-linux-tests/webapp/Dbank_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/Dbank_Link.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "dbankonlinestorage.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which dbankonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which dbankonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Click the different links in the page several times. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Dbank_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/Dbank_Name.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "dbankonlinestorage.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which dbankonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which dbankonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Search "dbankonlinestorage" app shortcut in the launcher and check the app name. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Dbank_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/Dbank_UI.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "dbankonlinestorage.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which dbankonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which dbankonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Validate the page layout and display. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Douban_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/Douban_Feature.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "douban.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which douban)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which douban)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Choose a song and play. </li>
       <li>Click the "Next Music" link. </li>

--- a/misc/webappmanu-linux-tests/webapp/Douban_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/Douban_Link.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "douban.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which douban)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which douban)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Click the different links in the page several times. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Douban_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/Douban_Name.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "douban.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which douban)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which douban)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Search "douban" app shortcut in the launcher and check the app name. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Douban_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/Douban_UI.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "douban.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which douban)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which douban)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Validate the page layout and display. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Kingsoft_Fast_Docs_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/Kingsoft_Fast_Docs_Feature.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "kingsoftfastdocs.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which kingsoftfastdocs)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which kingsoftfastdocs)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Use the kingsoft account login in the web system. </li>
       <li>Click the "Create" button to create a document and save. </li>

--- a/misc/webappmanu-linux-tests/webapp/Kingsoft_Fast_Docs_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/Kingsoft_Fast_Docs_Link.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "kingsoftfastdocs.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which kingsoftfastdocs)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which kingsoftfastdocs)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Click the different links in the page several times. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Kingsoft_Fast_Docs_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/Kingsoft_Fast_Docs_Name.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "kingsoftfastdocs.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which kingsoftfastdocs)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which kingsoftfastdocs)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Search "kingsoftfastdocs" app shortcut in the launcher and check the app name. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Kingsoft_Fast_Docs_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/Kingsoft_Fast_Docs_UI.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "kingsoftfastdocs.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which kingsoftfastdocs)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which kingsoftfastdocs)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Validate the page layout and display. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Kugou_Music_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/Kugou_Music_Feature.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "kugoumusic.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which kugoumusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which kugoumusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Choose a song and play. </li>
       <li>Click the "Next Music" link. </li>

--- a/misc/webappmanu-linux-tests/webapp/Kugou_Music_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/Kugou_Music_Link.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "kugoumusic.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which kugoumusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which kugoumusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Click the different links in the page several times. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Kugou_Music_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/Kugou_Music_Name.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "kugoumusic.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which kugoumusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which kugoumusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Search "kugoumusic" app shortcut in the launcher and check the app name. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Kugou_Music_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/Kugou_Music_UI.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "kugoumusic.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which kugoumusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which kugoumusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Validate the page layout and display. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Kuwo_Music_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/Kuwo_Music_Feature.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "kuwomusic.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which kuwomusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which kuwomusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Choose a song and play. </li>
       <li>Click the "Next Music" link. </li>

--- a/misc/webappmanu-linux-tests/webapp/Kuwo_Music_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/Kuwo_Music_Link.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "kuwomusic.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which kuwomusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which kuwomusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Click the different links in the page several times. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Kuwo_Music_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/Kuwo_Music_Name.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "kuwomusic.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which kuwomusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which kuwomusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Search "kuwomusic" app shortcut in the launcher and check the app name. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Kuwo_Music_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/Kuwo_Music_UI.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "kuwomusic.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which kuwomusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which kuwomusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Validate the page layout and display. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Pan_Baidu_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/Pan_Baidu_Feature.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "baiduonlinestorage.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which baiduonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which baiduonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Use the baidu account login in the web system. </li>
       <li>Click the "Upload File" button to upload a file. </li>

--- a/misc/webappmanu-linux-tests/webapp/Pan_Baidu_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/Pan_Baidu_Link.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "baiduonlinestorage.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which baiduonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which baiduonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Click the different links in the page several times. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Pan_Baidu_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/Pan_Baidu_Name.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "baiduonlinestorage.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which baiduonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which baiduonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Search "baiduonlinestorage" app shortcut in the launcher and check the app name. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Pan_Baidu_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/Pan_Baidu_UI.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "baiduonlinestorage.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which baiduonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which baiduonlinestorage)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Validate the page layout and display. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Ttpod_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/Ttpod_Feature.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "ttpod.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which ttpod)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which ttpod)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Choose a song and play. </li>
       <li>Click the "Next Music" link. </li>

--- a/misc/webappmanu-linux-tests/webapp/Ttpod_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/Ttpod_Link.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "ttpod.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which ttpod)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which ttpod)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Click the different links in the page several times. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Ttpod_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/Ttpod_Name.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "ttpod.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which ttpod)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which ttpod)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Search "ttpod" app shortcut in the launcher and check the app name. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Ttpod_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/Ttpod_UI.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "ttpod.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which ttpod)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which ttpod)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Validate the page layout and display. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Xiami_Music_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/Xiami_Music_Feature.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "xiamimusic.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which xiamimusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which xiamimusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Click the "Next Music" link</li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Xiami_Music_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/Xiami_Music_Link.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "xiamimusic.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which xiamimusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which xiamimusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Click the different links in the page several times</li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Xiami_Music_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/Xiami_Music_Name.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "xiamimusic.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which xiamimusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which xiamimusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Search "xiamimusic" app shortcut in the launcher and check the app name</li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Xiami_Music_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/Xiami_Music_UI.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "xiamimusic.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which xiamimusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which xiamimusic)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Validate the page layout and display</li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Youdao_Note_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/Youdao_Note_Feature.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "youdaonote.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which youdaonote)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which youdaonote)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Click the "Login in cloud note" link and Use the youdao account login in the web system. </li>
       <li>Click the "Create Note" button to create a note and save. </li>

--- a/misc/webappmanu-linux-tests/webapp/Youdao_Note_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/Youdao_Note_Link.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "youdaonote.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which youdaonote)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which youdaonote)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Click the different links in the page several times. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Youdao_Note_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/Youdao_Note_Name.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "youdaonote.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which youdaonote)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which youdaonote)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Search "youdaonote" app shortcut in the launcher and check the app name. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/Youdao_Note_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/Youdao_Note_UI.html
@@ -42,7 +42,7 @@ Authors:
     </p>
     <ol>
       <li>Install the "youdaonote.deb" webapp and launch it with command like:<br>
-          xwalk $(dirname $(realpath $(which youdaonote)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+          xwalk $(dirname $(readlink -f $(which youdaonote)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
       </li>
       <li>Validate the page layout and display. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kugoumusic/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kugoumusic/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "deepin-webapps-kugou-music",
   "xwalk_version": "0.0.1",
-  "start_url": "http://web.kugou.com"
+  "start_url": "http://web.kugou.com/default.html"
 }


### PR DESCRIPTION
- Update the way to launch test app refer to
https://crosswalk-project.org/jira/browse/XWALK-4537

- Due to the test page of kugoumusic became invalid, update
test page link

Impacted tests(approved): new 0, update 40, delete 0
Unit test platform: Crosswalk for Linux 15.44.370.0
Unit test result summary: pass 36, fail 4, block 0

Failed tests tracked by https://crosswalk-project.org/jira/browse/XWALK-3670
and https://crosswalk-project.org/jira/browse/XWALK-3791

Test app can be launched in Ubuntu 14.04 successfully.