### PR TITLE
[webapi] Update xml configure files

### DIFF
--- a/webapi/tct-forms-html5-tests/tests.full.xml
+++ b/webapi/tct-forms-html5-tests/tests.full.xml
@@ -1565,7 +1565,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/HTML5 Forms (Partial)" execution_type="auto" id="fieldset_checkValidity_input_true" priority="P2" purpose="Check if input.checkValidity() method return true if the element does satisfy its constraints" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-forms-html5-tests/forms/w3c/submission/constraints/form-validation-checkValidity.html?total_num=121&amp;locator_key=id&amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-forms-html5-tests/forms/w3c/submission/constraints/form-validation-checkValidity.html?total_num=121&amp;locator_key=id&amp;value=113</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1697,7 +1697,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/HTML5 Forms (Partial)" execution_type="auto" id="fieldset_input_url_typeMismatch_value_true" priority="P3" purpose="Check if fieldset input.validity.typeMismatch attribute return false when a url control has a value that is url string for the form control value attribute" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-forms-html5-tests/forms/w3c/submission/constraints/form-validation-checkValidity.html?total_num=121&amp;locator_key=id&amp;value=49</test_script_entry>
+          <test_script_entry>/opt/tct-forms-html5-tests/forms/w3c/submission/constraints/form-validation-checkValidity.html?total_num=121&amp;locator_key=id&amp;value=39</test_script_entry>
         </description>
         <specs>
           <spec>

--- a/webapi/tct-forms-html5-tests/tests.xml
+++ b/webapi/tct-forms-html5-tests/tests.xml
@@ -635,7 +635,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/HTML5 Forms (Partial)" execution_type="auto" id="fieldset_checkValidity_input_true" purpose="Check if input.checkValidity() method return true if the element does satisfy its constraints">
         <description>
-          <test_script_entry>/opt/tct-forms-html5-tests/forms/w3c/submission/constraints/form-validation-checkValidity.html?total_num=121&amp;locator_key=id&amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-forms-html5-tests/forms/w3c/submission/constraints/form-validation-checkValidity.html?total_num=121&amp;locator_key=id&amp;value=113</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/HTML5 Forms (Partial)" execution_type="auto" id="fieldset_checkValidity_textarea_false" purpose="Check if textarea.checkValidity() method return false if the element does not satisfy its constraints">
@@ -690,7 +690,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/HTML5 Forms (Partial)" execution_type="auto" id="fieldset_input_url_typeMismatch_value_true" purpose="Check if fieldset input.validity.typeMismatch attribute return false when a url control has a value that is url string for the form control value attribute">
         <description>
-          <test_script_entry>/opt/tct-forms-html5-tests/forms/w3c/submission/constraints/form-validation-checkValidity.html?total_num=121&amp;locator_key=id&amp;value=49</test_script_entry>
+          <test_script_entry>/opt/tct-forms-html5-tests/forms/w3c/submission/constraints/form-validation-checkValidity.html?total_num=121&amp;locator_key=id&amp;value=39</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/HTML5 Forms (Partial)" execution_type="auto" id="fieldset_input_valid_value_false" purpose="Check if fieldset input.validity.valid attribute return false when the element's value has validity problems">

--- a/webapi/tct-indexeddb-w3c-tests/tests.full.xml
+++ b/webapi/tct-indexeddb-w3c-tests/tests.full.xml
@@ -1703,18 +1703,6 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBCursor_continue_no_argument" priority="P2" purpose="Check if IDBCursor.continue() has no argument argument that expecting this method runs the steps for asynchronously executing a request" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbcursor_continue_index.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="continue" element_type="method" interface="IDBCursor" section="Storage" specification="Indexed Database API (Partial)" />
-            <spec_url>http://www.w3.org/TR/2011/WD-IndexedDB-20111206/#widl-IDBCursor-continue-void-any-key</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
       <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="idbcursor_continue_objectstore" priority="P2" purpose="Check if iterate to the next record on index" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbcursor_continue_objectstore.htm</test_script_entry>
@@ -2015,30 +2003,6 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_createObjectStore_exception_ConstraintError" priority="P3" purpose="Check if IDBDatabase.createObjectStore() throws an exception ConstraintError when an object store with the same name, compared in a case-sensitive manner, already exists in the connected database" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbdatabase_createObjectStore4.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="" element_type="TRUE" interface="IDBDatabase" section="Storage" specification="Indexed Database API (Partial)" />
-            <spec_url>http://www.w3.org/TR/2011/WD-IndexedDB-20111206/#idl-def-IDBDatabase</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_createObjectStore_exception_InvalidStateError" priority="P2" purpose="Check if IDBDatabase.createObjectStore() was not called from a VERSION_CHANGE transaction callback that expecting an exception InvalidStateError to be thrown" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbdatabase_createObjectStore3.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="createObjectStore" element_type="method" interface="IDBDatabase" section="Storage" specification="Indexed Database API (Partial)" />
-            <spec_url>http://www.w3.org/TR/2011/WD-IndexedDB-20111206/#widl-IDBDatabase-createObjectStore-IDBObjectStore-DOMString-name-IDBObjectStoreParameters-optionalParameters</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
       <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_createObjectStore_keyPath_Array_invalid" priority="P3" purpose="Check if IDBDatabase.createObjectStore() throws an exception SyntaxError when keyPath is an Array which any items is an invalid string" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/IDBDatabase_createObjectStore_keyPath_Array_invalid.html</test_script_entry>
@@ -2095,18 +2059,6 @@
           <spec>
             <spec_assertion category="Tizen W3C API Specifications" element_name="deleteObjectStore" element_type="method" interface="IDBDatabase" section="Storage" specification="Indexed Database API (Partial)" />
             <spec_url>http://www.w3.org/TR/2011/WD-IndexedDB-20111206/#widl-IDBDatabase-deleteObjectStore-void-DOMString-name</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_deleteObjectStore_called_outside_VERSION_CHANGE" priority="P3" purpose="Check if IDBDatabase.deleteObjectStore() throws an exception InvalidStateError when deleteObjectStore() was not called from a VERSION_CHANGE transaction callback" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbdatabase_deleteObjectStore2.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="" element_type="TRUE" interface="IDBDatabase" section="Storage" specification="Indexed Database API (Partial)" />
-            <spec_url>http://www.w3.org/TR/2011/WD-IndexedDB-20111206/#idl-def-IDBDatabase</spec_url>
             <spec_statement />
           </spec>
         </specs>
@@ -2222,30 +2174,6 @@
       <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_transaction_exception_InvalidAccessError" priority="P2" purpose="Check if IDBDatabase.transaction was called with an empty list of store names that expecting an exception InvalidAccessError to be thrown" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/IDBDatabase_transaction_exception_InvalidAccessError.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transaction" element_type="method" interface="IDBDatabase" section="Storage" specification="Indexed Database API (Partial)" />
-            <spec_url>http://www.w3.org/TR/2011/WD-IndexedDB-20111206/#widl-IDBDatabase-transaction-IDBTransaction-any-storeNames-unsigned-short-mode</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_transaction_exception_InvalidStateError" priority="P2" purpose="Check if the IDBDatabase.close() method has been called on this IDBDatabase instance that expecting an exception InvalidStateError to be thrown" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbdatabase_transaction3.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transaction" element_type="method" interface="IDBDatabase" section="Storage" specification="Indexed Database API (Partial)" />
-            <spec_url>http://www.w3.org/TR/2011/WD-IndexedDB-20111206/#widl-IDBDatabase-transaction-IDBTransaction-any-storeNames-unsigned-short-mode</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_transaction_exception_NotFoundError" priority="P2" purpose="Check if one of the names provided in the storeNames argument doesn't exist in this database that expecting an exception NotFoundError to be thrown" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbdatabase_transaction.htm</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -3866,18 +3794,6 @@
       <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBObjectStore_deleteIndex_exception_InvalidStateError" priority="P2" purpose="Check if IDBObjectStore.deleteIndex() throws an exception InvalidStateError when this method was not called from a VERSION_CHANGE transaction callback" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/IDBObjectStore_deleteIndex_exception_InvalidStateError.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="deleteIndex" element_type="method" interface="IDBObjectStore" section="Storage" specification="Indexed Database API (Partial)" />
-            <spec_url>http://www.w3.org/TR/2011/WD-IndexedDB-20111206/#widl-IDBObjectStore-deleteIndex-void-DOMString-indexName</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBObjectStore_deleteIndex_exception_NotFoundError" priority="P2" purpose="Check if IDBObjectStore.deleteIndex() throws an exception NotFoundError when there is no index with the given name" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbobjectstore_deleteIndex.htm</test_script_entry>
         </description>
         <specs>
           <spec>

--- a/webapi/tct-indexeddb-w3c-tests/tests.xml
+++ b/webapi/tct-indexeddb-w3c-tests/tests.xml
@@ -738,11 +738,6 @@
           <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbcursor_continue_index4.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBCursor_continue_no_argument" purpose="Check if IDBCursor.continue() has no argument argument that expecting this method runs the steps for asynchronously executing a request">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbcursor_continue_index.htm</test_script_entry>
-        </description>
-      </testcase>
       <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="idbcursor_continue_objectstore" purpose="Check if iterate to the next record on index">
         <description>
           <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbcursor_continue_objectstore.htm</test_script_entry>
@@ -868,16 +863,6 @@
           <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/IDBDatabase_createObjectStore_base.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_createObjectStore_exception_ConstraintError" purpose="Check if IDBDatabase.createObjectStore() throws an exception ConstraintError when an object store with the same name, compared in a case-sensitive manner, already exists in the connected database">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbdatabase_createObjectStore4.htm</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_createObjectStore_exception_InvalidStateError" purpose="Check if IDBDatabase.createObjectStore() was not called from a VERSION_CHANGE transaction callback that expecting an exception InvalidStateError to be thrown">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbdatabase_createObjectStore3.htm</test_script_entry>
-        </description>
-      </testcase>
       <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_createObjectStore_keyPath_Array_invalid" purpose="Check if IDBDatabase.createObjectStore() throws an exception SyntaxError when keyPath is an Array which any items is an invalid string">
         <description>
           <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/IDBDatabase_createObjectStore_keyPath_Array_invalid.html</test_script_entry>
@@ -901,11 +886,6 @@
       <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_deleteObjectStore_base" purpose="Check if deleteObjectStore() has a valid argument that expecting the object store to be destroy">
         <description>
           <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/IDBDatabase_deleteObjectStore_base.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_deleteObjectStore_called_outside_VERSION_CHANGE" purpose="Check if IDBDatabase.deleteObjectStore() throws an exception InvalidStateError when deleteObjectStore() was not called from a VERSION_CHANGE transaction callback">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbdatabase_deleteObjectStore2.htm</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_name_normal_value" purpose="Check if the value of IDBDatabase.name attribute is normal">
@@ -956,16 +936,6 @@
       <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_transaction_exception_InvalidAccessError" purpose="Check if IDBDatabase.transaction was called with an empty list of store names that expecting an exception InvalidAccessError to be thrown">
         <description>
           <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/IDBDatabase_transaction_exception_InvalidAccessError.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_transaction_exception_InvalidStateError" purpose="Check if the IDBDatabase.close() method has been called on this IDBDatabase instance that expecting an exception InvalidStateError to be thrown">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbdatabase_transaction3.htm</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_transaction_exception_NotFoundError" purpose="Check if one of the names provided in the storeNames argument doesn't exist in this database that expecting an exception NotFoundError to be thrown">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbdatabase_transaction.htm</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBDatabase_transaction_mandatory" purpose="Check if transaction() has a valid argument that expecting an IDBTransaction object to be created">
@@ -1641,11 +1611,6 @@
       <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBObjectStore_deleteIndex_exception_InvalidStateError" purpose="Check if IDBObjectStore.deleteIndex() throws an exception InvalidStateError when this method was not called from a VERSION_CHANGE transaction callback">
         <description>
           <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/IDBObjectStore_deleteIndex_exception_InvalidStateError.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBObjectStore_deleteIndex_exception_NotFoundError" purpose="Check if IDBObjectStore.deleteIndex() throws an exception NotFoundError when there is no index with the given name">
-        <description>
-          <test_script_entry>/opt/tct-indexeddb-w3c-tests/indexeddb/w3c/idbobjectstore_deleteIndex.htm</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Storage/Indexed Database API (Partial)" execution_type="auto" id="IDBObjectStore_get_exception_DataError" purpose="Check if IDBObjectStore.get() throws an exception DataError when the key parameter is not a valid key">

--- a/webapi/webapi-webcl-nonw3c-tests/tests.full.xml
+++ b/webapi/webapi-webcl-nonw3c-tests/tests.full.xml
@@ -1358,17 +1358,6 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos (Partial)" execution_type="auto" id="webCLCommandQueue_enqueueReadBuffer_Kernel" priority="P1" purpose="Check if webCLCommandQueue.enqueueReadBuffer using kernel works" status="approved" type="compliance" subcase="12">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueReadBufferRect.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen Supplementary API Specifications" element_name="enqueueReadBuffer" element_type="method" interface="webCLCommandQueue" section="N/A" specification="WebCL - Khronos (Partial)" />
-            <spec_url>https://www.khronos.org/registry/webcl/specs/latest/1.0/</spec_url>
-          </spec>
-        </specs>
-      </testcase>
       <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos (Partial)" execution_type="auto" id="webCLCommandQueue_enqueueReadImage_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueReadImage functionality works" status="approved" type="compliance" subcase="4">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueReadImage.html</test_script_entry>
@@ -1392,17 +1381,6 @@
         </specs>
       </testcase>
       <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos (Partial)" execution_type="auto" id="webCLCommandQueue_enqueueWriteBufferRect_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueWriteBufferRect functionality works" status="approved" type="compliance" subcase="12">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueWriteBufferRect.html</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen Supplementary API Specifications" element_name="enqueueWriteBufferRect" element_type="method" interface="webCLCommandQueue" section="N/A" specification="WebCL - Khronos (Partial)" />
-            <spec_url>https://www.khronos.org/registry/webcl/specs/latest/1.0/</spec_url>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos (Partial)" execution_type="auto" id="webCLCommandQueue_enqueueWriteBufferRect_Kernel" priority="P1" purpose="Check if webCLCommandQueue.enqueueWriteBufferRect using kernel works" status="approved" type="compliance" subcase="12">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueWriteBufferRect.html</test_script_entry>
         </description>
@@ -1481,7 +1459,7 @@
       </testcase>
       <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos (Partial)" execution_type="auto" id="WebCLObject_releaseAll_function" priority="P1" purpose="Check if WebCLObject.releaseAll function works" status="approved" type="compliance" subcase="9">
         <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/release/release.html</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/release/releaseAll.html</test_script_entry>
         </description>
         <specs>
           <spec>

--- a/webapi/webapi-webcl-nonw3c-tests/tests.xml
+++ b/webapi/webapi-webcl-nonw3c-tests/tests.xml
@@ -632,11 +632,6 @@
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueReadBufferRect.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos (Partial)" execution_type="auto" id="webCLCommandQueue_enqueueReadBuffer_Kernel" purpose="Check if webCLCommandQueue.enqueueReadBuffer using kernel works" subcase="12">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueReadBufferRect.html</test_script_entry>
-        </description>
-      </testcase>
       <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos (Partial)" execution_type="auto" id="webCLCommandQueue_enqueueReadImage_function" purpose="Check if webCLCommandQueue.enqueueReadImage functionality works" subcase="4">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueReadImage.html</test_script_entry>
@@ -648,11 +643,6 @@
         </description>
       </testcase>
       <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos (Partial)" execution_type="auto" id="webCLCommandQueue_enqueueWriteBufferRect_function" purpose="Check if webCLCommandQueue.enqueueWriteBufferRect functionality works" subcase="12">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueWriteBufferRect.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos (Partial)" execution_type="auto" id="webCLCommandQueue_enqueueWriteBufferRect_Kernel" purpose="Check if webCLCommandQueue.enqueueWriteBufferRect using kernel works" subcase="12">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueWriteBufferRect.html</test_script_entry>
         </description>
@@ -689,7 +679,7 @@
       </testcase>
       <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos (Partial)" execution_type="auto" id="WebCLObject_releaseAll_function" purpose="Check if WebCLObject.releaseAll function works" subcase="9">
         <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/release/release.html</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/release/releaseAll.html</test_script_entry>
         </description>
       </testcase>
     </set>

--- a/webapi/webapi-webrtc-w3c-tests/tests.full.xml
+++ b/webapi/webapi-webrtc-w3c-tests/tests.full.xml
@@ -9,9 +9,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="localDescription" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="localDescription" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -21,9 +21,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="remoteDescription" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="remoteDescription" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -33,9 +33,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="signalingState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="signalingState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -45,9 +45,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="iceGatheringState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="iceGatheringState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -57,9 +57,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="iceConnectionState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="iceConnectionState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -69,9 +69,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onnegotiationneeded" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="onnegotiationneeded" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -81,9 +81,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onicecandidate" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="onicecandidate" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -93,9 +93,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onsignalingstatechange" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="onsignalingstatechange" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -105,9 +105,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onaddstream" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="onaddstream" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -117,9 +117,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onremovestream" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="onremovestream" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -129,9 +129,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="oniceconnectionstatechange" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="oniceconnectionstatechange" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -141,9 +141,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="ondatachannel" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="ondatachannel" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -153,9 +153,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createOffer" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createOffer" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -165,9 +165,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createAnswer" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createAnswer" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -177,9 +177,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="setLocalDescription" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="setLocalDescription" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -189,9 +189,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="setRemoteDescription" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="setRemoteDescription" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -201,9 +201,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="updateIce" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="updateIce" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -213,9 +213,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="addIceCandidate" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="addIceCandidate" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -225,9 +225,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="getLocalStreams" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="getLocalStreams" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -237,9 +237,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="getRemoteStreams" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="getRemoteStreams" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -249,9 +249,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="getStreamById" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="getStreamById" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -261,9 +261,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="addStream" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="addStream" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -273,9 +273,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="removeStream" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="removeStream" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -285,9 +285,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="close" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="close" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -297,9 +297,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -309,9 +309,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="getStats" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="getStats" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -321,9 +321,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="peerIdentity" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="peerIdentity" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -333,9 +333,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onidentityresult" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="onidentityresult" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -345,9 +345,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="setIdentityProvider" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="setIdentityProvider" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -357,9 +357,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="getIdentityAssertion" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="getIdentityAssertion" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -369,9 +369,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="sdpLineNumber" element_type="property" interface="RTCSdpError" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="sdpLineNumber" element_type="property" interface="RTCSdpError" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcsdperror</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -381,9 +381,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="type" element_type="property" interface="RTCSessionDescription" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="type" element_type="property" interface="RTCSessionDescription" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcsessiondescription-class</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -393,9 +393,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="sdp" element_type="property" interface="RTCSessionDescription" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="sdp" element_type="property" interface="RTCSessionDescription" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcsessiondescription-class</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -405,9 +405,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="property" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="property" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -417,9 +417,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="sdpMid" element_type="property" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="sdpMid" element_type="property" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -429,9 +429,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="sdpMLineIndex" element_type="property" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="sdpMLineIndex" element_type="property" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -441,9 +441,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="event" interface="RTCPeerConnectionIceEvent" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="event" interface="RTCPeerConnectionIceEvent" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnectioniceevent</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -453,9 +453,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="label" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="label" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -465,9 +465,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="ordered" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="ordered" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -477,9 +477,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="maxRetransmitTime" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="maxRetransmitTime" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -489,9 +489,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="maxRetransmits" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="maxRetransmits" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -501,9 +501,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="protocol" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="protocol" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -513,9 +513,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="negotiated" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="negotiated" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -525,9 +525,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="id" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="id" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -537,9 +537,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="readyState" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="readyState" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -549,9 +549,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="bufferedAmount" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="bufferedAmount" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -561,9 +561,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="binaryType" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="binaryType" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -573,9 +573,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onopen" element_type="event" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="onopen" element_type="event" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -585,9 +585,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onerror" element_type="event" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="onerror" element_type="event" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -597,9 +597,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onclose" element_type="event" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="onclose" element_type="event" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -609,9 +609,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onmessage" element_type="event" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="onmessage" element_type="event" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -621,9 +621,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="close" element_type="method" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="close" element_type="method" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -633,9 +633,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="send" element_type="method" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="send" element_type="method" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -645,9 +645,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="channel" element_type="event" interface="RTCDataChannelEvent" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="channel" element_type="event" interface="RTCDataChannelEvent" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannelevent</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -657,9 +657,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createDTMFSender" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createDTMFSender" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface-extensions</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -669,9 +669,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="canInsertDTMF" element_type="property" interface="RTCDTMFSender" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="canInsertDTMF" element_type="property" interface="RTCDTMFSender" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -681,9 +681,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="track" element_type="property" interface="RTCDTMFSender" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="track" element_type="property" interface="RTCDTMFSender" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -693,9 +693,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="toneBuffer" element_type="property" interface="RTCDTMFSender" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="toneBuffer" element_type="property" interface="RTCDTMFSender" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -705,9 +705,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="duration" element_type="property" interface="RTCDTMFSender" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="duration" element_type="property" interface="RTCDTMFSender" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -717,9 +717,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="interToneGap" element_type="property" interface="RTCDTMFSender" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="interToneGap" element_type="property" interface="RTCDTMFSender" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -729,9 +729,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="ontonechange" element_type="event" interface="RTCDTMFSender" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="ontonechange" element_type="event" interface="RTCDTMFSender" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -741,9 +741,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="insertDTMF" element_type="method" interface="RTCDTMFSender" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="insertDTMF" element_type="method" interface="RTCDTMFSender" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -753,9 +753,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="tone" element_type="property" interface="RTCDTMFToneChangeEvent" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="tone" element_type="property" interface="RTCDTMFToneChangeEvent" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmftonechangeevent</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -765,9 +765,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="RTCStats" element_type="property" interface="RTCStatsReport" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="RTCStats" element_type="property" interface="RTCStatsReport" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcstatsreport-object</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -777,9 +777,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="assertion" element_type="property" interface="RTCIdentityEvent" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="assertion" element_type="property" interface="RTCIdentityEvent" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcidentityevent-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -789,9 +789,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="stream" element_type="property" interface="MediaStreamEvent" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="stream" element_type="property" interface="MediaStreamEvent" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#mediastreamevent</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -803,9 +803,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="binaryType" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="binaryType" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -815,9 +815,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="bufferedAmount" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="bufferedAmount" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -827,9 +827,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="id" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="id" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -839,9 +839,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="label" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="label" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -851,9 +851,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="maxRetransmits" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="maxRetransmits" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -863,9 +863,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="maxRetransmitTime" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="maxRetransmitTime" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -875,9 +875,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="negotiated" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="negotiated" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -887,9 +887,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="ordered" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="ordered" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -899,9 +899,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="protocol" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="protocol" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -911,9 +911,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="readyState" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="readyState" element_type="property" interface="RTCDataChannel" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -923,9 +923,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="addIceCandidate" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="addIceCandidate" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -935,9 +935,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createDTMFSender" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createDTMFSender" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCDataChannelEvent</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -947,9 +947,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="close" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="close" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCDataChannelEvent</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -959,9 +959,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -971,9 +971,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="getLocalStreams" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="getLocalStreams" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -983,9 +983,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="iceConnectionState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="iceConnectionState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -995,9 +995,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="iceGatheringState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="iceGatheringState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1007,9 +1007,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="localDescription" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="localDescription" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1019,9 +1019,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="remoteDescription" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="remoteDescription" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1031,9 +1031,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="signalingState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="signalingState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1043,9 +1043,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="signalingState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="signalingState" element_type="property" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1055,9 +1055,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="updateIce" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="updateIce" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1067,9 +1067,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="sdp" element_type="property" interface="RTCSessionDescription" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="sdp" element_type="property" interface="RTCSessionDescription" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1079,9 +1079,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="type" element_type="property" interface="RTCSessionDescription" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="type" element_type="property" interface="RTCSessionDescription" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1091,9 +1091,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="datachannel" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="datachannel" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCDataChannelEvent</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1103,9 +1103,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="iceconnectionstatechange" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="iceconnectionstatechange" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCDataChannelEvent</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1115,9 +1115,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="signalingstatechange" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="signalingstatechange" element_type="event" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCDataChannelEvent</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1127,9 +1127,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="property" interface="RTCPeerConnectionIceEvent" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="property" interface="RTCPeerConnectionIceEvent" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCDataChannelEvent</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1139,9 +1139,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="canInsertDTMF" element_type="property" interface="RTCDTMFSender" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="canInsertDTMF" element_type="property" interface="RTCDTMFSender" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#idl-def-RTCDataChannelEvent</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1151,9 +1151,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="getLocalStreams" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="getLocalStreams" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#widl-RTCPeerConnection-getLocalStreams-sequence-MediaStream</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1163,81 +1163,81 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="getRemoteStreams" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="getRemoteStreams" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#widl-RTCPeerConnection-getRemoteStreams-sequence-MediaStream</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection_EventHandler_1" priority="P1" purpose="Check if the RTCPeerConnection.onnegotiationneeded is valid" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html</test_script_entry>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onnegotiationneeded" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
-            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#interface-definition?total_num=6&amp;amp;locator_key=id&amp;amp;value=1</spec_url>
-            <spec_statement />
+            <spec_assertion category="W3C API Specifications" element_name="onnegotiationneeded" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#interface-definition</spec_url>
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection_EventHandler_2" priority="P1" purpose="Check if the RTCPeerConnection.onicecandidate is valid" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html</test_script_entry>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onicecandidate" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
-            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#interface-definition?total_num=6&amp;amp;locator_key=id&amp;amp;value=2</spec_url>
-            <spec_statement />
+            <spec_assertion category="W3C API Specifications" element_name="onicecandidate" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#interface-definition</spec_url>
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection_EventHandler_3" priority="P1" purpose="Check if the RTCPeerConnection.onsignalingstatechange is valid" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html</test_script_entry>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onsignalingstatechange" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
-            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#interface-definition?total_num=6&amp;amp;locator_key=id&amp;amp;value=3</spec_url>
-            <spec_statement />
+            <spec_assertion category="W3C API Specifications" element_name="onsignalingstatechange" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#interface-definition</spec_url>
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection_EventHandler_4" priority="P1" purpose="Check if the RTCPeerConnection.onaddstream is valid" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html</test_script_entry>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onaddstream" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
-            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#interface-definition?total_num=6&amp;amp;locator_key=id&amp;amp;value=4</spec_url>
-            <spec_statement />
+            <spec_assertion category="W3C API Specifications" element_name="onaddstream" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#interface-definition</spec_url>
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection_EventHandler_5" priority="P1" purpose="Check if the RTCPeerConnection.onremovestream is valid" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html</test_script_entry>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onremovestream" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
-            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#interface-definition?total_num=6&amp;amp;locator_key=id&amp;amp;value=5</spec_url>
-            <spec_statement />
+            <spec_assertion category="W3C API Specifications" element_name="onremovestream" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#interface-definition</spec_url>
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection_EventHandler_6" priority="P1" purpose="Check if the RTCPeerConnection.oniceconnectionstatechange is valid" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html</test_script_entry>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="oniceconnectionstatechange" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
-            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#interface-definition?total_num=6&amp;amp;locator_key=id&amp;amp;value=6</spec_url>
-            <spec_statement />
+            <spec_assertion category="W3C API Specifications" element_name="oniceconnectionstatechange" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#interface-definition</spec_url>
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1247,9 +1247,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="setIdentityProvider" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="setIdentityProvider" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#widl-RTCPeerConnection-setIdentityProvider-void-DOMString-provider-DOMString-protocol-DOMString-username</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1259,9 +1259,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="getIdentityAssertion" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="getIdentityAssertion" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#widl-RTCPeerConnection-getIdentityAssertion-void</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1271,141 +1271,165 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="close" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="close" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#widl-RTCPeerConnection-close-void</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_1" priority="P1" purpose="Check if if the new RTCIceCandidate " status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_1" priority="P1" purpose="Test new RTCIceCandidate" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_2" priority="P1" purpose="Check if candidate" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_2" priority="P1" purpose="Test candidate" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="attribute" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="attribute" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_3" priority="P1" purpose="Check if sdpMid" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_3" priority="P1" purpose="Test sdpMid" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="attribute" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="attribute" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_4" priority="P1" purpose="Check if sdpMLineIndex" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_4" priority="P1" purpose="Test sdpMLineIndex" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="attribute" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="attribute" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_6" priority="P1" purpose="Check if new RTCIceCandidate(initializer)" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_5" priority="P1" purpose="Test initializer" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_6" priority="P1" purpose="Test new RTCIceCandidate(initializer)" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_7" priority="P1" purpose="Check if initializer candidate" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_7" priority="P1" purpose="Test initializer candidate" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="method" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="method" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_8" priority="P1" purpose="Check if initializer sdpMid" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_8" priority="P1" purpose="Test initializer sdpMid" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="method" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="method" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_9" priority="P1" purpose="Check if initializer sdpMLineIndex" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_9" priority="P1" purpose="Test initializer sdpMLineIndex" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="method" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="candidate" element_type="method" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_10" priority="P1" purpose="Check if RTCIceCandidate({})" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_10" priority="P1" purpose="Test RTCIceCandidate({})" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_11" priority="P1" purpose="Check if RTCIceCandidate({})" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_11" priority="P1" purpose="Test RTCIceCandidate(5)" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_12" priority="P1" purpose="Check if RTCIceCandidate('foobar')" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_12" priority="P1" purpose="Test RTCIceCandidate('foobar')" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCIceCandidate" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
-            <spec_statement />
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_13" priority="P1" purpose="Test new RTCIceCandidate()" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCIceCandidate" section="Networking" specification="WebRTC"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1415,9 +1439,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="[add|remove]Stream" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="[add|remove]Stream" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1427,9 +1451,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createAnswer" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createAnswer" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#widl-RTCPeerConnection-createAnswer-void-RTCSessionDescriptionCallback-successCallback-RTCPeerConnectionErrorCallback-failureCallback-MediaConstraints-constraints</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1439,9 +1463,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createOffer" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createOffer" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#widl-RTCPeerConnection-createOffer-void-RTCSessionDescriptionCallback-successCallback-RTCPeerConnectionErrorCallback-failureCallback-MediaConstraints-constraints</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1451,9 +1475,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1463,9 +1487,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1475,9 +1499,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1487,9 +1511,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1499,9 +1523,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1511,9 +1535,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1523,9 +1547,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="createDataChannel" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1535,9 +1559,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="RTCDTMFSender" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="RTCDTMFSender" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1547,9 +1571,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="addIceCandidate" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="addIceCandidate" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1559,9 +1583,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="localDescription" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="localDescription" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#widl-RTCPeerConnection-setLocalDescription-void-RTCSessionDescription-description-VoidFunction-successCallback-RTCPeerConnectionErrorCallback-failureCallback</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1571,9 +1595,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="remoteDescription" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="remoteDescription" element_type="method" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#widl-RTCPeerConnection-setRemoteDescription-void-RTCSessionDescription-description-VoidFunction-successCallback-RTCPeerConnectionErrorCallback-failureCallback</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1583,9 +1607,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="onnegotiationneeded" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="onnegotiationneeded" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#widl-RTCPeerConnection-onnegotiationneeded</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1595,9 +1619,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="signalingState" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="signalingState" element_type="attribute" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#widl-RTCPeerConnection-signalingState</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1607,9 +1631,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCPeerConnection" section="Networking" specification="WebRTC" />
+            <spec_assertion category="W3C API Specifications" element_name="constructor" element_type="constructor" interface="RTCPeerConnection" section="Networking" specification="WebRTC"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface-extensions-2</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>

--- a/webapi/webapi-webrtc-w3c-tests/tests.xml
+++ b/webapi/webapi-webrtc-w3c-tests/tests.xml
@@ -494,32 +494,32 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection_EventHandler_1" purpose="Check if the RTCPeerConnection.onnegotiationneeded is valid">
         <description>
-          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html</test_script_entry>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection_EventHandler_2" purpose="Check if the RTCPeerConnection.onicecandidate is valid">
         <description>
-          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html</test_script_entry>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection_EventHandler_3" purpose="Check if the RTCPeerConnection.onsignalingstatechange is valid">
         <description>
-          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html</test_script_entry>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection_EventHandler_4" purpose="Check if the RTCPeerConnection.onaddstream is valid">
         <description>
-          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html</test_script_entry>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection_EventHandler_5" purpose="Check if the RTCPeerConnection.onremovestream is valid">
         <description>
-          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html</test_script_entry>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection_EventHandler_6" purpose="Check if the RTCPeerConnection.oniceconnectionstatechange is valid">
         <description>
-          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html</test_script_entry>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection_setIdentityProvider" purpose="Check if the RTCPeerConnection.setIdentityProvider is valid">
@@ -537,59 +537,69 @@
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_close.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_1" purpose="Check if if the new RTCIceCandidate ">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_1" purpose="Test new RTCIceCandidate">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_2" purpose="Check if candidate">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_2" purpose="Test candidate">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_3" purpose="Check if sdpMid">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_3" purpose="Test sdpMid">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_4" purpose="Check if sdpMLineIndex">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_4" purpose="Test sdpMLineIndex">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_6" purpose="Check if new RTCIceCandidate(initializer)">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_5" purpose="Test initializer">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_6" purpose="Test new RTCIceCandidate(initializer)">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_7" purpose="Check if initializer candidate">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_7" purpose="Test initializer candidate">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_8" purpose="Check if initializer sdpMid">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_8" purpose="Test initializer sdpMid">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_9" purpose="Check if initializer sdpMLineIndex">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_9" purpose="Test initializer sdpMLineIndex">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_10" purpose="Check if RTCIceCandidate({})">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_10" purpose="Test RTCIceCandidate({})">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_11" purpose="Check if RTCIceCandidate({})">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_11" purpose="Test RTCIceCandidate(5)">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_12" purpose="Check if RTCIceCandidate('foobar')">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_12" purpose="Test RTCIceCandidate('foobar')">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCIceCandidate_13" purpose="Test new RTCIceCandidate()">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCIceCandidate.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-AddRemoveStream" purpose="Check if RTCPeerConnection [add|remove]Stream">


### PR DESCRIPTION
- Update test entery in xml for tct-forms-html5-tests,
webapi-webcl-nonw3c-tests and webapi-webrtc-w3c-tests

- Remove duplicated test entery in xml for webapi-webcl-nonw3c-tests
and tct-indexeddb-w3c-tests

Impacted suites: tct-forms-html5-tests
Impacted tests(approved): new 0, update 2, delete 0
Unit test platform: Crosswalk for Android 15.43.354
Unit result summary: pass 2, fail 0, block 0

Impacted suites: tct-indexeddb-w3c-tests
Impacted tests(approved): new 0, update 0, delete 7
Unit test platform: Crosswalk for Android 15.43.354
Unit result summary: pass 0, fail 0, block 0

Impacted suites: webapi-webcl-nonw3c-tests
Impacted tests(approved): new 0, update 1, delete 2
Unit test platform: Crosswalk for Android 15.43.354
Unit result summary: pass 0, fail 1, block 0

Impacted suites: webapi-webrtc-w3c-tests
Impacted tests(approved): new 0, update 6, delete 0
Unit test platform: Crosswalk for Android 15.43.354
Unit result summary: pass 6, fail 0, block 0