### PR TITLE
[tools] Remove Tizen related test suites from WTS

### DIFF
--- a/tools/build/test_suites.list
+++ b/tools/build/test_suites.list
@@ -62,7 +62,6 @@ webapi-hrtime-w3c-tests
 webapi-iap-xwalk-tests
 webapi-input-html5-tests
 webapi-messaging-w3c-tests
-webapi-nacl-xwalk-tests
 webapi-nativefilesystem-xwalk-tests
 webapi-performancetimeline-w3c-tests
 webapi-presentation-xwalk-tests

--- a/tools/build/test_suites.list
+++ b/tools/build/test_suites.list
@@ -55,14 +55,12 @@ tct-websocket-w3c-tests
 tct-webstorage-w3c-tests
 tct-workers-w3c-tests
 tct-xmlhttprequest-w3c-tests
-webapi-audiosystem-tizen-tests
 webapi-contactsmanager-w3c-tests
 webapi-devicecapabilities-w3c-tests
 webapi-gamepad-w3c-tests
 webapi-hrtime-w3c-tests
 webapi-iap-xwalk-tests
 webapi-input-html5-tests
-webapi-mediarenderer-tizen-tests
 webapi-messaging-w3c-tests
 webapi-nacl-xwalk-tests
 webapi-nativefilesystem-xwalk-tests
@@ -73,7 +71,6 @@ webapi-promises-nonw3c-tests
 webapi-rawsockets-w3c-tests
 webapi-resourcetiming-w3c-tests
 webapi-simd-nonw3c-tests
-webapi-sso-tizen-tests
 webapi-usertiming-w3c-tests
 webapi-webcl-nonw3c-tests
 webapi-webrtc-w3c-tests

--- a/tools/build/test_suites.list
+++ b/tools/build/test_suites.list
@@ -64,7 +64,6 @@ webapi-input-html5-tests
 webapi-messaging-w3c-tests
 webapi-nacl-xwalk-tests
 webapi-nativefilesystem-xwalk-tests
-webapi-nfc-w3c-tests
 webapi-performancetimeline-w3c-tests
 webapi-presentation-xwalk-tests
 webapi-promises-nonw3c-tests


### PR DESCRIPTION
Web Testing Service (WTS) shall run all the test cases on Crosswalk
platforms and browsers. So it should not include any test suites
specific for Tizen platform.