### PR TITLE
[webapi] Integrate w3c tests for NavigatorLanguage

### DIFF
--- a/webapi/tct-extra-html5-tests/tests.full.xml
+++ b/webapi/tct-extra-html5-tests/tests.full.xml
@@ -7624,6 +7624,35 @@
         </specs>
       </testcase>
     </set>
+    <set name="Systemstate" type="js">
+      <testcase component="W3C_HTML5 APIs/W3C_EXTRAHTML5/Systemstateandcapabilities" execution_type="auto" id="navigatorlanguage" priority="P2" purpose="the most preferred language is the one returned by navigator.language" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/tct-extra-html5-tests/w3c/system-state-and-capabilities/the-navigator-object/navigatorlanguage.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="W3C HTML5 API Specifications" element_name="language" element_type="attribute" interface="NavigatorLanguage" section="ExtraHTML5" specification="Language preferences"/>
+            <spec_url>https://html.spec.whatwg.org/multipage/webappapis.html#navigatorlanguage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/W3C_EXTRAHTML5/Systemstateandcapabilities" execution_type="manual" id="get-navigatorlanguage" priority="P2" purpose="navigator.language returns the user's preferred language" status="approved" type="compliance">
+        <description>
+          <pre_condition>
+            Set Android phone language to Espanol (Estados Unidos).
+          </pre_condition>
+          <test_script_entry>/opt/tct-extra-html5-tests/w3c/system-state-and-capabilities/the-navigator-object/get-navigatorlanguage-manual.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="W3C HTML5 API Specifications" element_name="language" element_type="attribute" interface="NavigatorLanguage" section="ExtraHTML5" specification="Language preferences"/>
+            <spec_url>https://html.spec.whatwg.org/multipage/webappapis.html#navigatorlanguage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+    </set>
     <set name="browsers-bdd" type="js" ui-auto="bdd">
       <testcase component="W3C_HTML5 APIs/W3C_EXTRAHTML5/Browsers" execution_type="manual" id="window_alert_base" priority="P3" purpose="Check if pop the alert dialog" status="approved" type="compliance">
         <description>

--- a/webapi/tct-extra-html5-tests/tests.xml
+++ b/webapi/tct-extra-html5-tests/tests.xml
@@ -3202,6 +3202,35 @@
         </description>
       </testcase>
     </set>
+    <set name="Systemstate" type="js">
+      <testcase component="W3C_HTML5 APIs/W3C_EXTRAHTML5/Systemstateandcapabilities" execution_type="auto" id="navigatorlanguage" priority="P2" purpose="the most preferred language is the one returned by navigator.language" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/tct-extra-html5-tests/w3c/system-state-and-capabilities/the-navigator-object/navigatorlanguage.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="W3C HTML5 API Specifications" element_name="language" element_type="attribute" interface="NavigatorLanguage" section="ExtraHTML5" specification="Language preferences"/>
+            <spec_url>https://html.spec.whatwg.org/multipage/webappapis.html#navigatorlanguage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/W3C_EXTRAHTML5/Systemstateandcapabilities" execution_type="manual" id="get-navigatorlanguage" priority="P2" purpose="navigator.language returns the user's preferred language" status="approved" type="compliance">
+        <description>
+          <pre_condition>
+            Set Android phone language to Espanol (Estados Unidos).
+          </pre_condition>
+          <test_script_entry>/opt/tct-extra-html5-tests/w3c/system-state-and-capabilities/the-navigator-object/get-navigatorlanguage-manual.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="W3C HTML5 API Specifications" element_name="language" element_type="attribute" interface="NavigatorLanguage" section="ExtraHTML5" specification="Language preferences"/>
+            <spec_url>https://html.spec.whatwg.org/multipage/webappapis.html#navigatorlanguage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+    </set>
     <set name="browsers-bdd" type="js" ui-auto="bdd">
       <testcase component="W3C_HTML5 APIs/W3C_EXTRAHTML5/Browsers" execution_type="manual" id="window_alert_base" purpose="Check if pop the alert dialog">
         <description>

--- a/webapi/tct-extra-html5-tests/w3c/system-state-and-capabilities/the-navigator-object/get-navigatorlanguage-manual.html
+++ b/webapi/tct-extra-html5-tests/w3c/system-state-and-capabilities/the-navigator-object/get-navigatorlanguage-manual.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>NavigatorLanguage: navigator.language returns the user's preferred language</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigatorlanguage">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<h2>Precondition</h2>
+<p>Set Android phone language to Espanol (Estados Unidos).</p>
+<div id="log"></div>
+<script>
+  test(function() {
+    assert_equals(navigator.language, "es-US");
+  });
+</script>
+

--- a/webapi/tct-extra-html5-tests/w3c/system-state-and-capabilities/the-navigator-object/navigatorlanguage.html
+++ b/webapi/tct-extra-html5-tests/w3c/system-state-and-capabilities/the-navigator-object/navigatorlanguage.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>NavigatorLanguage: the most preferred language is the one returned by navigator.language</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigatorlanguage">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+  test(function() {
+    assert_true("language" in navigator);
+    assert_true("languages" in navigator);
+
+    assert_equals(navigator.languages[0], navigator.language,
+    "navigator.languages is the most preferred language first");
+
+  });
+</script>
+


### PR DESCRIPTION
Change get-navigatorlanguage-manual.html precondition refer to 
https://crosswalk-project.org/jira/browse/XWALK-2132

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: Crosswalk Project for Android 15.44.371.0
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-2242