### PR TITLE
[Embeddingapi] Change pause & resume time autocase asserting ways

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v1/XWalkViewTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v1/XWalkViewTest.java
@@ -532,12 +532,23 @@ public class XWalkViewTest extends XWalkViewTestBase {
             String url = "file:///android_asset/pause_timers.html";
             addJavascriptInterface();
             loadUrlSync(url);
-	    resumeTimers();
+            resumeTimers();
             SystemClock.sleep(2000);
             String date = new Date().toString();
             pauseTimers();
             SystemClock.sleep(2000);
-            assertEquals(date, getTitleOnUiThread());
+            String title = getTitleOnUiThread();
+            long seconds = Integer.valueOf(date.substring(11, 12))*3600
+            		+ Integer.valueOf(date.substring(14, 15))*60 
+            		+ Integer.valueOf(date.substring(17, 18));
+            long seconds2 = Integer.valueOf(title.substring(11, 12))*3600
+            		+ Integer.valueOf(title.substring(14, 15))*60 
+            		+ Integer.valueOf(title.substring(17, 18));
+            if (seconds==seconds2 || Math.abs(seconds-seconds2)==1) {
+                assertTrue(true);
+            } else {
+                assertTrue(false);
+            }
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);
@@ -556,7 +567,18 @@ public class XWalkViewTest extends XWalkViewTestBase {
             resumeTimers();
             SystemClock.sleep(1000);
             String date = new Date().toString();
-            assertEquals(date, getTitleOnUiThread());
+            String title = getTitleOnUiThread();
+            long seconds = Integer.valueOf(date.substring(11, 12))*3600
+            		+ Integer.valueOf(date.substring(14, 15))*60 
+            		+ Integer.valueOf(date.substring(17, 18));
+            long seconds2 = Integer.valueOf(title.substring(11, 12))*3600
+            		+ Integer.valueOf(title.substring(14, 15))*60 
+            		+ Integer.valueOf(title.substring(17, 18));
+            if (seconds==seconds2 || Math.abs(seconds-seconds2)==1) {
+                assertTrue(true);
+            } else {
+                assertTrue(false);
+            }
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v1/XWalkViewTest.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v1/XWalkViewTest.java
@@ -537,7 +537,18 @@ public class XWalkViewTest extends XWalkViewTestBase {
             String date = new Date().toString();
             pauseTimers();
             SystemClock.sleep(2000);
-            assertEquals(date, getTitleOnUiThread());
+            String title = getTitleOnUiThread();
+            long seconds = Integer.valueOf(date.substring(11, 12))*3600
+            		+ Integer.valueOf(date.substring(14, 15))*60 
+            		+ Integer.valueOf(date.substring(17, 18));
+            long seconds2 = Integer.valueOf(title.substring(11, 12))*3600
+            		+ Integer.valueOf(title.substring(14, 15))*60 
+            		+ Integer.valueOf(title.substring(17, 18));
+            if (seconds==seconds2 || Math.abs(seconds-seconds2)==1) {
+                assertTrue(true);
+            } else {
+                assertTrue(false);
+            }
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);
@@ -556,7 +567,18 @@ public class XWalkViewTest extends XWalkViewTestBase {
             resumeTimers();
             SystemClock.sleep(1000);
             String date = new Date().toString();
-            assertEquals(date, getTitleOnUiThread());
+            String title = getTitleOnUiThread();
+            long seconds = Integer.valueOf(date.substring(11, 12))*3600
+            		+ Integer.valueOf(date.substring(14, 15))*60 
+            		+ Integer.valueOf(date.substring(17, 18));
+            long seconds2 = Integer.valueOf(title.substring(11, 12))*3600
+            		+ Integer.valueOf(title.substring(14, 15))*60 
+            		+ Integer.valueOf(title.substring(17, 18));
+            if (seconds==seconds2 || Math.abs(seconds-seconds2)==1) {
+                assertTrue(true);
+            } else {
+                assertTrue(false);
+            }
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);


### PR DESCRIPTION
-Modify testResumeTimers_function & testPauseTimers_function cases
-cover the XWalkViewActivity and XWalkInitializer two ways

Impacted tests(approved): new 0, update 2, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4444