### PR TITLE
[Crosswalk-14][Cordova] Adjust the crosswalk version config

### DIFF
--- a/cordova/cordova-feature-android-tests/suite.json
+++ b/cordova/cordova-feature-android-tests/suite.json
@@ -34,6 +34,7 @@
             "copylist": {
                 "inst.apk.py": "inst.py",
                 "PACK-TOOL-ROOT/cordova_plugins/cordova-plugin-crosswalk-webview": "tools/cordova-plugin-crosswalk-webview",
+                "PACK-TOOL-ROOT/../VERSION": "VERSION",
                 "feature": "feature",
                 "arch.txt": "arch.txt",
                 "mode.txt": "mode.txt",

--- a/cordova/cordova-sampleapp-android-tests/suite.json
+++ b/cordova/cordova-sampleapp-android-tests/suite.json
@@ -35,6 +35,7 @@
             "copylist": {
                 "inst.apk.py": "inst.py",
                 "PACK-TOOL-ROOT/cordova_plugins/cordova-plugin-crosswalk-webview": "tools/cordova-plugin-crosswalk-webview",
+                "PACK-TOOL-ROOT/../VERSION": "VERSION",
                 "sampleapp": "sampleapp",
                 "testscripts": "testscripts",
                 "arch.txt": "arch.txt",

--- a/cordova/cordova-webapp-android-tests/suite.json
+++ b/cordova/cordova-webapp-android-tests/suite.json
@@ -34,6 +34,7 @@
             "copylist": {
                 "inst.apk.py": "inst.py",
                 "PACK-TOOL-ROOT/cordova_plugins/cordova-plugin-crosswalk-webview": "tools/cordova-plugin-crosswalk-webview",
+                "PACK-TOOL-ROOT/../VERSION": "VERSION",
                 "webapp": "webapp",
                 "arch.txt": "arch.txt",
                 "mode.txt": "mode.txt",


### PR DESCRIPTION
- Support shared mode according cordova-plugin-crosswalk-webview
- Use crosswalk-test-suite/VERSION to configure the crosswalk version for cordova 4.0 build
- For cordova 4.0 shared mode: feature currently not completely support

Impacted tests(approved): new 0, update 28, delete 0
Unit test platform: Crosswalk Project for Android 14.43.343.21
Unit test result summary: pass 28, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4458