### PR TITLE
[tools] Apply pack scripts to cordova with higher version than 5.0.0

### DIFF
--- a/tools/build/pack.py
+++ b/tools/build/pack.py
@@ -594,8 +594,10 @@ def packCordova_cli(build_json=None, app_src=None, app_dest=None, app_name=None)
     project_root = os.path.join(BUILD_ROOT, app_name)
 
     output = commands.getoutput("cordova -v")
-    if output != "5.0.0":
-        LOG.error("Cordova 4.0 build requires Cordova-CLI 5.0.0, install with command: '$ sudo npm install cordova@5.0.0 -g'")
+    output_version = int(output[0])
+    if output_version < 5:
+        LOG.error(
+            "Cordova 4.0 build requires the latest Cordova-CLI, and must >= 5.0.0, install with command: '$ sudo npm install cordova -g'")
         return False
 
     plugin_tool = os.path.join(BUILD_ROOT, "cordova_plugins")

--- a/tools/build/pack_cordova_sample.py
+++ b/tools/build/pack_cordova_sample.py
@@ -623,8 +623,10 @@ def packSampleApp_cli(app_name=None):
     project_root = os.path.join(BUILD_ROOT, app_name)
 
     output = commands.getoutput("cordova -v")
-    if output != "5.0.0":
-        LOG.error("Cordova 4.0 build requires Cordova-CLI 5.0.0, install with command: '$ sudo npm install cordova@5.0.0 -g'")
+    output_version = int(output[0])
+    if output_version < 5:
+        LOG.error(
+            "Cordova 4.0 build requires the latest Cordova-CLI, and must >= 5.0.0, install with command: '$ sudo npm install cordova -g'")
         return False
 
     plugin_tool = os.path.join(BUILD_ROOT, "cordova_plugins")


### PR DESCRIPTION
Before the pack scripts required the cordova version exactly 5.0.0.
If it's not 5.0.0, packing will fail. Now cordova version has already
upgrade to 5.1.1. But the scripts do not update to accommodate to this change.

On master branch this modification was done before but it's not synchronized to
Crosswalk-14 branch. So merge this change to Crosswalk-14 branch.

https://crosswalk-project.org/jira/browse/XWALK-4670