### PR TITLE
[Embeddingapi] Add usecase about selecting xwalkview language

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -302,5 +302,14 @@
                 <category android:name="android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".XWalkViewWithSetLanguage"
+            android:label="XWalkViewWithSetLanguage"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -296,3 +296,13 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load, dispatchKeyEvent methods
 
+
+
+### 28. The [XWalkViewWithSetLanguage](XWalkViewWithSetLanguage.java) sample check whether xwalkview can set accept language, include:
+
+* XWalkView can use setAcceptLanguages method
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, setAcceptLanguages methods
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkViewWithSetLanguage.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkViewWithSetLanguage.java
@@ -1,0 +1,60 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.asyncsample;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+
+
+public class XWalkViewWithSetLanguage extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private XWalkInitializer mXWalkInitializer;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        setContentView(R.layout.xwview_layout);
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can update the accept language.\n\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if loading 'bing' page includes chinese.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mXWalkView.setAcceptLanguages("zh-CN");
+        mXWalkView.load("http://www.bing.com", null);
+    }
+}
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -302,5 +302,14 @@
                 <category android:name="android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".XWalkViewWithSetLanguage"
+            android:label="XWalkViewWithSetLanguage"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -296,3 +296,14 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load, dispatchKeyEvent methods
 
+
+
+### 28. The [XWalkViewWithSetLanguage](XWalkViewWithSetLanguage.java) sample check whether xwalkview can set accept language, include:
+
+* XWalkView can use setAcceptLanguages method
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, setAcceptLanguages methods
+
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithSetLanguage.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithSetLanguage.java
@@ -1,0 +1,40 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.sample;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+
+
+public class XWalkViewWithSetLanguage extends XWalkActivity {
+    private XWalkView mXWalkView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        setContentView(R.layout.xwview_layout);
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can update the accept language.\n\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if loading 'bing' page includes chinese.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mXWalkView.setAcceptLanguages("zh-CN");
+        mXWalkView.load("http://www.bing.com", null);
+    }
+}
+

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -338,6 +338,18 @@
           </steps>
           <test_script_entry test_script_expected_result="0" />
         </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithSetLanguage" purpose="setAcceptLanguages() Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
       </testcase>      
     </set>
     <set name="XWalkView-Async">
@@ -676,7 +688,19 @@
           </steps>
           <test_script_entry test_script_expected_result="0" />
         </description>
-      </testcase>         
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithSetLanguage" purpose="setAcceptLanguages() Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>          
     </set>    
   </suite>
 </test_definition>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -367,6 +367,19 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithSetLanguage" platform="android" priority="P0" purpose="setAcceptLanguages() Test With XWalkActivity" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewUIInflation" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -721,6 +734,19 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithDispatchKeyEvent" platform="android" priority="P0" purpose="dispatchKeyEvent() Test With XWalkInitializer" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithSetLanguage" platform="android" priority="P0" purpose="setAcceptLanguages() Test With XWalkInitializer" status="approved" type="functional_positive">
         <description>
           <pre_condition />
           <post_condition />


### PR DESCRIPTION
-Add usecase to check XWalkView.setAcceptLanguages api
-cover the XWalkViewActivity and XWalkInitializer two ways

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0