### PR TITLE
[webapi] Add test about getRealPath function

### DIFF
--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_getRealPath.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_getRealPath.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<meta charset="utf-8">
+<title>NativeFileAPI Test: Getting real path of virtual root API has been exposed to native file system</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Chunyanx wang" href="mailto:chunyanx.wang@intel.com">
+<link rel="help" href="https://crosswalk-project.org/jira/browse/XWALK-2455">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+  test(function() {
+    assert_true("getRealPath" in xwalk.experimental.native_file_system,
+    "xwalk.experimental.native_file_system.getRealPath exists");
+
+    test(function() {
+      var realPath = xwalk.experimental.native_file_system.getRealPath("DOWNLOADS");
+      assert_regexp_match(realPath, /^(\/storage)(\/\w+)+(\/Download)$/);
+    }, "Get full path of DOWNLOADS");
+
+    test(function() {
+      var realPath = xwalk.experimental.native_file_system.getRealPath("Downloads");
+      var excepted = xwalk.experimental.native_file_system.getRealPath("DOWNLOADS");
+      assert_equals(realPath, excepted);
+    }, "Insensitive to virtual root character that Downloads has same full path with DOWNLOADS");
+    
+    test(function() {
+      var realPath = xwalk.experimental.native_file_system.getRealPath("MUSIC");
+      assert_regexp_match(realPath, /^(\/storage)(\/\w+)+(\/Music)$/);
+    }, "Get full path of MUSIC");
+  });
+</script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/tests.full.xml
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/tests.full.xml
@@ -627,6 +627,18 @@
           </spec>
         </specs>
       </testcase>
+      <testcase component="Crosswalk APIs/Experimental/Native File System" execution_type="auto" id="NativeFileSystem_getRealPath" priority="P3" purpose="Check if getRealPath function returns the full path of this virtual root" status="approved" type="compliance" subcase="4">
+        <description>
+          <test_script_entry>/opt/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_getRealPath.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getRealPath" element_type="method" interface="NativeFileSystem" section="Storage" specification="Native File System" />
+            <spec_url>https://crosswalk-project.org/jira/browse/XWALK-2455</spec_url>
+            <spec_statement />
+          </spec>
+        </specs>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/tests.xml
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/tests.xml
@@ -263,6 +263,11 @@
           <test_script_entry>/opt/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_requestNativeFileSystem_exist.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk APIs/Experimental/Native File System" execution_type="auto" id="NativeFileSystem_getRealPath" purpose="Check if getRealPath function returns the full path of this virtual root" subcase="4">
+        <description>
+          <test_script_entry>/opt/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_getRealPath.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
There are different real path on arm and x86 devices.
For example, getRealPath("DOWNLOADS") returns "/storage/emulated/0/Download"
on ARM devices, but returns "/storage/sdcard0/Download" on x86 devices.

Impacted TCs num(approved): New 4, Update 0, Delete 0
Unit test Platform: Crosswalk Project for Android 15.44.382.0
Unit test result summary: Pass 4, Fail 0, Blocked 0

https://crosswalk-project.org/jira/browse/XWALK-2455