### PR TITLE
[webapi] Update test path of w3c-webstorage-app

### DIFF
--- a/webapi/tct-webstorage-w3c-tests/suite.json
+++ b/webapi/tct-webstorage-w3c-tests/suite.json
@@ -51,9 +51,8 @@
             "subapp-list": {
                 "w3c-webstorage-app": {
                     "apk-common-opts": "--enable-remote-debugging",
-                    "install-path": "app",
                     "copylist": {
-                        "../webstorage/bdd": "webstorage"
+                        "../webstorage/w3c/bdd": "webstorage/w3c"
                     }
                 }
             }


### PR DESCRIPTION
Failure analysis:
XWALK-4397 [REG][webdriver] Click element failed in webdriver after crosswalk rebased M44

Impacted tests(approved): new 0, update 2, delete 0
Unit test platform: Crosswalk Project for Android 15.44.366.0
Unit test result summary: pass 0, fail 2, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4579