### PR TITLE
[usecase-cordova] Add XwalkCommandLine usecase

### DIFF
--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-pack_cordova_sample.py is used for auto build Cordova sample apps, including mobilespec, helloworld, remotedebugging, gallery, renamePkg, and except renamePkg only support Cordova 4.0, others support both Cordova 3.6 and Cordova 4.0 build.  
+pack_cordova_sample.py is used for auto build Cordova sample apps, including mobilespec, helloworld, remotedebugging, gallery, renamePkg, xwalkCommandLine, and except renamePkg and xwalkCommandLine only support Cordova 4.0, others support both Cordova 3.6 and Cordova 4.0 build.  
 **Note**: For cordova 4.0 pkg, need to configure crosswalk version in crosswalk-test-suite/VERSION file
 
 ## Pre-conditions
@@ -30,7 +30,7 @@ pack_cordova_sample.py is used for auto build Cordova sample apps, including mob
 ## Usage
 
 * ```./pack_cordova_sample.py -n <pkg-name> --cordova-version <cordova-version> [-m <pkg-mode>] [-a <pkg-arch>] [--tools=<tools-path>]```  
-**pkg-name**: mobilespec, helloworld, remotedebugging, gallery, CIRC, statusbar, renamePkg  
+**pkg-name**: mobilespec, helloworld, remotedebugging, gallery, CIRC, statusbar, renamePkg, xwalkCommandLine  
 **cordova-version**: 3.6, 4.0  
 **pkg-mode**: embedded(default), shared  
 **pkg-arch**: arm(default), x86  

--- a/tools/build/pack_cordova_sample.py
+++ b/tools/build/pack_cordova_sample.py
@@ -53,7 +53,7 @@ sys.setdefaultencoding('utf8')
 TOOL_VERSION = "v0.1"
 VERSION_FILE = "VERSION"
 DEFAULT_CMD_TIMEOUT = 600
-PKG_NAMES = ["gallery", "helloworld", "remotedebugging", "mobilespec", "CIRC", "Eh", "statusbar", "renamePkg"]
+PKG_NAMES = ["gallery", "helloworld", "remotedebugging", "mobilespec", "CIRC", "Eh", "statusbar", "renamePkg", "xwalkCommandLine"]
 CORDOVA_VERSIONS = ["3.6", "4.0"]
 PKG_MODES = ["shared", "embedded"]
 PKG_ARCHS = ["x86", "arm"]
@@ -998,6 +998,20 @@ def packSampleApp_cli(app_name=None):
         if not replaceKey(os.path.join(project_root, "config.xml"),
                           "id=\"com.test.renamePkg\"",
                           "id=\"com.example.renamePkg\""):
+            os.chdir(orig_dir)
+            return False
+
+    if checkContains(app_name, "xwalkCommandLine"):
+        if not replaceKey(os.path.join(project_root, "config.xml"),
+                          "value=\"--disable-pull-to-refresh-effect --disable-webrtc" \
+                          "--disable-webgl\"",
+                          "value=\"--disable-pull-to-refresh-effect\""):
+            os.chdir(orig_dir)
+            return False
+        if not doCopy(os.path.join(BUILD_PARAMETERS.pkgpacktools,
+                "..", "usecase", "usecase-cordova-android-tests",
+                "samples", "XwalkCommandLine", "res", "index.html"),
+                os.path.join(project_root, "www", "index.html")):
             os.chdir(orig_dir)
             return False
 

--- a/usecase/usecase-cordova-android-tests/samples/XwalkCommandLine/REAMDE.md
+++ b/usecase/usecase-cordova-android-tests/samples/XwalkCommandLine/REAMDE.md
@@ -1,0 +1,6 @@
+## Usecase Design
+
+This sample demonstrates CROSSWALK_ANDROID_COMMANDLINE config feature basic functionalities, include:
+
+* <preference name="CROSSWALK_ANDROID_COMMANDLINE" value="--disable-pull-to-refresh-effect --disable-webrtc --disable-webgl" />
+

--- a/usecase/usecase-cordova-android-tests/samples/XwalkCommandLine/index.html
+++ b/usecase/usecase-cordova-android-tests/samples/XwalkCommandLine/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Zhu, Yongyong <yongyongx.zhu@intel.com>
+
+-->
+
+<meta charset="utf-8" />
+<meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, width=device-width" />
+<link rel="stylesheet" type="text/css" href="../../css/bootstrap.css">
+<link rel="stylesheet" type="text/css" href="../../css/main.css">
+<script src="../../js/jquery-2.1.3.min.js"></script>
+<script src="../../js/bootstrap.min.js"></script>
+<script src="../../js/common.js"></script>
+<script src="../../js/tests.js"></script>
+
+<div id="header">
+  <h3 id="main_page_title"></h3>
+</div>
+<div class="content">
+  <h4>Note</h4>
+  <ol>
+    <li>It's only for Cordova version 4.0</li>
+  </ol>
+  <h4>Test Steps</h4>
+  <ol>
+    <li>Get cordova4.0_sampleapp.zip from internal release link, then unzip it to /tmp/cordova-sampleapp/</li>
+    <li>Install statusbar.apk</li>
+      <div>
+        $ adb install /tmp/cordova-sampleapp/xwalkCommandLine.apk<br/>
+      </div>
+    <li>Launch and Run the app</li>
+    <li>Pull down the app page</li>
+    <li>Check the app screen</li>
+  </ol>
+</div>
+<div class="footer">
+  <div id="footer"></div>
+</div>
+<div class="modal fade" id="popup_info">
+</div>

--- a/usecase/usecase-cordova-android-tests/samples/XwalkCommandLine/res/index.html
+++ b/usecase/usecase-cordova-android-tests/samples/XwalkCommandLine/res/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu,Yuhan <yuhanx.xu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>webgl_webrtc_disable_tests</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="">
+<meta name="flags" content="">
+<meta name="assert" content="Check if can disable the WebGL and WebRTC API.">
+<body>
+  <p>Disable WebGL:</p>
+  <div id="test1" style="color:red">Fail</div>
+  <canvas id="canvas"></canvas>
+  <p>Disable WebRTC:</p>
+  <div id="test2" style="color:red">Fail</div>
+  <script>
+      var t1 = document.getElementById('test1');
+      var t2 = document.getElementById('test2');
+
+      try{
+          var webgl = null;
+          var canvasObject = document.getElementById('canvas');
+          webgl = canvasObject.getContext("experimental-webgl");
+
+          if (!webgl) {
+              t1.innerHTML = "Pass";
+              t1.style.color = "green";
+          }
+      } catch (e) {
+          t1.innerHTML = "Pass";
+          t1.style.color = "green";
+      }
+
+      try{
+          var pc = null;
+          window.RTCPeerConnection = window.RTCPeerConnection || window.webkitRTCPeerConnection;
+          pc = new RTCPeerConnection({"iceServers":[]});
+
+          if (!pc) {
+              t2.innerHTML = "Pass";
+              t2.style.color = "green";
+          }
+      } catch (e) {
+          t2.innerHTML = "Pass";
+          t2.style.color = "green";
+      }
+  </script>
+</body>

--- a/usecase/usecase-cordova-android-tests/steps/XwalkCommandLine/step.js
+++ b/usecase/usecase-cordova-android-tests/steps/XwalkCommandLine/step.js
@@ -1,0 +1,11 @@
+var step = '<font class="fontSize">'
+            +'<p>Purpose:</p>'
+            +'<p>Verify the CROSSWALK_ANDROID_COMMANDLINE config feature</p>'
+            +'<p>Expected Results:</p>'
+            +'<ol>'
+            +'<li>The app can be installed successfully</li>'
+            +'<li>The app can launch and run successfully</li>'
+            +'<li>The app page does not refresh and not cause ugly behaviour</li>'
+            +'<li>There are green "Pass" below "Disable WebGL" and "Disable WebRTC" on the app page</li>'
+            +'</ol>'
+          +'</font>';

--- a/usecase/usecase-cordova-android-tests/tests.full.xml
+++ b/usecase/usecase-cordova-android-tests/tests.full.xml
@@ -37,6 +37,8 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/Cordova" execution_type="manual" platform="android" priority="P0" status="approved" type="functional_positive" id="RenamePkg" purpose="RenamePkg Test">
       </testcase>
+      <testcase component="Crosswalk Use Cases/Cordova" execution_type="manual" platform="android" priority="P0" status="approved" type="functional_positive" id="XwalkCommandLine" purpose="XwalkCommandLine Test">
+      </testcase>
     </set>
     <set name="Cordova" background="bs-purple-lighter1" icon="glyphicon-sound-dolby">
       <testcase component="sample" type="functional_positive" status="approved" execution_type="manual" platform="android" priority="P0" id="CordovaInfo" purpose="CordovaInfo">

--- a/usecase/usecase-cordova-android-tests/tests.xml
+++ b/usecase/usecase-cordova-android-tests/tests.xml
@@ -37,6 +37,8 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/Cordova" execution_type="manual" id="RenamePkg" purpose="RenamePkg Test">
       </testcase>
+      <testcase component="Crosswalk Use Cases/Cordova" execution_type="manual" id="XwalkCommandLine" purpose="XwalkCommandLine Test">
+      </testcase>
     </set>
     <set name="Cordova" background="bs-purple-lighter1" icon="glyphicon-sound-dolby">
       <testcase component="sample" execution_type="manual" id="CordovaInfo" purpose="CordovaInfo">


### PR DESCRIPTION
- Check --disable-pull-to-refresh-effect --disable-webrtc and --disable-webgl for XwalkCommandLine
- Failure Analyse: XWALK-4415

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: Crosswalk Project for Android 15.44.382.0
Unit test result summary: pass 0, fail 1, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4792