### PR TITLE
[wrt] Update test script for packertool and manifest

### DIFF
--- a/wrt/wrt-manifest-android-tests/gen_apks.py
+++ b/wrt/wrt-manifest-android-tests/gen_apks.py
@@ -111,7 +111,7 @@ def ge_apks(suite_dir, arch_arg, res_arch_dir):
         'crosswalk',
         'make_apk.py') + " --package=org.xwalk.test --app-versionCode=123 --arch=" + arch_arg + " --manifest="
     manifest_path = os.path.join(suite_dir, "manifest.json")
-    res_suite_dir = os.path.join(res_arch_dir, suitename_without_flag)
+    res_suite_dir = os.path.join(res_arch_dir, suite_name)
 
     if not os.path.exists(manifest_path):
         LOG.error("%s not exists !!!" % manifest_path)
@@ -141,7 +141,7 @@ def ge_apks(suite_dir, arch_arg, res_arch_dir):
         shutil.rmtree(res_suite_dir)
 
     ores_file.write(
-        suitename_without_flag +
+        suite_name +
         "\t" +
         flag +
         "\t" +

--- a/wrt/wrt-manifest-android-tests/run_app.py
+++ b/wrt/wrt-manifest-android-tests/run_app.py
@@ -27,11 +27,11 @@ def tryRunApp(num, caseDir):
             print (" get env error\n")
             sys.exit(1)
 
-        resultfile = open(ConstPath + "/report/packRes.txt")
         fp = open(ConstPath + "/arch.txt")
         if fp.read().strip("\n\t") != "x86":
             ARCH = "arm"
         fp.close()
+        resultfile = open(apkDir + "/apks/" + ARCH + "/Pkg_result.txt")
         lines = resultfile.readlines()
         for line in lines:
             if line.startswith(num) and 'positive' in line and 'PASS' in line:
@@ -63,7 +63,8 @@ def tryRunApp(num, caseDir):
                             "adb -s " +
                             device +
                             " shell am start -n org.xwalk.test/.TestActivity")
-                        if launchstatus[0] != 0:
+                        if launchstatus[0] != 0 and \
+                        "error" not in launchstatus[1].lower():
                             print "Launch APK ---------------->Error"
                             os.system(
                                 "adb -s " +

--- a/wrt/wrt-packertool-android-tests/run_app.py
+++ b/wrt/wrt-packertool-android-tests/run_app.py
@@ -76,7 +76,8 @@ def tryRunApp(num, caseDir):
                                 "/." +
                                 acivityName +
                                 "Activity")
-                            if launchstatus[0] != 0:
+                            if launchstatus[0] != 0 and \
+                            "error" not in launchstatus[1].lower():
                                 print "Launch APK ---------------->Error"
                                 os.system(
                                     "adb -s " +

--- a/wrt/wrt-packertool-android-tests/tests.py
+++ b/wrt/wrt-packertool-android-tests/tests.py
@@ -311,12 +311,6 @@ class TestCaseUnit(unittest.TestCase):
   def test_negative_cmd190(self):
      self.assertEqual("PASS", run_app.tryRunApp("cmd190-negative", "/opt/wrt-packertool-android-tests/apks/arm/cmd190-negative"))
 
-  def test_negative_cmd191(self):
-     self.assertEqual("PASS", run_app.tryRunApp("cmd191-negative", "/opt/wrt-packertool-android-tests/apks/arm/cmd191-negative"))
-
-  def test_negative_cmd192(self):
-     self.assertEqual("PASS", run_app.tryRunApp("cmd192-negative", "/opt/wrt-packertool-android-tests/apks/arm/cmd192-negative"))
-
   def test_positive_cmd2(self):
      self.assertEqual("PASS", run_app.tryRunApp("cmd2-positive", "/opt/wrt-packertool-android-tests/apks/arm/cmd2-positive"))
 


### PR DESCRIPTION
- Update the naming rule for manifest script
- Update the tests.py for packertool
- The test suites can pack and run normally