### PR TITLE
[TC release]Add maven/gradle build way suffix for embeddingapi test s…

### DIFF
--- a/tools/build/pack.py
+++ b/tools/build/pack.py
@@ -1426,6 +1426,18 @@ def main():
         LOG.info("pkg_file: %s" % pkg_file)
         if not zipDir(os.path.join(BUILD_ROOT, "pkg"), pkg_file):
             exitHandler(1)
+    elif BUILD_PARAMETERS.pkgtype.startswith("embeddingapi") and BUILD_PARAMETERS.packtype:      
+        pkg_file = os.path.join(
+            BUILD_PARAMETERS.destdir,
+            "%s-%s-%s.%s-%s.zip" %
+            (PKG_NAME,
+             pkg_main_version,
+             pkg_release_version,
+             BUILD_PARAMETERS.pkgtype,
+             BUILD_PARAMETERS.packtype))
+
+        if not zipDir(os.path.join(BUILD_ROOT, "pkg"), pkg_file):
+            exitHandler(1)
     else:
         pkg_file = os.path.join(
             BUILD_PARAMETERS.destdir,


### PR DESCRIPTION
…uites

We need all maven/gradle/ant build way for all the embeddingapi test suites.
However, each way has the same zip file name after packing. That will cause
the latter build overwrite the former and only produce one zip file. We want
3 zip files in all for each embeddingapi test suite.
To fix this, we add a build way suffix for the zip file name.

https://crosswalk-project.org/jira/browse/XWALK-4528