### PR TITLE
[apptools-android] Update tests to test 'xwalk' prefix in the manifest for apptools android

### DIFF
--- a/apptools/apptools-android-tests/README
+++ b/apptools/apptools-android-tests/README
@@ -32,11 +32,7 @@ For example: if you want to test with "crosswalk-13.42.319.11.zip", content of t
 1. Download crosswalk-app-tools to apptools-android-tests/tools, then install npm
   1.1 cd tools, then clone source code from https://github.com/crosswalk-project/crosswalk-app-tools
   1.2 Run commands: cd crosswalk-app-tools, then run: npm install
-2. Install grunt-cli:
-  2.1 $ cd /path/to/opt/apptools-android-tests/tools/crosswalk-app-tools
-  2.2 $ npm install -g grunt-cli
-  2.2 $ grunt test
-If wanning: grunt is not recognized. Please add "C:/Users/AppData/Roaming/npm/" dir to path env.
+2. Install nodeunit: npm install nodeunit -g
 3. Environment variable configuration:
   3.1 Set ANDORID_HOME env
   3.2 Set CROSSWALK_APP_TOOLS_CACHE_DIR env to /path/to/opt/apptools-sampleapp-tests/tools

--- a/apptools/apptools-android-tests/apptools/Check_VersionName.html
+++ b/apptools/apptools-android-tests/apptools/Check_VersionName.html
@@ -43,22 +43,22 @@ Authors:
         On Android: <br/>
         &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
-        &nbsp; &nbsp; Update "crosswalk_app_version" in app/manifest.json file <br/>
+        &nbsp; &nbsp; Update "xwalk_app_version" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
         On Windows: <br/>
         &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
-        &nbsp; &nbsp; Update "crosswalk_app_version" in app\manifest.json file <br/>
+        &nbsp; &nbsp; Update "xwalk_app_version" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Install the app on android device <br/>
-        In android device application list, check if the app version is same with "crosswalk_app_version" which you update in manifest.json file
+        In android device application list, check if the app version is same with "xwalk_app_version" which you update in manifest.json file
     </li>
   </ol>
   <p>
     <strong>Expected Results:</strong>
   </p>
   <ol>
-    <li>The app version is same with "crosswalk_app_version" which you update in manifest.json file</li>
+    <li>The app version is same with "xwalk_app_version" which you update in manifest.json file</li>
   </ol>
 </body>
 

--- a/apptools/apptools-android-tests/apptools/Keeping_Screen_On.html
+++ b/apptools/apptools-android-tests/apptools/Keeping_Screen_On.html
@@ -43,12 +43,12 @@ Authors:
         On Android: <br/>
         &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
-        &nbsp; &nbsp; Set "crosswalk_android_keep_screen_on" to "true" in app/manifest.json file <br/>
+        &nbsp; &nbsp; Set "xwalk_android_keep_screen_on" to "true" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
         On Windows: <br/>
         &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
-        &nbsp; &nbsp; Set "crosswalk_android_keep_screen_on" to "true" in app\manifest.json file <br/>
+        &nbsp; &nbsp; Set "xwalk_android_keep_screen_on" to "true" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node  ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Install the app on android device <br/>
         Set the device screen off as 15 seconds(Setting->Display->Sleep: 15 seconds) <br/>

--- a/apptools/apptools-android-tests/apptools/versionCode.py
+++ b/apptools/apptools-android-tests/apptools/versionCode.py
@@ -66,7 +66,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         jsons = jsonfile.read()
         jsonfile.close()
         jsonDict = json.loads(jsons)
-        jsonDict["crosswalk_app_version"] = "0.1"
+        jsonDict["xwalk_app_version"] = "0.1"
         json.dump(jsonDict, open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "w"))
         with open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json") as json_file:
             data = json.load(json_file)
@@ -85,7 +85,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
                 versionCode_xml = attributes[x]
                 break
         comm.clear("org.xwalk.test")
-        self.assertEquals(data['crosswalk_app_version'].strip(os.linesep), "0.1")
+        self.assertEquals(data['xwalk_app_version'].strip(os.linesep), "0.1")
         self.assertEquals(versionCode, versionCode_xml)
 
     def test_update_app_version_twodot(self):
@@ -96,7 +96,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         jsons = jsonfile.read()
         jsonfile.close()
         jsonDict = json.loads(jsons)
-        jsonDict["crosswalk_app_version"] = "0.0.1"
+        jsonDict["xwalk_app_version"] = "0.0.1"
         json.dump(jsonDict, open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "w"))
         with open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json") as json_file:
             data = json.load(json_file)
@@ -115,7 +115,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
                 versionCode_xml = attributes[x]
                 break
         comm.clear("org.xwalk.test")
-        self.assertEquals(data['crosswalk_app_version'].strip(os.linesep), "0.0.1")
+        self.assertEquals(data['xwalk_app_version'].strip(os.linesep), "0.0.1")
         self.assertEquals(versionCode, versionCode_xml)
 
     def test_update_app_version_threedot(self):
@@ -126,14 +126,14 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         jsons = jsonfile.read()
         jsonfile.close()
         jsonDict = json.loads(jsons)
-        jsonDict["crosswalk_app_version"] = "0.0.0.1"
+        jsonDict["xwalk_app_version"] = "0.0.0.1"
         json.dump(jsonDict, open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "w"))
         with open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json") as json_file:
             data = json.load(json_file)
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
         return_code = os.system(buildcmd)
         comm.clear("org.xwalk.test")
-        self.assertEquals(data['crosswalk_app_version'].strip(os.linesep), "0.0.0.1")
+        self.assertEquals(data['xwalk_app_version'].strip(os.linesep), "0.0.0.1")
         self.assertNotEquals(return_code, 0)
 
     def test_update_app_version_out_of_range(self):
@@ -144,14 +144,14 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         jsons = jsonfile.read()
         jsonfile.close()
         jsonDict = json.loads(jsons)
-        jsonDict["crosswalk_app_version"] = "1000"
+        jsonDict["xwalk_app_version"] = "1000"
         json.dump(jsonDict, open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "w"))
         with open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json") as json_file:
             data = json.load(json_file)
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
         return_code = os.system(buildcmd)
         comm.clear("org.xwalk.test")
-        self.assertEquals(data['crosswalk_app_version'].strip(os.linesep), "1000")
+        self.assertEquals(data['xwalk_app_version'].strip(os.linesep), "1000")
         self.assertNotEquals(return_code, 0)
 
 if __name__ == '__main__':

--- a/apptools/apptools-android-tests/apptools/versionName.py
+++ b/apptools/apptools-android-tests/apptools/versionName.py
@@ -53,7 +53,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
                 break
         comm.clear("org.xwalk.test")
         self.assertEquals(buildstatus, 0)
-        self.assertEquals(data['crosswalk_app_version'].strip("\n\t"), versionName_xml)
+        self.assertEquals(data['xwalk_app_version'].strip("\n\t"), versionName_xml)
 
     def test_update_app_version(self):
         comm.setUp()
@@ -63,7 +63,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         jsons = jsonfile.read()
         jsonfile.close()
         jsonDict = json.loads(jsons)
-        jsonDict["crosswalk_app_version"] = "0.1"
+        jsonDict["xwalk_app_version"] = "0.1"
         json.dump(jsonDict, open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "w"))
         with open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json") as json_file:
             data = json.load(json_file)
@@ -76,9 +76,9 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
                 versionName_xml = attributes[x]
                 break
         comm.clear("org.xwalk.test")
-        self.assertEquals(data['crosswalk_app_version'].strip("\n\t"), "0.1")
+        self.assertEquals(data['xwalk_app_version'].strip("\n\t"), "0.1")
         self.assertEquals(buildstatus, 0)
-        self.assertEquals(data['crosswalk_app_version'].strip("\n\t"), versionName_xml)
+        self.assertEquals(data['xwalk_app_version'].strip("\n\t"), versionName_xml)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Impacted tests(approved): new 0, update 8, delete 0
Unit test platform: [Android]
Unit test result summary: pass 8, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4736