### PR TITLE
[cordova][hotfix] Improve comm.py for cordova feature cases

### DIFF
--- a/cordova/cordova-feature-android-tests/feature/comm.py
+++ b/cordova/cordova-feature-android-tests/feature/comm.py
@@ -87,12 +87,12 @@ def setUp():
         CORDOVA_VERSION = "3.6"
     f_version.close()
 
-    with open(const_path + "/../VERSION", "rt") as pkg_version_file:
-        pkg_version_raw = pkg_version_file.read()
-        pkg_version_file.close()
-        pkg_version_json = json.loads(pkg_version_raw)
-        CROSSWALK_VERSION = pkg_version_json["main-version"]
-
+    if CORDOVA_VERSION == "4.0":
+        with open(const_path + "/../VERSION", "rt") as pkg_version_file:
+            pkg_version_raw = pkg_version_file.read()
+            pkg_version_file.close()
+            pkg_version_json = json.loads(pkg_version_raw)
+            CROSSWALK_VERSION = pkg_version_json["main-version"]
 
 
 def create(appname, pkgname, mode, sourcecodepath, replace_index_list, self):

--- a/cordova/cordova-sampleapp-android-tests/sampleapp/comm.py
+++ b/cordova/cordova-sampleapp-android-tests/sampleapp/comm.py
@@ -87,12 +87,12 @@ def setUp():
         CORDOVA_VERSION = "3.6"
     f_version.close()
 
-    with open(const_path + "/../VERSION", "rt") as pkg_version_file:
-        pkg_version_raw = pkg_version_file.read()
-        pkg_version_file.close()
-        pkg_version_json = json.loads(pkg_version_raw)
-        CROSSWALK_VERSION = pkg_version_json["main-version"]
-
+    if CORDOVA_VERSION == "4.0":
+        with open(const_path + "/../VERSION", "rt") as pkg_version_file:
+            pkg_version_raw = pkg_version_file.read()
+            pkg_version_file.close()
+            pkg_version_json = json.loads(pkg_version_raw)
+            CROSSWALK_VERSION = pkg_version_json["main-version"]
 
 
 def create(appname, pkgname, mode, sourcecodepath, replace_index_list, self):

--- a/cordova/cordova-webapp-android-tests/webapp/comm.py
+++ b/cordova/cordova-webapp-android-tests/webapp/comm.py
@@ -87,12 +87,12 @@ def setUp():
         CORDOVA_VERSION = "3.6"
     f_version.close()
 
-    with open(const_path + "/../VERSION", "rt") as pkg_version_file:
-        pkg_version_raw = pkg_version_file.read()
-        pkg_version_file.close()
-        pkg_version_json = json.loads(pkg_version_raw)
-        CROSSWALK_VERSION = pkg_version_json["main-version"]
-
+    if CORDOVA_VERSION == "4.0":
+        with open(const_path + "/../VERSION", "rt") as pkg_version_file:
+            pkg_version_raw = pkg_version_file.read()
+            pkg_version_file.close()
+            pkg_version_json = json.loads(pkg_version_raw)
+            CROSSWALK_VERSION = pkg_version_json["main-version"]
 
 
 def create(appname, pkgname, mode, sourcecodepath, replace_index_list, self):


### PR DESCRIPTION
- When build cordova 4.0 app, no need to read VERSION file for crosswalk version, and VERSION file not exist in the release package, so Improve comm.py to ignore the VERSION file

Impacted tests(approved): new 0, update 28, delete 0
Unit test platform: Crosswalk Project for Android 14.43.343.21
Unit test result summary: pass 28, fail 0, block 0