### PR TITLE
[Embeddingapi] Add setUserAgentString test when XWalk downloading

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -930,6 +930,15 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
+    
+	protected void setUserAgent(final String userAgent) {
+	    getInstrumentation().runOnMainSync(new Runnable() {
+	        @Override
+	        public void run() {
+	            mXWalkView.setUserAgentString(userAgent);
+	        }
+	    });
+	}    
 
     public static final String ABOUT_TITLE = "About the Google";
 

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkUIClientTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkUIClientTest.java
@@ -210,12 +210,14 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
         final String data = "download data";
         final String contentDisposition = "attachment;filename=\"download.txt\"";
         final String mimeType = "text/plain";
+        final String userAgent = "Chrome/44.0.2403.81 Crosswalk/15.44.376.0 Mobile Safari/537.36";
 
         List<Pair<String, String>> downloadHeaders = new ArrayList<Pair<String, String>>();
         downloadHeaders.add(Pair.create("Content-Disposition", contentDisposition));
         downloadHeaders.add(Pair.create("Content-Type", mimeType));
         downloadHeaders.add(Pair.create("Content-Length", Integer.toString(data.length())));
 
+        setUserAgent(userAgent);
         setDownloadListener();
 
         try {
@@ -228,6 +230,7 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
             assertEquals(contentDisposition, mDownloadStartHelper.getContentDisposition());
             assertEquals(mimeType, mDownloadStartHelper.getMimeType());
             assertEquals(data.length(), mDownloadStartHelper.getContentLength());
+            assertEquals(userAgent, mDownloadStartHelper.getUserAgent());
         } catch (Exception e) {
 	    // TODO Auto-generated catch block
             assertFalse(true);

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -897,6 +897,15 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
+    
+	protected void setUserAgent(final String userAgent) {
+	    getInstrumentation().runOnMainSync(new Runnable() {
+	        @Override
+	        public void run() {
+	            mXWalkView.setUserAgentString(userAgent);
+	        }
+	    });
+	}    
 
     public static final String ABOUT_TITLE = "About the Google";
 

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkUIClientTest.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkUIClientTest.java
@@ -210,12 +210,14 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
         final String data = "download data";
         final String contentDisposition = "attachment;filename=\"download.txt\"";
         final String mimeType = "text/plain";
+        final String userAgent = "Chrome/44.0.2403.81 Crosswalk/15.44.376.0 Mobile Safari/537.36";        
 
         List<Pair<String, String>> downloadHeaders = new ArrayList<Pair<String, String>>();
         downloadHeaders.add(Pair.create("Content-Disposition", contentDisposition));
         downloadHeaders.add(Pair.create("Content-Type", mimeType));
         downloadHeaders.add(Pair.create("Content-Length", Integer.toString(data.length())));
 
+        setUserAgent(userAgent);
         setDownloadListener();
 
         try {
@@ -228,6 +230,7 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
             assertEquals(contentDisposition, mDownloadStartHelper.getContentDisposition());
             assertEquals(mimeType, mDownloadStartHelper.getMimeType());
             assertEquals(data.length(), mDownloadStartHelper.getContentLength());
+            assertEquals(userAgent, mDownloadStartHelper.getUserAgent());            
         } catch (Exception e) {
 	    // TODO Auto-generated catch block
             assertFalse(true);

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkViewWithDownloadListenerActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkViewWithDownloadListenerActivity.java
@@ -59,7 +59,7 @@ public class XWalkViewWithDownloadListenerActivity extends Activity implements X
         
         mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
         downloadText = (TextView) findViewById(R.id.text1);
-        
+        mXWalkView.setUserAgentString("Chrome/44.0.2403.81 Crosswalk/15.44.376.0 Mobile Safari/537.36");
         mXWalkView.setDownloadListener(new XWalkDownloadListener(getApplicationContext()) {
 			
 			@Override
@@ -67,11 +67,11 @@ public class XWalkViewWithDownloadListenerActivity extends Activity implements X
 			                String contentDisposition, String mimetype, long contentLength) {
 				// TODO Auto-generated method stub
 				// You can realize your down here.
-				downloadText.setText("url: " + url + "\n" +
-									 "userAgent: " + userAgent + "\n" +
-									 "contentDisposition: " + contentDisposition + "\n" +
-									 "mimeType: " + mimetype + "\n" +
-									 "contentLength: " + contentLength);
+				downloadText.setText("url: " + url + "\n" + 
+				                    "userAgent: " + userAgent + "\n" + 
+				                    "contentDisposition: " + contentDisposition + "\n" + 
+				                    "mimeType: " + mimetype + "\n" + 
+				                    "contentLength: " + contentLength);
 			}
 		});
         mXWalkView.load("http://www.baidu.com/", null);

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithDownloadListenerActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithDownloadListenerActivity.java
@@ -34,7 +34,7 @@ public class XWalkViewWithDownloadListenerActivity extends XWalkActivity {
         
         mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
         downloadText = (TextView) findViewById(R.id.text1);
-        
+        mXWalkView.setUserAgentString("Chrome/44.0.2403.81 Crosswalk/15.44.376.0 Mobile Safari/537.36");
         mXWalkView.setDownloadListener(new XWalkDownloadListener(getApplicationContext()) {
 			
 			@Override
@@ -42,10 +42,11 @@ public class XWalkViewWithDownloadListenerActivity extends XWalkActivity {
 			                String contentDisposition, String mimetype, long contentLength) {
 				// TODO Auto-generated method stub
 				// You can realize your down here.
-				downloadText.setText("url: " + url + "\n" +									 "userAgent: " + userAgent + "\n" +
-									 "contentDisposition: " + contentDisposition + "\n" +
-									 "mimeType: " + mimetype + "\n" +
-									 "contentLength: " + contentLength);
+				downloadText.setText("url: " + url + "\n" + 
+				                    "userAgent: " + userAgent + "\n" + 
+				                    "contentDisposition: " + contentDisposition + "\n" + 
+				                    "mimeType: " + mimetype + "\n" + 
+				                    "contentLength: " + contentLength);
 			}
 		});
         mXWalkView.load("http://www.baidu.com/", null);


### PR DESCRIPTION
-Add setUserAgentString test when XWalk downloading
-Cover the XWalkViewActivity and XWalkInitializer two ways

Impacted tests(approved): new 0, update 4, delete 0
Unit test platform: [Android]
Unit test result summary: pass 4, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4694