### PR TITLE
[Embeddingapi] Add checking xwalkview ready module

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/MainActivity.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/MainActivity.java
@@ -65,4 +65,9 @@ public class MainActivity extends XWalkActivity  {
         KeyguardLock keyguardLock = keyguardManager.newKeyguardLock("");
         keyguardLock.disableKeyguard();
     }
+
+    @Override
+    public boolean isXWalkReady() {
+	    return super.isXWalkReady();
+    }
 }


### PR DESCRIPTION
-Add isXWalkReady function on extending XWalkActivity
-On case setUp func, wait isXWalkReady be true

Impacted tests(approved): new 0, update 60, delete 0
Unit test platform: [Android]
Unit test result summary: pass 60, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4647