### PR TITLE
[EmbeddingApi] Move the creation of XWalkView to onCreate() method

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/ContactExtensionActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/ContactExtensionActivity.java
@@ -1,5 +1,6 @@
 package org.xwalk.embedded.api.sample;
 
+import android.os.Bundle;
 import org.xwalk.core.XWalkActivity;
 import org.xwalk.core.XWalkView;
 
@@ -9,6 +10,13 @@ public class ContactExtensionActivity extends XWalkActivity {
     private ExtensionContact mExtension;
     private XWalkView mXWalkView;
 
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.xwview_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);                
+    }
+    
 	@Override
 	protected void onXWalkReady() {
 		// TODO Auto-generated method stub
@@ -27,10 +35,7 @@ public class ContactExtensionActivity extends XWalkActivity {
         .setPositiveButton("confirm" ,  null )
         .show();
 
-        setContentView(R.layout.xwview_layout);
         mExtension = new ExtensionContact(ContactExtensionActivity.this);
-        
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
         mXWalkView.load("file:///android_asset/contact.html", null);
 	}
 

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/EchoExtensionActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/EchoExtensionActivity.java
@@ -22,6 +22,7 @@ public class EchoExtensionActivity extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.container);        
     }
 
     @Override
@@ -37,9 +38,7 @@ public class EchoExtensionActivity extends XWalkActivity {
         .setPositiveButton("confirm" ,  null )
         .show();
         
-        setContentView(R.layout.container);
         LinearLayout parent = (LinearLayout) findViewById(R.id.container);
-
         LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 LinearLayout.LayoutParams.MATCH_PARENT);

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/FullScreenActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/FullScreenActivity.java
@@ -18,6 +18,8 @@ public class FullScreenActivity extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.xwview_fullscreen);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview_fullscreen);        
     }
 
     @Override
@@ -32,8 +34,7 @@ public class FullScreenActivity extends XWalkActivity {
         .setMessage(mess.toString())
         .setPositiveButton("confirm", null)
         .show();
-        setContentView(R.layout.xwview_fullscreen);
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview_fullscreen);
+
         Button leaveFullScreenBtn = (Button) findViewById(R.id.leave_fullscreen);
         leaveFullScreenBtn.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/LoadAppFromManifestLayoutActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/LoadAppFromManifestLayoutActivity.java
@@ -15,6 +15,7 @@ import android.content.res.AssetManager;
 import android.os.Bundle;
 
 public class LoadAppFromManifestLayoutActivity extends XWalkActivity {
+    private XWalkView xwalkView;
 
     private String getAssetsFileContent(AssetManager assetManager, String fileName)
             throws IOException {
@@ -37,6 +38,8 @@ public class LoadAppFromManifestLayoutActivity extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.xwview_layout);
+        xwalkView = (XWalkView) findViewById(R.id.xwalkview);        
     }
 
     @Override
@@ -51,8 +54,7 @@ public class LoadAppFromManifestLayoutActivity extends XWalkActivity {
         .setMessage(mess.toString())
         .setPositiveButton("confirm" ,  null )
         .show();
-        setContentView(R.layout.xwview_layout);
-        XWalkView xwalkView = (XWalkView) findViewById(R.id.xwalkview);
+
         String manifestContent = "";
         try {
             manifestContent = getAssetsFileContent(this.getAssets(), "manifest.json");

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/MultiXWalkViewActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/MultiXWalkViewActivity.java
@@ -18,6 +18,7 @@ public class MultiXWalkViewActivity extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.container);        
     }
 
     @Override
@@ -33,7 +34,6 @@ public class MultiXWalkViewActivity extends XWalkActivity {
         .setPositiveButton("confirm" ,  null )
         .show();
         
-        setContentView(R.layout.container);
         LinearLayout parent = (LinearLayout) findViewById(R.id.container);
 
         LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/OnCreateWindowRequestedActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/OnCreateWindowRequestedActivity.java
@@ -19,6 +19,8 @@ public class OnCreateWindowRequestedActivity extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
     	super.onCreate(savedInstanceState);
+        setContentView(R.layout.embedding_main);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview_embedding);    	
     }
 
     class TestXWalkUIClientBase extends XWalkUIClient {
@@ -52,8 +54,6 @@ public class OnCreateWindowRequestedActivity extends XWalkActivity {
         .setPositiveButton("confirm" ,  null )
         .show();
 
-        setContentView(R.layout.embedding_main);
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview_embedding);
         mXWalkView.setUIClient(new TestXWalkUIClientBase(mXWalkView));
 
         XWalkPreferences.setValue(XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS, true);

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/OnHideOnShowActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/OnHideOnShowActivity.java
@@ -16,6 +16,8 @@ public class OnHideOnShowActivity extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.xwview_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
     }
 
     @Override
@@ -34,8 +36,6 @@ public class OnHideOnShowActivity extends XWalkActivity {
         .setMessage(mess.toString())
         .setPositiveButton("confirm" ,  null )
         .show();
-        setContentView(R.layout.xwview_layout);
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
 
         // The web page below will display a video.
         // When home button is pressed, the activity will be in background, and the video will be paused.

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/OnIconAvailableOnReceivedIconActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/OnIconAvailableOnReceivedIconActivity.java
@@ -24,6 +24,8 @@ public class OnIconAvailableOnReceivedIconActivity extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
     	super.onCreate(savedInstanceState);
+        setContentView(R.layout.embedding_main);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview_embedding);    	
     }
 
     class TestXWalkUIClientBase extends XWalkUIClient {
@@ -68,8 +70,6 @@ public class OnIconAvailableOnReceivedIconActivity extends XWalkActivity {
         .setPositiveButton("confirm" ,  null )
         .show();
 
-        setContentView(R.layout.embedding_main);
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview_embedding);
         mXWalkView.setUIClient(new TestXWalkUIClientBase(mXWalkView));
 
         XWalkPreferences.setValue(XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS, true);

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/PauseTimersActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/PauseTimersActivity.java
@@ -21,6 +21,8 @@ public class PauseTimersActivity extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.pause_timers_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
     }
 
     @Override
@@ -37,8 +39,6 @@ public class PauseTimersActivity extends XWalkActivity {
         .setMessage(mess.toString())
         .setPositiveButton("confirm" ,  null )
         .show();
-        setContentView(R.layout.pause_timers_layout);
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
 
         isPaused = false;
         mButton = (ImageButton) findViewById(R.id.pause);

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/ResourceAndUIClientsActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/ResourceAndUIClientsActivity.java
@@ -102,6 +102,8 @@ public class ResourceAndUIClientsActivity extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.xwview_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
     }
 
     @Override
@@ -116,8 +118,7 @@ public class ResourceAndUIClientsActivity extends XWalkActivity {
         .setMessage(mess.toString())
         .setPositiveButton("confirm" ,  null )
         .show();
-        setContentView(R.layout.xwview_layout);
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+
         mXWalkView.setResourceClient(new ResourceClient(mXWalkView));
         mXWalkView.setUIClient(new UIClient(mXWalkView));
         mXWalkView.load("http://www.baidu.com", null);

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/ShouldOverrideUrlLoadingActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/ShouldOverrideUrlLoadingActivity.java
@@ -17,6 +17,8 @@ public class ShouldOverrideUrlLoadingActivity extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.embedding_main);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview_embedding);        
     }
 
     class TestXWalkResourceClientBase extends XWalkResourceClient {
@@ -49,8 +51,6 @@ public class ShouldOverrideUrlLoadingActivity extends XWalkActivity {
         .setPositiveButton("confirm" ,  null )
         .show();
 
-        setContentView(R.layout.embedding_main);
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview_embedding);
         mXWalkView.setResourceClient(new TestXWalkResourceClientBase(mXWalkView));
 
         XWalkPreferences.setValue(XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS, true);

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkBlockAndErrorRedirection.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkBlockAndErrorRedirection.java
@@ -7,6 +7,7 @@ import org.xwalk.core.XWalkPreferences;
 import org.xwalk.core.XWalkResourceClient;
 import org.xwalk.core.XWalkView;
 
+import android.os.Bundle;
 import android.app.AlertDialog;
 import android.util.Log;
 import android.webkit.WebResourceResponse;
@@ -15,6 +16,13 @@ import android.webkit.WebResourceResponse;
 public class XWalkBlockAndErrorRedirection extends XWalkActivity{
     private XWalkView mXWalkView;
     private static final String TAG = XWalkBlockAndErrorRedirection.class.getName();
+    
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.xwview_layout);        
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
+    }    
 
     class ResourceClient extends XWalkResourceClient {
 
@@ -64,7 +72,7 @@ public class XWalkBlockAndErrorRedirection extends XWalkActivity{
         StringBuffer mess = new StringBuffer();
         mess.append("Test Purpose: \n\n")
         .append("Verifies XWalkView can block response.\n\n")
-	.append("Verifies XWalkView can redirect to default page when load error page.\n\n")
+	    .append("Verifies XWalkView can redirect to default page when load error page.\n\n")
         .append("Expected Result:\n\n")
         .append("1. Test passes if click first link to show a cat image.\n\n")
         .append("2. Test passes if click second link to show baidu homepage.\n\n");
@@ -78,9 +86,7 @@ public class XWalkBlockAndErrorRedirection extends XWalkActivity{
         XWalkPreferences.setValue(XWalkPreferences.REMOTE_DEBUGGING, true);
         XWalkPreferences.setValue(XWalkPreferences.JAVASCRIPT_CAN_OPEN_WINDOW, true);
 
-        setContentView(R.layout.xwview_layout);        
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
         mXWalkView.setResourceClient(new ResourceClient(mXWalkView));
         mXWalkView.load("file:///android_asset/block_redirect_url.html", null);
-    }  
+    }   
 }

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkNavigationActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkNavigationActivity.java
@@ -27,6 +27,8 @@ public class XWalkNavigationActivity extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.navigation_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
     }
 
     private void showNavigationItemInfo(XWalkNavigationItem navigationItem){
@@ -55,10 +57,8 @@ public class XWalkNavigationActivity extends XWalkActivity {
         .setPositiveButton("confirm" ,  null )
         .show();
  
-        setContentView(R.layout.navigation_layout);
         mPrevButton = (ImageButton) findViewById(R.id.prev);
         mNextButton = (ImageButton) findViewById(R.id.next);
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
 
         text1 = (TextView) super.findViewById(R.id.text1);
         text2 = (TextView) super.findViewById(R.id.text2);

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkPreferencesActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkPreferencesActivity.java
@@ -17,6 +17,8 @@ public class XWalkPreferencesActivity extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.xwview_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
     }
 
     @Override
@@ -31,8 +33,6 @@ public class XWalkPreferencesActivity extends XWalkActivity {
         .setMessage(mess.toString())
         .setPositiveButton("confirm" ,  null )
         .show();
-        setContentView(R.layout.xwview_layout);
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
 
         // Enable remote debugging.
         // You can debug the web content via PC chrome.

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkVersionAndAPIVersion.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkVersionAndAPIVersion.java
@@ -17,6 +17,8 @@ public class XWalkVersionAndAPIVersion extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.version_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
     }
 
     @Override
@@ -31,8 +33,7 @@ public class XWalkVersionAndAPIVersion extends XWalkActivity {
         .setMessage(mess.toString())
         .setPositiveButton("confirm" ,  null )
         .show();
-        setContentView(R.layout.version_layout);
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+
         String apiVersion = mXWalkView.getAPIVersion();
         String xwalkVersion = mXWalkView.getXWalkVersion();
         TextView text1 = (TextView) super.findViewById(R.id.text1);

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithClearCache.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithClearCache.java
@@ -31,11 +31,12 @@ public class XWalkViewWithClearCache extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.clearcache_layout);        
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
     }
 
     @Override
     protected void onXWalkReady() {
-        setContentView(R.layout.clearcache_layout);
         StringBuffer mess = new StringBuffer();
         mess.append("Test Purpose: \n\n")
         .append("Verifies XWalkView can clear the cache.\n\n")
@@ -61,7 +62,7 @@ public class XWalkViewWithClearCache extends XWalkActivity {
 				}
 			}
 		});
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
+   
         mXWalkView.setUIClient(new UIClient(mXWalkView));
         mXWalkView.load("http://www.baidu.com/", null);
     }

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithDispatchKeyEvent.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithDispatchKeyEvent.java
@@ -19,11 +19,12 @@ public class XWalkViewWithDispatchKeyEvent extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.xwview_layout);        
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
     }
 
     @Override
     protected void onXWalkReady() {
-        setContentView(R.layout.xwview_layout);
         StringBuffer mess = new StringBuffer();
         mess.append("Test Purpose: \n\n")
         .append("Verifies XWalkView can disable back button.\n\n")
@@ -34,7 +35,7 @@ public class XWalkViewWithDispatchKeyEvent extends XWalkActivity {
         .setMessage(mess.toString())
         .setPositiveButton("confirm" ,  null )
         .show();
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+
         mXWalkView.load("http://www.baidu.com/", null);
     }
 

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithDownloadListenerActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithDownloadListenerActivity.java
@@ -8,6 +8,7 @@ package org.xwalk.embedded.api.sample;
 import org.xwalk.core.XWalkActivity;
 import org.xwalk.core.XWalkDownloadListener;
 
+import android.os.Bundle;
 import org.xwalk.core.XWalkView;
 import android.app.AlertDialog;
 import android.widget.TextView;
@@ -17,8 +18,15 @@ public class XWalkViewWithDownloadListenerActivity extends XWalkActivity {
     private TextView downloadText;
     
     @Override
-    protected void onXWalkReady() {
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
         setContentView(R.layout.version_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);                
+    }
+        
+    @Override
+    protected void onXWalkReady() {
+
         StringBuffer mess = new StringBuffer();
         mess.append("Test Purpose: \n\n")
         .append("Verifies XWalkView can set DownloadListener & override onDownloadStart.\n\n")
@@ -31,9 +39,9 @@ public class XWalkViewWithDownloadListenerActivity extends XWalkActivity {
         .setMessage(mess.toString())
         .setPositiveButton("confirm" ,  null )
         .show();
-        
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+                
         downloadText = (TextView) findViewById(R.id.text1);
+        
         mXWalkView.setUserAgentString("Chrome/44.0.2403.81 Crosswalk/15.44.376.0 Mobile Safari/537.36");
         mXWalkView.setDownloadListener(new XWalkDownloadListener(getApplicationContext()) {
 			

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithLayoutActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithLayoutActivity.java
@@ -16,11 +16,12 @@ public class XWalkViewWithLayoutActivity extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.xwview_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);                
     }
 
     @Override
     protected void onXWalkReady() {
-        setContentView(R.layout.xwview_layout);
         StringBuffer mess = new StringBuffer();
         mess.append("Test Purpose: \n\n")
         .append("Verifies XWalkView can load view UI.\n\n")
@@ -31,7 +32,7 @@ public class XWalkViewWithLayoutActivity extends XWalkActivity {
         .setMessage(mess.toString())
         .setPositiveButton("confirm" ,  null )
         .show();
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+
         mXWalkView.load("http://www.baidu.com/", null);
     }
 }

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithLoadImage.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithLoadImage.java
@@ -17,6 +17,8 @@ public class XWalkViewWithLoadImage extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.xwview_layout);        
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
     }
 
 	@Override
@@ -29,7 +31,6 @@ public class XWalkViewWithLoadImage extends XWalkActivity {
 	@Override
 	protected void onXWalkReady() {
 		// TODO Auto-generated method stub
-        setContentView(R.layout.xwview_layout);
         StringBuffer mess = new StringBuffer();
         mess.append("Test Purpose: \n\n")
         .append("Verifies XWalkView can load image.\n\n")
@@ -40,7 +41,7 @@ public class XWalkViewWithLoadImage extends XWalkActivity {
         .setMessage(mess.toString())
         .setPositiveButton("confirm" ,  null )
         .show();
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+
         mXWalkView.load("http://jquery.decadework.com/", null);
 	}
     

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithRedirection.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithRedirection.java
@@ -23,6 +23,8 @@ public class XWalkViewWithRedirection extends XWalkActivity{
 	protected void onCreate(Bundle savedInstanceState) {
 		// TODO Auto-generated method stub
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.version_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
     }
 
 	
@@ -97,8 +99,6 @@ public class XWalkViewWithRedirection extends XWalkActivity{
         .setPositiveButton("confirm" ,  null )
         .show();
  
-        setContentView(R.layout.version_layout);
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
         LoadstoppedTimes = (TextView) findViewById(R.id.text1);
 
         mXWalkView.setUIClient(new UIClient(mXWalkView));

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithSetLanguage.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithSetLanguage.java
@@ -17,11 +17,12 @@ public class XWalkViewWithSetLanguage extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.xwview_layout);        
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
     }
 
     @Override
     protected void onXWalkReady() {
-        setContentView(R.layout.xwview_layout);
         StringBuffer mess = new StringBuffer();
         mess.append("Test Purpose: \n\n")
         .append("Verifies XWalkView can update the accept language.\n\n")
@@ -32,7 +33,7 @@ public class XWalkViewWithSetLanguage extends XWalkActivity {
         .setMessage(mess.toString())
         .setPositiveButton("confirm" ,  null )
         .show();
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+
         mXWalkView.setAcceptLanguages("zh-CN");
         mXWalkView.load("http://www.bing.com", null);
     }

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithTransparent.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithTransparent.java
@@ -13,12 +13,12 @@ public class XWalkViewWithTransparent extends XWalkActivity{
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.xwview_transparent_layout);        
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview_transparent);        
     }
 
     @Override
     protected void onXWalkReady() {
-        
-        setContentView(R.layout.xwview_transparent_layout);
         StringBuffer mess = new StringBuffer();
         mess.append("Test Purpose: \n\n")
         .append("Check XWalkView's transparent feature whether display the view under the webview.\n\n")
@@ -29,7 +29,7 @@ public class XWalkViewWithTransparent extends XWalkActivity{
         .setMessage(mess.toString())
         .setPositiveButton("confirm" ,  null )
         .show();
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview_transparent);
+
         mXWalkView.setZOrderOnTop(true);
         mXWalkView.setBackgroundColor(0);
         mXWalkView.load("http://www.baidu.com/", null);

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkWithInputConnection.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkWithInputConnection.java
@@ -22,6 +22,7 @@ public class XWalkWithInputConnection extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.container);        
     }
 
     @Override
@@ -40,7 +41,6 @@ public class XWalkWithInputConnection extends XWalkActivity {
         .setPositiveButton("confirm" ,  null )
         .show();
         
-        setContentView(R.layout.container);
         LinearLayout parent = (LinearLayout) findViewById(R.id.container);
 
         mXWalkView = new myXWalkView(this, this);

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkWithSaveState.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkWithSaveState.java
@@ -24,6 +24,7 @@ public class XWalkWithSaveState extends XWalkActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.savestate_layout);        
     }
 
     @Override
@@ -43,7 +44,6 @@ public class XWalkWithSaveState extends XWalkActivity {
         .setPositiveButton("confirm" ,  null )
         .show();
         
-        setContentView(R.layout.savestate_layout);
         button_one = (Button) findViewById(R.id.button_one);
         button_two = (Button) findViewById(R.id.button_two);
         button_three = (Button) findViewById(R.id.button_three);

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/ZoomInAndOutXWalkViewActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/ZoomInAndOutXWalkViewActivity.java
@@ -15,6 +15,7 @@ import android.widget.Button;
 import android.widget.SeekBar;
 import android.widget.SeekBar.OnSeekBarChangeListener;
 import android.widget.TextView;
+import android.os.Bundle;
 
 public class ZoomInAndOutXWalkViewActivity extends XWalkActivity {
     private XWalkView mXWalkView;
@@ -25,8 +26,14 @@ public class ZoomInAndOutXWalkViewActivity extends XWalkActivity {
     private static final String ZOOMRANGE = "Set zoom range: 0.5~2.0\n";
     
     @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.zoom_layout);      
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);   
+    }    
+    
+    @Override
     protected void onXWalkReady() {
-        setContentView(R.layout.zoom_layout);
         StringBuffer mess = new StringBuffer();
         mess.append("Test Purpose: \n\n")
         .append("Verifies XWalkView can zoom.\n\n")
@@ -42,7 +49,6 @@ public class ZoomInAndOutXWalkViewActivity extends XWalkActivity {
         .setPositiveButton("confirm" ,  null )
         .show();
 
-        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
         zoomInBtn = (Button) findViewById(R.id.zoomin_btn);
         zoomOutBtn = (Button) findViewById(R.id.zoomout_btn);
         canZoomText = (TextView) findViewById(R.id.zommtv);


### PR DESCRIPTION
-The creation of XWalkView should be put on the onCreate()
-Modify all the embedding usecase which extends XWalkActivity

Impacted tests(approved): new 0, update 26, delete 0
Unit test platform: [Android]
Unit test result summary: pass 26, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4686