### PR TITLE
[misc-linux] Update the way to launch test app

### DIFF
--- a/misc/webappmanu-linux-tests/webapp/12306_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/12306_Feature.html
@@ -41,7 +41,9 @@ Authors:
       <strong>Test steps:</strong>
     </p>
     <ol>
-      <li>Install the "test12306.deb" webapp and launch it. </li>
+      <li>Install the "test12306.deb" webapp and launch it with command like:<br>
+          xwalk $(dirname $(readlink -f $(which test12306)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+      </li>
       <li>Enter the address into the origin and destination input box, as well as the time, then click the "Search" button. </li>
       <li>Click the "Booking Tickets" button in the search result list. </li>
     </ol>

--- a/misc/webappmanu-linux-tests/webapp/12306_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/12306_Link.html
@@ -41,7 +41,9 @@ Authors:
       <strong>Test steps:</strong>
     </p>
     <ol>
-      <li>Install the "test12306.deb" webapp and launch it. </li>
+      <li>Install the "test12306.deb" webapp and launch it with command like:<br>
+          xwalk $(dirname $(readlink -f $(which test12306)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+      </li>
       <li>Click the different links in the page several times. </li>
     </ol>
     <p>

--- a/misc/webappmanu-linux-tests/webapp/12306_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/12306_Name.html
@@ -41,7 +41,9 @@ Authors:
       <strong>Test steps:</strong>
     </p>
     <ol>
-      <li>Install the "test12306.deb" webapp and launch it. </li>
+      <li>Install the "test12306.deb" webapp and launch it with command like:<br>
+          xwalk $(dirname $(readlink -f $(which test12306)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+      </li>
       <li>Search "test12306" app shortcut in the launcher and check the app name. </li>
     </ol>
     <p>

--- a/misc/webappmanu-linux-tests/webapp/12306_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/12306_UI.html
@@ -41,7 +41,9 @@ Authors:
       <strong>Test steps:</strong>
     </p>
     <ol>
-      <li>Install the "test12306.deb" webapp and launch it. </li>
+      <li>Install the "test12306.deb" webapp and launch it with command like:<br>
+          xwalk $(dirname $(readlink -f $(which test12306)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+      </li>
       <li>Validate the page layout and display. </li>
     </ol>
     <p>

--- a/misc/webappmanu-linux-tests/webapp/IM_Baidu_Feature.html
+++ b/misc/webappmanu-linux-tests/webapp/IM_Baidu_Feature.html
@@ -41,7 +41,9 @@ Authors:
       <strong>Test steps:</strong>
     </p>
     <ol>
-      <li>Install the "baiduhi.deb" webapp and launch it. </li>
+      <li>Install the "baiduhi.deb" webapp and launch it with command like:<br>
+          xwalk $(dirname $(readlink -f $(which baiduhi)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+      </li>
       <li>Use the baidu account login in the web system. </li>
       <li>Choose the linkman tab and click the "Add a contact" button. </li>
       <li>Click the "Hi_Wonderful" link which under the "Space Friends" tag and click the "Send" button after enter message in the right inputbox. </li>

--- a/misc/webappmanu-linux-tests/webapp/IM_Baidu_Link.html
+++ b/misc/webappmanu-linux-tests/webapp/IM_Baidu_Link.html
@@ -41,7 +41,9 @@ Authors:
       <strong>Test steps:</strong>
     </p>
     <ol>
-      <li>Install the "baiduhi.deb" webapp and launch it. </li>
+      <li>Install the "baiduhi.deb" webapp and launch it with command like:<br>
+          xwalk $(dirname $(readlink -f $(which baiduhi)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+      </li>
       <li>Click the different links in the page several times. </li>
     </ol>
     <p>

--- a/misc/webappmanu-linux-tests/webapp/IM_Baidu_Name.html
+++ b/misc/webappmanu-linux-tests/webapp/IM_Baidu_Name.html
@@ -41,7 +41,9 @@ Authors:
       <strong>Test steps:</strong>
     </p>
     <ol>
-      <li>Install the "baiduhi.deb" webapp and launch it. </li>
+      <li>Install the "baiduhi.deb" webapp and launch it with command like:<br>
+          xwalk $(dirname $(readlink -f $(which baiduhi)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+      </li>
       <li>Search "baiduhi" app shortcut in the launcher and check the app name.</li>
     </ol>
     <p>

--- a/misc/webappmanu-linux-tests/webapp/IM_Baidu_UI.html
+++ b/misc/webappmanu-linux-tests/webapp/IM_Baidu_UI.html
@@ -41,7 +41,9 @@ Authors:
       <strong>Test steps:</strong>
     </p>
     <ol>
-      <li>Install the "baiduhi.deb" webapp and launch it. </li>
+      <li>Install the "baiduhi.deb" webapp and launch it with command like:<br>
+          xwalk $(dirname $(readlink -f $(which baiduhi)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+      </li>
       <li>Validate the page layout and display. </li>
     </ol>
     <p>


### PR DESCRIPTION
Update the way to launch test app for test12306 and baiduhi

Impacted tests(approved): new 0, update 8, delete 0
Unit test platform: Crosswalk for Linux 15.44.370.0
Unit test result summary: pass 8, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4535