### PR TITLE
[Embeddingapi] Add use case to check PROFILE_NAME in XWalkPreferences

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkPreferencesActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkPreferencesActivity.java
@@ -60,10 +60,12 @@ public class XWalkPreferencesActivity extends Activity implements XWalkInitializ
         XWalkPreferences.setValue(XWalkPreferences.JAVASCRIPT_CAN_OPEN_WINDOW, true);
         XWalkPreferences.setValue(XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS, 3);
         XWalkPreferences.setValue(XWalkPreferences.ALLOW_UNIVERSAL_ACCESS_FROM_FILE, "testSetValue_String");
+        XWalkPreferences.setValue(XWalkPreferences.PROFILE_NAME, "MyDefault");
         XWalkPreferences.getBooleanValue(XWalkPreferences.REMOTE_DEBUGGING);
         XWalkPreferences.getBooleanValue(XWalkPreferences.JAVASCRIPT_CAN_OPEN_WINDOW);
         XWalkPreferences.getIntegerValue(XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS);
         XWalkPreferences.getStringValue(XWalkPreferences.ALLOW_UNIVERSAL_ACCESS_FROM_FILE);
+        XWalkPreferences.getStringValue(XWalkPreferences.PROFILE_NAME);
         mXWalkView.load("http://www.baidu.com/", null);
     }
 }

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkPreferencesActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkPreferencesActivity.java
@@ -40,10 +40,12 @@ public class XWalkPreferencesActivity extends XWalkActivity {
         XWalkPreferences.setValue(XWalkPreferences.JAVASCRIPT_CAN_OPEN_WINDOW, true);
         XWalkPreferences.setValue(XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS, 3);
         XWalkPreferences.setValue(XWalkPreferences.ALLOW_UNIVERSAL_ACCESS_FROM_FILE, "testSetValue_String");
+        XWalkPreferences.setValue(XWalkPreferences.PROFILE_NAME, "MyDefault");
         XWalkPreferences.getBooleanValue(XWalkPreferences.REMOTE_DEBUGGING);
         XWalkPreferences.getBooleanValue(XWalkPreferences.JAVASCRIPT_CAN_OPEN_WINDOW);
         XWalkPreferences.getIntegerValue(XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS);
         XWalkPreferences.getStringValue(XWalkPreferences.ALLOW_UNIVERSAL_ACCESS_FROM_FILE);
+        XWalkPreferences.getStringValue(XWalkPreferences.PROFILE_NAME);
         mXWalkView.load("http://www.baidu.com/", null);
     }
 }


### PR DESCRIPTION
-Add use case to check PROFILE_NAME in XWalkPreferences
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-2375