### PR TITLE
[usecase-linux] Update the way to launch test app

### DIFF
--- a/usecase/usecase-wrt-linux-tests/samples/Flash/index.html
+++ b/usecase/usecase-wrt-linux-tests/samples/Flash/index.html
@@ -47,7 +47,7 @@ Authors:
   <h2>Test Steps:</h2>
   <ol>
     <li>Install the webapp 'flashplugin.deb' and launch webapp with command like:<br>
-        xwalk $(dirname $(realpath $(which flashplugin)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
+        xwalk $(dirname $(readlink -f $(which flashplugin)))/www/manifest.json --ppapi-flash-path=/path/to/chrome/PepperFlash/libpepflashplayer.so
     </li>
   </ol>
   <h2>Expected Result:</h2>

--- a/usecase/usecase-wrt-linux-tests/samples/MediaCodec/res/audioplay/index.html
+++ b/usecase/usecase-wrt-linux-tests/samples/MediaCodec/res/audioplay/index.html
@@ -50,7 +50,7 @@ Authors:
       <h2>Test Steps:</h2>
       <ol>
         <li>Install the webapp 'audioplay.deb', then execute command like:<br>
-            xwalk $(dirname $(realpath  $(which audioplay)))/www/manifest.json --proprietary-codec-lib-path=/path/to/chrome/libffmpegsumo.so</li>
+            xwalk $(dirname $(readlink -f $(which audioplay)))/www/manifest.json --proprietary-codec-lib-path=/path/to/chrome/libffmpegsumo.so</li>
         <li>Click Audio MP3 play button</li>
         <li>Click Audio MP4 play button</li>
       </ol>

--- a/usecase/usecase-wrt-linux-tests/samples/MediaCodec/res/videoplay/index.html
+++ b/usecase/usecase-wrt-linux-tests/samples/MediaCodec/res/videoplay/index.html
@@ -50,7 +50,7 @@ Authors:
       <h2>Test Steps:</h2>
       <ol>
         <li>Install the webapp 'videoplay.deb', then execute command like:<br>
-            xwalk $(dirname $(realpath  $(which videoplay)))/www/manifest.json --proprietary-codec-lib-path=/path/to/chrome/libffmpegsumo.so</li>
+            xwalk $(dirname $(readlink -f $(which videoplay)))/www/manifest.json --proprietary-codec-lib-path=/path/to/chrome/libffmpegsumo.so</li>
         <li>Click Video MP4 play button</li>
       </ol>
       <h2>Expected Result:</h2>


### PR DESCRIPTION
Update the way to launch test app for MediaCodec and Flash refer to https://crosswalk-project.org/jira/
browse/XWALK-4537

Impacted tests(approved): new 0, update 3, delete 0
Unit test platform: Crosswalk for Linux 15.44.370.0
Unit test result summary: pass 3, fail 0, block 0