### PR TITLE
[tools] Put test author into metadata

### DIFF
--- a/tools/template/reftest_reference_ref.html
+++ b/tools/template/reftest_reference_ref.html
@@ -24,15 +24,12 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
 OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Authors:
-        Your, Name <youremail@intel.com>
-
 -->
 
 <meta charset="utf-8">
 <title>[Test Area] Reference File</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Givenname Surname" href="mailto:givenname.surname@intel.com">
 <style>
   [CSS for test]
 </style>

--- a/tools/template/reftest_test_case.html
+++ b/tools/template/reftest_test_case.html
@@ -24,15 +24,12 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
 OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Authors:
-        Your, Name <youremail@intel.com>
-
 -->
 
 <meta charset="utf-8">
 <title>[Test Area]: [Title/Scope of Test]</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Givenname Surname" href="mailto:givenname.surname@intel.com">
 <link rel="help" href="http://www.w3.org/TR/[direct link to tested section]">
 <link rel="match" href="[path to reference file]">
 <meta name="flags" content="[requirement flags]">

--- a/tools/template/script_test_case.html
+++ b/tools/template/script_test_case.html
@@ -24,15 +24,12 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
 OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Authors:
-        Your, Name <youremail@intel.com>
-
 -->
 
 <meta charset="utf-8">
 <title>[Test Area]: [Title/Scope of Test]</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Givenname Surname" href="mailto:givenname.surname@intel.com">
 <link rel="help" href="http://www.w3.org/TR/[direct link to tested section]">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION
Historically test developer's name was put into file comments
immediately after license info. At the very beginning, this template is
OK for internal using.

As projects moving forward, these tests are expected to contribute to
upstream, e.g. W3C. It is important to put the author info into metadata
rather than into comment, because this comment including license and
author info must be removed before submission.

Sometimes, the authorship informations in metadata are used to
respect the authors, for example CSS WG nightly unstable lists all
authors in its acknowledgements section at
http://test.csswg.org/suites/css-transforms-1_dev/nightly-unstable/
Therefore both Intel and co-author Jieqiong Cui are acknowledged.

Sometimes, people can use this author metadata to talk test issues,
which is easier than finding author(s) via git log.

These templates are used for new test cases development; not for
existing tests.