### PR TITLE
[Crosswalk-14][Cordova] Adjust the pack for crosswalk version config change

### DIFF
--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -1,6 +1,7 @@
 ## Introduction
 
 pack_cordova_sample.py is used for auto build Cordova sample apps, including mobilespec, helloworld, remotedebugging, gallery, and support both Cordova 3.6 and Cordova 4.0 build.  
+**Note**: For cordova 4.0 pkg, need to configure crosswalk version in crosswalk-test-suite/VERSION file
 
 ## Pre-conditions
 
@@ -30,7 +31,7 @@ pack_cordova_sample.py is used for auto build Cordova sample apps, including mob
 **cordova-version**: 3.6, 4.0  
 **pkg-mode**: embedded(default), shared
 **pkg-arch**: arm(default), x86 
-**Note**: -m argument is only for cordova version 3.6, -a argument is only for cordova version 4.0, if no --tools argument, please run script under the path where it is.
+**Note**: -a argument is only for cordova version 4.0, if no --tools argument, please run script under the path where it is.
 
 ## Authors:
 

--- a/tools/build/pack.py
+++ b/tools/build/pack.py
@@ -639,7 +639,17 @@ def packCordova_cli(build_json=None, app_src=None, app_dest=None, app_name=None)
     plugin_dirs = os.listdir(plugin_tool)
     for i_dir in plugin_dirs:
         i_plugin_dir = os.path.join(plugin_tool, i_dir)
-        plugin_install_cmd = "cordova plugin add %s" % i_plugin_dir
+        if i_dir == "cordova-plugin-crosswalk-webview":
+            os.chdir(i_plugin_dir)
+            output = commands.getoutput("git pull").strip("\r\n")
+            os.chdir(project_root)
+            plugin_install_webview = "cordova plugin add %s --variable CROSSWALK_ANDROID_VERSION=\"%s\"" % (i_plugin_dir, CROSSWALK_VERSION)
+            if BUILD_PARAMETERS.pkgmode == "shared":
+                plugin_install_cmd = plugin_install_webview + " --variable LIB_MODE=\"shared\""
+            else:
+                plugin_install_cmd = plugin_install_webview + " --variable LIB_MODE=\"embedd\""
+        else:
+            plugin_install_cmd = "cordova plugin add %s" % i_plugin_dir
         if not doCMD(plugin_install_cmd, DEFAULT_CMD_TIMEOUT):
             os.chdir(orig_dir)
             return False
@@ -1359,9 +1369,6 @@ def main():
         if BUILD_PARAMETERS.subversion:
             if not str(BUILD_PARAMETERS.subversion) in cordova_subv_list :
                 LOG.error("The argument of cordova --sub-version can only be '3.6' or '4.0' , exit ...")
-                sys.exit(1)
-            if BUILD_PARAMETERS.subversion == '4.0' and BUILD_PARAMETERS.pkgmode:
-                LOG.error("Command -m is only for cordova version 3.6")
                 sys.exit(1)
             parameters_type = BUILD_PARAMETERS.pkgtype + BUILD_PARAMETERS.subversion
 


### PR DESCRIPTION
- Support shared mode according cordova-plugin-crosswalk-webview
- Use crosswalk-test-suite/VERSION to configure the crosswalk version for cordova 4.0 pack
- It's successfull to pack embedded mode pkg
- For cordova 4.0 shared mode: feature currently not completely support

https://crosswalk-project.org/jira/browse/XWALK-4458