### PR TITLE
[Crosswalk-14][hotfix][Cordova] Define CROSSWALK_VERSION variable in pack.py

### DIFF
--- a/tools/build/pack.py
+++ b/tools/build/pack.py
@@ -56,6 +56,7 @@ PKG_MODES = ["shared", "embedded"]
 PKG_ARCHS = ["x86", "arm"]
 PKG_BLACK_LIST = []
 PACK_TYPES = ["ant", "gradle", "maven"]
+CROSSWALK_VERSION = ""
 PKG_NAME = None
 BUILD_PARAMETERS = None
 BUILD_ROOT = None


### PR DESCRIPTION
- Successful to pack cordova 4.0 pkg with Crosswalk-14 code