### PR TITLE
[webapi] Add subcase support for Transitions,Resourcetiming,Websocket,Usertiming

### DIFF
--- a/webapi/tct-transitions-css3-tests/tests.full.xml
+++ b/webapi/tct-transitions-css3-tests/tests.full.xml
@@ -9,9 +9,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function_tag</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -21,7 +21,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/</spec_url>
             <spec_statement>note that order is important in this property. The first value that can be parsed as a time is assigned to the transition-duration. The second value that can be parsed as a time is assigned to transition-delay</spec_statement>
           </spec>
@@ -33,9 +33,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-delay" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-delay" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-delay</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -45,9 +45,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-delay" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-delay" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-delay</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -57,9 +57,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-delay" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-delay" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-delay</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -69,9 +69,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-duration" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-duration" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-duration</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -81,9 +81,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-duration" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-duration" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-duration</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -93,9 +93,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-property" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-property" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-property</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -105,9 +105,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-property</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -117,9 +117,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/</spec_url>
-            <spec_statement>a negative value for transition-duration is treated as &#8216;0&#8217;.</spec_statement>
+            <spec_statement>a negative value for transition-duration is treated as ‘0’.</spec_statement>
           </spec>
         </specs>
       </testcase>
@@ -129,9 +129,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-duration" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-duration" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-duration</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -141,9 +141,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-property" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-property" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-property</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -153,16 +153,16 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="css3_transition_tests_entry5" priority="P3" purpose="To check if the remove of transition properties can work properly" status="approved" type="compliance">
         <description>
-          <pre_condition />
-          <post_condition />
+          <pre_condition/>
+          <post_condition/>
           <steps>
             <step order="1">
               <step_desc>Removes the transition properties while the transition is running, then adds them back in.</step_desc>
@@ -173,16 +173,16 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-property-property</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="css3_transition_tests_entry6" priority="P3" purpose="To check if changes  transition-duration while the transition is running to ensure that the running transition is not affected" status="approved" type="compliance">
         <description>
-          <pre_condition />
-          <post_condition />
+          <pre_condition/>
+          <post_condition/>
           <steps>
             <step order="1">
               <step_desc>Changes transition-duration while the transition is running</step_desc>
@@ -193,16 +193,16 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-duration-property</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="transition-end-event-nested" priority="P3" purpose="Test transitionend event" status="approved" type="compliance">
         <description>
-          <pre_condition />
-          <post_condition />
+          <pre_condition/>
+          <post_condition/>
           <steps>
             <step order="1">
               <step_desc>Use WRT to visit the test script file to check if TransitionEnd can implement transitionend event normally</step_desc>
@@ -213,9 +213,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-events</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -225,9 +225,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-property" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-property" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3"/>
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-property-property</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>

--- a/webapi/tct-transitions-css3-tests/tests.full.xml
+++ b/webapi/tct-transitions-css3-tests/tests.full.xml
@@ -111,9 +111,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-duration_negative" priority="P3" purpose="Check if a negative value for transition-duration is treated as 0" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transition-duration-001" priority="P3" purpose="Test transition-duration" status="approved" type="compliance" subcase="21">
         <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-duration-001.html?total_num=21&amp;locator_key=id&amp;value=11</test_script_entry>
+          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-duration-001.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -135,9 +135,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-property_none" priority="P2" purpose="Check if the transition-property value is none" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transition-property-001" priority="P2" purpose="Test transition-property" status="approved" type="compliance" subcase="5">
         <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-property-001.html?total_num=5&amp;locator_key=id&amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-property-001.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -147,158 +147,14 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-property_all" priority="P2" purpose="Check if the transition-property value is all" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transition-timing-function-001" priority="P2" purpose="Test transition-timing-function" status="approved" type="compliance" subcase="20">
         <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-property-001.html?total_num=5&amp;locator_key=id&amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-property" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_ease" priority="P2" purpose="Check if the transition-timing-function value is ease" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html</test_script_entry>
         </description>
         <specs>
           <spec>
             <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
             <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_easein" priority="P2" purpose="Check if the transition-timing-function value is ease-in" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_easeout" priority="P2" purpose="Check if the transition-timing-function value is ease-out" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_easeinout" priority="P2" purpose="Check if the transition-timing-function value is ease-in-out" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=5</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_step-start" priority="P2" purpose="To check if 'transition-timing-function' can set 'step-start'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=6</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_step-end" priority="P2" purpose="To check if 'transition-timing-function' can set 'step-end'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=7</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_cubic-bezier_x_range" priority="P2" purpose="To check if 'transition-timing-function' can set 'cubic-bezier' with x [0, 1]" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=8</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_cubic-bezier_y_exceed" priority="P2" purpose="To check if 'transition-timing-function' can set 'cubic-bezier' with y exceed [0, 1]" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=10</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_steps_start" priority="P2" purpose="To check if 'transition-timing-function' can set 'steps(integer, start)'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=11</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_steps_end" priority="P2" purpose="To check if 'transition-timing-function' can set 'steps(integer, end)'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=12</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_steps_integer" priority="P2" purpose="To check if 'transition-timing-function' can set 'steps(integer)'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=13</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_cubic-bezier_x_invalid" priority="P2" purpose="To check if 'transition-timing-function' can set 'cubic-bezier' with invalid x coordinate" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=20</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-timing-function" element_type="property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-timing-function-property</spec_url>
             <spec_statement />
           </spec>
         </specs>
@@ -343,17 +199,17 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="css3_transition_tests_entry25" priority="P3" purpose="To check if left can implement transitionend event normally" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="transition-end-event-nested" priority="P3" purpose="Test transitionend event" status="approved" type="compliance">
         <description>
           <pre_condition />
           <post_condition />
           <steps>
             <step order="1">
               <step_desc>Use WRT to visit the test script file to check if TransitionEnd can implement transitionend event normally</step_desc>
-              <expected>Background-color property missed</expected>
+              <expected>PASS</expected>
             </step>
           </steps>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/webkit/transition-end-event-nested-manual.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/webkit/transition-end-event-nested-manual.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -363,217 +219,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="css3_transition_tests_entry26" priority="P3" purpose="To check if background-color can implement transitionend event normally" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transitions-animatable-properties-01" priority="P1" purpose="Test animatable CSS properties" status="approved" type="compliance" onload_delay="60" subcase="94">
         <description>
-          <pre_condition />
-          <post_condition />
-          <steps>
-            <step order="1">
-              <step_desc>Use WRT to visit the test script file to check if TransitionEnd can implement transitionend event normally</step_desc>
-              <expected>Left property missed</expected>
-            </step>
-          </steps>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/webkit/transition-end-event-nested-manual.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-events</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="css3_transition_tests_entry27" priority="P3" purpose="To check if width can implement transitionend event normally" status="approved" type="compliance">
-        <description>
-          <pre_condition />
-          <post_condition />
-          <steps>
-            <step order="1">
-              <step_desc>Use WRT to visit the test script file to check if TransitionEnd can implement transitionend event normally</step_desc>
-              <expected>Width property missed</expected>
-            </step>
-          </steps>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/webkit/transition-end-event-nested-manual.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-events</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry21" priority="P1" purpose="To check if shorthand properties background-color can implement transition-property function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-property" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-property-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry1" priority="P2" purpose="To check if  transition-property:background-position can implement transition-property function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-property" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-property-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry10" priority="P2" purpose="To check if  border-bottom-color can implement transition function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transitions</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry14" priority="P1" purpose="To check if border-bottom-width can implement transition function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transitions</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry11" priority="P2" purpose="To check if  border-left-color can implement transition function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transitions</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry15" priority="P2" purpose="To check if  border-left-width can implement transition function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transitions</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry9" priority="P2" purpose="To check if  border-right-color can implement transition function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transitions</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry13" priority="P2" purpose="To check if  border-right-width can implement transition function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transitions</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry8" priority="P2" purpose="To check if  border-top-color can implement transition function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=21</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transitions</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry12" priority="P2" purpose="To check if  border-top-width can implement transition function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=23</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transitions</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry7" priority="P1" purpose="To check if  transition-property:left can implement transition-property function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=39</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-delay-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry19" priority="P1" purpose="To check if shorthand properties margin-top can implement transition-property function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=51</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-property" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-property-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry20" priority="P1" purpose="To check if shorthand properties outline-color can implement transition-property function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=63</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-property" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-property-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry18" priority="P1" purpose="To check if shorthand properties padding-top can implement transition-property function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=75</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="transition-property" element_type="Property" interface="CSS" section="DOM, Forms and Styles" specification="CSS Transitions Module Level 3" />
-            <spec_url>http://www.w3.org/TR/2012/WD-css3-transitions-20120403/#transition-property-property</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry28" priority="P1" purpose="To check if  transition-property:top can implement transition-property function normally" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=83</test_script_entry>
+          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html</test_script_entry>
         </description>
         <specs>
           <spec>

--- a/webapi/tct-transitions-css3-tests/tests.full.xml
+++ b/webapi/tct-transitions-css3-tests/tests.full.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="tct-transitions-css3-tests">
     <set name="Transitions" type="js">
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function" priority="P1" purpose="To check if css.transition-timing-function exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-timing-function" priority="P1" purpose="To check if css.transition-timing-function exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-timing-function.html</test_script_entry>
         </description>
@@ -15,7 +15,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition_4s_1s" priority="P3" purpose="Check if the first value that can be parsed as a time is assigned to the transition-duration,the second is transition-delay" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition_4s_1s" priority="P3" purpose="Check if the first value that can be parsed as a time is assigned to the transition-duration,the second is transition-delay" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition_4s_1s.html</test_script_entry>
         </description>
@@ -27,7 +27,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-delay_0s" priority="P2" purpose="Check if the transition-delay value is 0s" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-delay_0s" priority="P2" purpose="Check if the transition-delay value is 0s" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-delay_0s.html</test_script_entry>
         </description>
@@ -39,7 +39,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-delay_4s_1s" priority="P2" purpose="Check if the transition-delay value is 4s and 1s" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-delay_4s_1s" priority="P2" purpose="Check if the transition-delay value is 4s and 1s" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-delay_4s_1s.html</test_script_entry>
         </description>
@@ -51,7 +51,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-delay_initial_value" priority="P2" purpose="Check if the transition-delay initial value is 0s" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-delay_initial_value" priority="P2" purpose="Check if the transition-delay initial value is 0s" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-delay_initial_value.html</test_script_entry>
         </description>
@@ -63,7 +63,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-duration_4s" priority="P2" purpose="Check if the transition-duration value is 4s" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-duration_4s" priority="P2" purpose="Check if the transition-duration value is 4s" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-duration_4s.html</test_script_entry>
         </description>
@@ -75,7 +75,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-duration_initial_value" priority="P2" purpose="Check if the transition-duration initial value is 0s" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-duration_initial_value" priority="P2" purpose="Check if the transition-duration initial value is 0s" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-duration_initial_value.html</test_script_entry>
         </description>
@@ -87,7 +87,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-property_initial_value" priority="P2" purpose="Check if the transition-property initial value is all" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-property_initial_value" priority="P2" purpose="Check if the transition-property initial value is all" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-property_initial_value.html</test_script_entry>
         </description>
@@ -99,7 +99,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_initial_value" priority="P2" purpose="Check if the transition-timing-function initial value is ease" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-timing-function_initial_value" priority="P2" purpose="Check if the transition-timing-function initial value is ease" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-timing-function_initial_value.html</test_script_entry>
         </description>
@@ -111,7 +111,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transition-duration-001" priority="P3" purpose="Test transition-duration" status="approved" type="compliance" subcase="21">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="transition-duration-001" priority="P3" purpose="Test transition-duration" status="approved" type="compliance" subcase="21">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-duration-001.html</test_script_entry>
         </description>
@@ -123,7 +123,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-duration_4s_1s" priority="P2" purpose="Check if the transition-duration value is 4s and 1s" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-duration_4s_1s" priority="P2" purpose="Check if the transition-duration value is 4s and 1s" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-duration_4s_1s.html</test_script_entry>
         </description>
@@ -135,7 +135,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transition-property-001" priority="P2" purpose="Test transition-property" status="approved" type="compliance" subcase="5">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="transition-property-001" priority="P2" purpose="Test transition-property" status="approved" type="compliance" subcase="5">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-property-001.html</test_script_entry>
         </description>
@@ -147,7 +147,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transition-timing-function-001" priority="P2" purpose="Test transition-timing-function" status="approved" type="compliance" subcase="20">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="transition-timing-function-001" priority="P2" purpose="Test transition-timing-function" status="approved" type="compliance" subcase="20">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html</test_script_entry>
         </description>
@@ -159,7 +159,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="css3_transition_tests_entry5" priority="P3" purpose="To check if the remove of transition properties can work properly" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="manual" id="css3_transition_tests_entry5" priority="P3" purpose="To check if the remove of transition properties can work properly" status="approved" type="compliance">
         <description>
           <pre_condition/>
           <post_condition/>
@@ -179,7 +179,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="css3_transition_tests_entry6" priority="P3" purpose="To check if changes  transition-duration while the transition is running to ensure that the running transition is not affected" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="manual" id="css3_transition_tests_entry6" priority="P3" purpose="To check if changes  transition-duration while the transition is running to ensure that the running transition is not affected" status="approved" type="compliance">
         <description>
           <pre_condition/>
           <post_condition/>
@@ -199,7 +199,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="transition-end-event-nested" priority="P3" purpose="Test transitionend event" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="manual" id="transition-end-event-nested" priority="P3" purpose="Test transitionend event" status="approved" type="compliance">
         <description>
           <pre_condition/>
           <post_condition/>
@@ -219,7 +219,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transitions-animatable-properties-01" priority="P1" purpose="Test animatable CSS properties" status="approved" type="compliance" onload_delay="60" subcase="94">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="transitions-animatable-properties-01" priority="P1" purpose="Test animatable CSS properties" status="approved" type="compliance" onload_delay="60" subcase="94">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html</test_script_entry>
         </description>

--- a/webapi/tct-transitions-css3-tests/tests.xml
+++ b/webapi/tct-transitions-css3-tests/tests.xml
@@ -3,72 +3,72 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="tct-transitions-css3-tests">
     <set name="Transitions" type="js">
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function" purpose="To check if css.transition-timing-function exists">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-timing-function" purpose="To check if css.transition-timing-function exists">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-timing-function.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition_4s_1s" purpose="Check if the first value that can be parsed as a time is assigned to the transition-duration,the second is transition-delay">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition_4s_1s" purpose="Check if the first value that can be parsed as a time is assigned to the transition-duration,the second is transition-delay">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition_4s_1s.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-delay_0s" purpose="Check if the transition-delay value is 0s">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-delay_0s" purpose="Check if the transition-delay value is 0s">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-delay_0s.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-delay_4s_1s" purpose="Check if the transition-delay value is 4s and 1s">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-delay_4s_1s" purpose="Check if the transition-delay value is 4s and 1s">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-delay_4s_1s.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-delay_initial_value" purpose="Check if the transition-delay initial value is 0s">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-delay_initial_value" purpose="Check if the transition-delay initial value is 0s">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-delay_initial_value.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-duration_4s" purpose="Check if the transition-duration value is 4s">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-duration_4s" purpose="Check if the transition-duration value is 4s">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-duration_4s.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-duration_initial_value" purpose="Check if the transition-duration initial value is 0s">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-duration_initial_value" purpose="Check if the transition-duration initial value is 0s">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-duration_initial_value.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-property_initial_value" purpose="Check if the transition-property initial value is all">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-property_initial_value" purpose="Check if the transition-property initial value is all">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-property_initial_value.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_initial_value" purpose="Check if the transition-timing-function initial value is ease">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-timing-function_initial_value" purpose="Check if the transition-timing-function initial value is ease">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-timing-function_initial_value.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transition-duration-001" purpose="Test transition-duration" subcase="21">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="transition-duration-001" purpose="Test transition-duration" subcase="21">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-duration-001.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-duration_4s_1s" purpose="Check if the transition-duration value is 4s and 1s">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="CSS3Transitions_transition-duration_4s_1s" purpose="Check if the transition-duration value is 4s and 1s">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-duration_4s_1s.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transition-property-001" purpose="Test transition-property" subcase="5">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="transition-property-001" purpose="Test transition-property" subcase="5">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-property-001.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transition-timing-function-001" purpose="Test transition-timing-function" subcase="20">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="transition-timing-function-001" purpose="Test transition-timing-function" subcase="20">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="css3_transition_tests_entry5" purpose="To check if the remove of transition properties can work properly">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="manual" id="css3_transition_tests_entry5" purpose="To check if the remove of transition properties can work properly">
         <description>
           <pre_condition/>
           <steps>
@@ -80,7 +80,7 @@
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/webkit/cancel-transition-manual.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="css3_transition_tests_entry6" purpose="To check if changes  transition-duration while the transition is running to ensure that the running transition is not affected">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="manual" id="css3_transition_tests_entry6" purpose="To check if changes  transition-duration while the transition is running to ensure that the running transition is not affected">
         <description>
           <pre_condition/>
           <steps>
@@ -92,7 +92,7 @@
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/webkit/change-values-during-transition-manual.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="transition-end-event-nested" purpose="Test transitionend event">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="manual" id="transition-end-event-nested" purpose="Test transitionend event">
         <description>
           <pre_condition/>
           <steps>
@@ -104,7 +104,7 @@
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/webkit/transition-end-event-nested-manual.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transitions-animatable-properties-01" purpose="Test animatable CSS properties" onload_delay="60" subcase="94">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3" execution_type="auto" id="transitions-animatable-properties-01" purpose="Test animatable CSS properties" onload_delay="60" subcase="94">
         <description>
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html</test_script_entry>
         </description>

--- a/webapi/tct-transitions-css3-tests/tests.xml
+++ b/webapi/tct-transitions-css3-tests/tests.xml
@@ -48,9 +48,9 @@
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-timing-function_initial_value.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-duration_negative" purpose="Check if a negative value for transition-duration is treated as 0">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transition-duration-001" purpose="Test transition-duration" subcase="21">
         <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-duration-001.html?total_num=21&amp;locator_key=id&amp;value=11</test_script_entry>
+          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-duration-001.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-duration_4s_1s" purpose="Check if the transition-duration value is 4s and 1s">
@@ -58,74 +58,14 @@
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/CSS3Transitions_transition-duration_4s_1s.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-property_none" purpose="Check if the transition-property value is none">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transition-property-001" purpose="Test transition-property" subcase="5">
         <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-property-001.html?total_num=5&amp;locator_key=id&amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-property-001.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-property_all" purpose="Check if the transition-property value is all">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transition-timing-function-001" purpose="Test transition-timing-function" subcase="20">
         <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-property-001.html?total_num=5&amp;locator_key=id&amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_ease" purpose="Check if the transition-timing-function value is ease">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_easein" purpose="Check if the transition-timing-function value is ease-in">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_easeout" purpose="Check if the transition-timing-function value is ease-out">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_easeinout" purpose="Check if the transition-timing-function value is ease-in-out">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=5</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_step-start" purpose="To check if 'transition-timing-function' can set 'step-start'">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=6</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_step-end" purpose="To check if 'transition-timing-function' can set 'step-end'">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=7</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_cubic-bezier_x_range" purpose="To check if 'transition-timing-function' can set 'cubic-bezier' with x [0, 1]">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=8</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_cubic-bezier_y_exceed" purpose="To check if 'transition-timing-function' can set 'cubic-bezier' with y exceed [0, 1]">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=10</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_steps_start" purpose="To check if 'transition-timing-function' can set 'steps(integer, start)'">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=11</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_steps_end" purpose="To check if 'transition-timing-function' can set 'steps(integer, end)'">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=12</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_steps_integer" purpose="To check if 'transition-timing-function' can set 'steps(integer)'">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=13</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="CSS3Transitions_transition-timing-function_cubic-bezier_x_invalid" purpose="To check if 'transition-timing-function' can set 'cubic-bezier' with invalid x coordinate">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html?total_num=20&amp;locator_key=id&amp;value=20</test_script_entry>
+          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/csswg/transition-timing-function-001.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="css3_transition_tests_entry5" purpose="To check if the remove of transition properties can work properly">
@@ -152,115 +92,21 @@
           <test_script_entry>/opt/tct-transitions-css3-tests/transitions/webkit/change-values-during-transition-manual.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="css3_transition_tests_entry25" purpose="To check if left can implement transitionend event normally">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="transition-end-event-nested" purpose="Test transitionend event">
         <description>
           <pre_condition/>
           <steps>
             <step order="1">
               <step_desc>Use WRT to visit the test script file to check if TransitionEnd can implement transitionend event normally</step_desc>
-              <expected>Background-color property missed</expected>
+              <expected>PASS</expected>
             </step>
           </steps>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/webkit/transition-end-event-nested-manual.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/webkit/transition-end-event-nested-manual.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="css3_transition_tests_entry26" purpose="To check if background-color can implement transitionend event normally">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="transitions-animatable-properties-01" purpose="Test animatable CSS properties" onload_delay="60" subcase="94">
         <description>
-          <pre_condition/>
-          <steps>
-            <step order="1">
-              <step_desc>Use WRT to visit the test script file to check if TransitionEnd can implement transitionend event normally</step_desc>
-              <expected>Left property missed</expected>
-            </step>
-          </steps>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/webkit/transition-end-event-nested-manual.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="manual" id="css3_transition_tests_entry27" purpose="To check if width can implement transitionend event normally">
-        <description>
-          <pre_condition/>
-          <steps>
-            <step order="1">
-              <step_desc>Use WRT to visit the test script file to check if TransitionEnd can implement transitionend event normally</step_desc>
-              <expected>Width property missed</expected>
-            </step>
-          </steps>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/webkit/transition-end-event-nested-manual.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry21" purpose="To check if shorthand properties background-color can implement transition-property function normally" onload_delay="30">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry1" purpose="To check if  transition-property:background-position can implement transition-property function normally" onload_delay="20">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry10" purpose="To check if  border-bottom-color can implement transition function normally" onload_delay="20">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry14" purpose="To check if border-bottom-width can implement transition function normally" onload_delay="20">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry11" purpose="To check if  border-left-color can implement transition function normally" onload_delay="20">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry15" purpose="To check if  border-left-width can implement transition function normally">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry9" purpose="To check if  border-right-color can implement transition function normally">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry13" purpose="To check if  border-right-width can implement transition function normally">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry8" purpose="To check if  border-top-color can implement transition function normally">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=21</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry12" purpose="To check if  border-top-width can implement transition function normally">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=23</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry7" purpose="To check if  transition-property:left can implement transition-property function normally">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=39</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry19" purpose="To check if shorthand properties margin-top can implement transition-property function normally">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=51</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry20" purpose="To check if shorthand properties outline-color can implement transition-property function normally">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=63</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry18" purpose="To check if shorthand properties padding-top can implement transition-property function normally">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=75</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transitions Module Level 3 (Partial)" execution_type="auto" id="css3_transition_tests_entry28" purpose="To check if  transition-property:top can implement transition-property function normally">
-        <description>
-          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html?total_num=94&amp;amp;locator_key=id&amp;amp;value=83</test_script_entry>
+          <test_script_entry>/opt/tct-transitions-css3-tests/transitions/w3c/transitions-animatable-properties-01.html</test_script_entry>
         </description>
       </testcase>
     </set>

--- a/webapi/tct-websocket-w3c-tests/tests.full.xml
+++ b/webapi/tct-websocket-w3c-tests/tests.full.xml
@@ -171,7 +171,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="BinaryType_wrong_value" onload_delay="10" priority="P2" purpose="Check if Secure WebSocket created when the binaryType is set to something other than blob/arraybuffer" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="binaryType-wrong-value" onload_delay="10" priority="P2" purpose="Test WebSockets: binaryType wrong value" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/binaryType-wrong-value.htm</test_script_entry>
         </description>
@@ -1011,7 +1011,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create_invalid_urls" priority="P2" purpose="Check if the SyntaxError exception thrown when created by an invalid url " status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-invalid-urls" priority="P2" purpose="Test WebSockets: Create invalid urls" status="approved" type="compliance" subcase="5">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Create-invalid-urls.htm</test_script_entry>
         </description>
@@ -1179,7 +1179,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_65K_data" onload_delay="10" priority="P2" purpose="Check if Secure WebSocket when Send 65K data" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-65K-data" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Send 65K data" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-65K-data.htm</test_script_entry>
         </description>
@@ -1191,7 +1191,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_65k_data" onload_delay="10" priority="P2" purpose="Check if 64k byte data can be received after 65k data send on a WebSocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-65K-data" onload_delay="10" priority="P2" purpose="Test WebSockets: Send 65K data" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Send-65K-data.htm</test_script_entry>
         </description>
@@ -1202,7 +1202,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_protocol_string" onload_delay="10" priority="P2" purpose="Check if connection can be opened or closed after open or close a secure WebSocket with a valid URL and protocol string" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-Secure-valid-url-protocol-string" onload_delay="10" priority="P2" purpose="Test WebSockets: Create Secure valid url protocol string" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-protocol-string.htm</test_script_entry>
         </description>
@@ -1213,7 +1213,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_server_initiated_close" onload_delay="10" priority="P2" purpose="Check if the connnection works when open or close a secure WebSocket with server initiated close" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-server-initiated-close" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Close server initiated close" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-server-initiated-close.htm</test_script_entry>
         </description>
@@ -1224,7 +1224,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_4999_reason" onload_delay="10" priority="P2" purpose="Check if the connection works when open or close a secure WebSocket with 4999 code and reason" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-4999-reason" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Close 4999 reason" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-4999-reason.htm</test_script_entry>
         </description>
@@ -1235,7 +1235,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_valid_url_protocol" onload_delay="10" priority="P2" purpose="Check if connection can be opened or closed after open or close a WebSocket with a valid URL and a protocol" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-valid-url-protocol" onload_delay="10" priority="P2" purpose="Test WebSockets: Create valid url protocol" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-valid-url-protocol.htm</test_script_entry>
         </description>
@@ -1246,7 +1246,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_extensions_empty" onload_delay="10" priority="P2" purpose="Check if the websocket connection with an empty extension can be opened or closed successfully" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-Secure-extensions-empty" onload_delay="10" priority="P2" purpose="Test WebSockets: Create Secure extensions empty" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-extensions-empty.htm</test_script_entry>
         </description>
@@ -1257,7 +1257,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_send_null" onload_delay="10" priority="P2" purpose="Check if null can be received when null data send on a Secure WebSocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-null" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Send null" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-null.htm</test_script_entry>
         </description>
@@ -1268,7 +1268,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_binarytype_blob" onload_delay="10" priority="P2" purpose="Check if a open secure WebSocket which binaryType should be set to 'blob' after connection is established." status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-Secure-valid-url-binaryType-blob" onload_delay="10" priority="P2" purpose="Test WebSockets: Create Secure valid url binaryType blob" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-binaryType-blob.htm</test_script_entry>
         </description>
@@ -1279,7 +1279,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_valid_url" onload_delay="10" priority="P2" purpose="Check if the connection works when sending the valid URL" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-valid-url" onload_delay="10" priority="P2" purpose="Test WebSockets: Create valid url" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-valid-url.htm</test_script_entry>
         </description>
@@ -1301,7 +1301,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_send_binary_blob" onload_delay="10" priority="P2" purpose="Check if binary data should be received in blob form when binary data in blob form send on a Secure Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-blob" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Send binary blob" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-blob.htm</test_script_entry>
         </description>
@@ -1312,7 +1312,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_array_protocols" onload_delay="10" priority="P2" purpose="Check if connection works when open or close a secure WebSocket with a valid URL and array of protocol strings" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-Secure-valid-url-array-protocols" onload_delay="10" priority="P2" purpose="Test WebSockets: Create Secure valid url and array protocols" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-array-protocols.htm</test_script_entry>
         </description>
@@ -1323,7 +1323,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_data" onload_delay="10" priority="P2" purpose="Check if data can be received after send data on a Secure WebSocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-data" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Send data" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-data.htm</test_script_entry>
         </description>
@@ -1334,7 +1334,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_3000_reason" onload_delay="10" priority="P2" purpose="Check if the desired wsocket.readyState is equal to 3 and evt.wasClean is true if the websocket call the method close(3000)" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-3000-reason" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Close 3000 reason" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-3000-reason.htm</test_script_entry>
         </description>
@@ -1356,7 +1356,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="close_1000" onload_delay="10" priority="P2" purpose="Check if readystate should be in CLOSED state and wasClean is TRUE after close a WebSocket with 1000 code and reason" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Close-1000" onload_delay="10" priority="P2" purpose="Test WebSockets: close(1000)" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Close-1000.htm</test_script_entry>
         </description>
@@ -1367,7 +1367,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_valid_url_array_protocols" onload_delay="10" priority="P2" purpose="Check if the websocket connection with a valid URL and array of protocols can be opened or closed successfully" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-valid-url-array-protocols" onload_delay="10" priority="P2" purpose="Test WebSockets: Create valid url array protocols" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-valid-url-array-protocols.htm</test_script_entry>
         </description>
@@ -1378,7 +1378,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="send_null" onload_delay="10" priority="P2" purpose="Check if null can be received after null send on a WebSocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-null" onload_delay="10" priority="P2" purpose="Test WebSockets: Send null" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Send-null.htm</test_script_entry>
         </description>
@@ -1389,7 +1389,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url" onload_delay="10" priority="P2" purpose="Check if the connection can be opened or closed after open or close a secure WebSocket with a valid URL" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-Secure-valid-url" onload_delay="10" priority="P2" purpose="Test WebSockets: Create Secure valid url" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url.htm</test_script_entry>
         </description>
@@ -1400,7 +1400,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_protocol_setcorrectly" onload_delay="10" priority="P2" purpose="Check if protocol is set correctly after connection" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-Secure-valid-url-protocol-setCorrectly" onload_delay="10" priority="P2" purpose="Test WebSockets: Create Secure valid url protocol setCorrectly" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-protocol-setCorrectly.htm</test_script_entry>
         </description>
@@ -1411,7 +1411,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="close_1000_reason" onload_delay="10" priority="P2" purpose="Check if readystate can be in CLOSED state and wasClean is TRUE if close a WebSocket with 1000 code and reason" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Close-1000-reason" onload_delay="10" priority="P2" purpose="Test WebSockets: close(1000, reason)" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Close-1000-reason.htm</test_script_entry>
         </description>
@@ -1422,7 +1422,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_1000" onload_delay="10" priority="P2" purpose="Check if readystate can be in CLOSED state and wasClean is TRUE after close a secure WebSocket with 1000 code" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-1000" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Close 1000" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1000.htm</test_script_entry>
         </description>
@@ -1433,7 +1433,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_readystate_closed" onload_delay="10" priority="P2" purpose="Check if readyState is in closed state when onclose is fired" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-readyState-Closed" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Close readyState Closed" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-readyState-Closed.htm</test_script_entry>
         </description>
@@ -1444,7 +1444,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_1000_reason" onload_delay="10" priority="P2" purpose="Check if readystate should be in CLOSED state and wasClean is TRUE after close a secure WebSocket with 1000 code and reason" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-1000-reason" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Close 1000 reason" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1000-reason.htm</test_script_entry>
         </description>
@@ -1455,7 +1455,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="send_0byte_data" onload_delay="10" priority="P2" purpose="Check if null can be received when 0 byte data send on a WebSocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-0byte-data" onload_delay="10" priority="P2" purpose="Test WebSockets: Send 0byte data" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Send-0byte-data.htm</test_script_entry>
         </description>
@@ -1514,7 +1514,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_1000_verify_code" onload_delay="10" priority="P2" purpose="Check if the return code is 1000 when close a secure WebSocket with 1000 code" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-1000-verify-code" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Close 1000 verify code" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1000-verify-code.htm</test_script_entry>
         </description>
@@ -1526,7 +1526,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_1005_verify_code" onload_delay="10" priority="P2" purpose="Check if the return code is 1005 when close a secure WebSocket with 1005 code" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-1005-verify-code" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Close 1005 verify code" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1005-verify-code.htm</test_script_entry>
         </description>
@@ -1538,7 +1538,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_3000_verify_code" onload_delay="10" priority="P2" purpose="Check if the return code is 3000 when close a secure WebSocket with 3000 code" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-3000-verify-code" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Close 3000 verify code" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-3000-verify-code.htm</test_script_entry>
         </description>
@@ -1550,7 +1550,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_65K_arraybuffer" onload_delay="10" priority="P2" purpose="Check if 65 byte data can be received after Send 65K binary data on a Secure Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-65K-arraybuffer" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Send binary 65K arraybuffer" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-65K-arraybuffer.htm</test_script_entry>
         </description>
@@ -1562,7 +1562,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybuffer" onload_delay="10" priority="P2" purpose="Check if binary data should be received when binary data send on a Secure Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybuffer" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Send binary arraybuffer" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybuffer.htm</test_script_entry>
         </description>
@@ -1574,7 +1574,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_paired_surrogates" onload_delay="10" priority="P2" purpose="Check if paired surrogates data should be received when paired surrogates data send on a Secure Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-paired-surrogates" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Send paired surrogates" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-paired-surrogates.htm</test_script_entry>
         </description>
@@ -1586,7 +1586,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_unicode_data" onload_delay="10" priority="P2" purpose="Check if unicode data message should be received when unicode data send on a Secure Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-unicode-data" onload_delay="10" priority="P2" purpose="Test WebSockets: Secure Send unicode data" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-unicode-data.htm</test_script_entry>
         </description>
@@ -1598,7 +1598,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_binary_65K_arraybuffer" onload_delay="10" priority="P2" purpose="Check if 65 byte data can be received after Send 65K binary data send on a WebSocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-binary-65K-arraybuffer" onload_delay="10" priority="P2" purpose="Test WebSockets: Send binary 65K arraybuffer" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-binary-65K-arraybuffer.htm</test_script_entry>
         </description>
@@ -1610,7 +1610,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_binary_arraybuffer" onload_delay="10" priority="P2" purpose="Check if binary data should be received when binary data send on a Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-binary-arraybuffer" onload_delay="10" priority="P2" purpose="Test WebSockets: Send binary arraybuffer" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-binary-arraybuffer.htm</test_script_entry>
         </description>
@@ -1622,7 +1622,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_binary_blob" onload_delay="10" priority="P2" purpose="Check if binary data should be received in blob form when binary data in blob form send on a Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-binary-blob" onload_delay="10" priority="P2" purpose="Test WebSockets: Send binary blob" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-binary-blob.htm</test_script_entry>
         </description>
@@ -1634,7 +1634,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_data" onload_delay="10" priority="P2" purpose="Check if data can be received after data send on a WebSocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-data" onload_delay="10" priority="P2" purpose="Test WebSockets: Send data" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-data.htm</test_script_entry>
         </description>
@@ -1646,7 +1646,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_paired_surrogates" onload_delay="10" priority="P2" purpose="Check if paired surrogates data should be received when paired surrogates data send on a Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-paired-surrogates" onload_delay="10" priority="P2" purpose="Test WebSockets: Send paired surrogates" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-paired-surrogates.htm</test_script_entry>
         </description>
@@ -1658,7 +1658,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_unicode_data" onload_delay="10" priority="P2" purpose="Check if unicode data message should be received when unicode data send on a Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-unicode-data" onload_delay="10" priority="P2" purpose="Test WebSockets: Send unicode data" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-unicode-data.htm</test_script_entry>
         </description>
@@ -1670,7 +1670,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_float32" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Float32Array type" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-float32" onload_delay="5" priority="P2" purpose="Test WebSockets:  Secure Send binary arraybufferview float32" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-float32.htm</test_script_entry>
         </description>
@@ -1682,7 +1682,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_float64" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Float64Array type" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-float64" onload_delay="5" priority="P2" purpose="Test WebSockets: Secure Send binary arraybufferview float64" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-float64.htm</test_script_entry>
         </description>
@@ -1694,7 +1694,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_int32" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Int32Array type " status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-int32" onload_delay="5" priority="P2" purpose="Test WebSockets: Secure Send binary arraybufferview int32" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-int32.htm</test_script_entry>
         </description>
@@ -1706,7 +1706,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint8_offset" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint8Array type with offset " status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-uint8-offset" onload_delay="5" priority="P2" purpose="Test WebSockets: Secure Send binary arraybufferview uint8 offset" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint8-offset.htm</test_script_entry>
         </description>
@@ -1718,7 +1718,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint8_offset_length" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint8Array type with offset and length " status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-uint8-offset-length" onload_delay="5" priority="P2" purpose="Test WebSockets: Secure Send binary arraybufferview uint8 offset length" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint8-offset-length.htm</test_script_entry>
         </description>
@@ -1730,7 +1730,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint16_offset_length" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint16Array type with offset and length" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-uint16-offset-length" onload_delay="5" priority="P2" purpose="Test WebSockets: Secure Send binary arraybufferview uint16 offset length" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint16-offset-length.htm</test_script_entry>
         </description>
@@ -1742,7 +1742,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint32_offset" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint32Array type with offset" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-uint32-offset" onload_delay="5" priority="P2" purpose="Test WebSockets: Secure Send binary arraybufferview uint32 offset" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint32-offset.htm</test_script_entry>
         </description>
@@ -1754,7 +1754,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_binary_arraybufferview_int8" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Int8Array type" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-binary-arraybufferview-int8" onload_delay="5" priority="P2" purpose="Test WebSockets: Send binary arraybufferview int8" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-binary-arraybufferview-int8.htm</test_script_entry>
         </description>
@@ -1766,7 +1766,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_binary_arraybufferview_int16_offset" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Int16Array type with offset " status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-binary-arraybufferview-int16-offset" onload_delay="5" priority="P2" purpose="Test WebSockets: Send binary arraybufferview int16 offset" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-binary-arraybufferview-int16-offset.htm</test_script_entry>
         </description>
@@ -1874,9 +1874,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_001_1" priority="P1" purpose="Check if WebSocket.CONNECTING exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_001" priority="P1" purpose="Test WebSockets: getting constants on constructor" status="approved" type="compliance" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/001.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1886,45 +1886,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_001_2" priority="P1" purpose="Check if WebSocket.OPEN exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_003" priority="P1" purpose="Test WebSockets: deleting constants" status="approved" type="compliance" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="OPEN" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_001_3" priority="P1" purpose="Check if WebSocket.CLOSING exists" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_001_4" priority="P1" purpose="Check if WebSocket.CLOSED exists" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSED" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_003_1" priority="P1" purpose="Check if can delete the attribute of WebSocket.CONNECTING" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/003.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/003.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1934,45 +1898,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_003_2" priority="P1" purpose="Check if can delete the attribute of WebSocket.OPEN" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004" priority="P1" purpose="Test WebSockets: getting constants on prototype and object" status="approved" type="compliance" subcase="8">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/003.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="OPEN" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_003_3" priority="P1" purpose="Check if can delete the attribute of WebSocket.CLOSING" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/003.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_003_4" priority="P1" purpose="Check if can delete the attribute ofWebSocket.CLOSED" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/003.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSED" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_1" priority="P1" purpose="Check if CONNECTING exists in WebSocket.prototype" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1982,9 +1910,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_2" priority="P1" purpose="Check if CONNECTING exists in WebSocket instance" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_005" priority="P1" purpose="Test WebSockets: defineProperty getter for constants" status="approved" type="compliance" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/005.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1994,169 +1922,13 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_3" priority="P1" purpose="Check if OPEN exists in WebSocket.prototype" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_006" priority="P1" purpose="Test WebSockets: defineProperty setter for constants" status="approved" type="compliance" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="OPEN" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_4" priority="P1" purpose="Check if OPEN exists in WebSocket instance" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="OPEN" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_5" priority="P1" purpose="Check if CLOSING exists in WebSocket.prototype" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_6" priority="P1" purpose="Check if CLOSING exists in WebSocket instance" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_7" priority="P1" purpose="Check if CLOSED exists in WebSocket.prototype" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSED" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_8" priority="P1" purpose="Check if CLOSED exists in WebSocket instance" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSED" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_005_1" priority="P1" purpose="Check if throw TypeError by defineProperty getter for CONNECTING" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/005.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/006.html</test_script_entry>
         </description>
         <specs>
           <spec>
             <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_005_2" priority="P1" purpose="Check if throw TypeError by defineProperty getter for OPEN" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/005.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="OPEN" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_005_3" priority="P1" purpose="Check if throw TypeError by defineProperty getter for CLOSING" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/005.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_005_4" priority="P1" purpose="Check if throw TypeError by defineProperty getter for CLOSED" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/005.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSED" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_006_1" priority="P1" purpose="Check if throw TypeError by defineProperty setter for CONNECTING" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/006.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_006_2" priority="P1" purpose="Check if throw TypeError by defineProperty setter for OPEN" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/006.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="OPEN" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_006_3" priority="P1" purpose="Check if throw TypeError by defineProperty setter for CLOSING" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/006.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_006_4" priority="P1" purpose="Check if throw TypeError by defineProperty setter for CLOSED" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/006.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSED" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
             <spec_statement />
           </spec>
@@ -2174,9 +1946,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_001_1" priority="P1" purpose="Check if onopen attribute nonexist when without define it on WebSocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_001" priority="P1" purpose="Test WebSockets: getting event" status="approved" type="compliance" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/001.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -2186,85 +1958,13 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_001_2" priority="P1" purpose="Check if onmessage attribute nonexist when without define it on WebSocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_002" priority="P1" purpose="Test WebSockets: setting event" status="approved" type="compliance" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_001_3" priority="P1" purpose="Check if onerror attribute nonexist when without define it on WebSocket" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onerror" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_001_4" priority="P1" purpose="Check if onclose attribute nonexist when without define it on WebSocket" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_002_1" priority="P1" purpose="Check if onopen attribute exist after it defined on WebSocket" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/002.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/002.html</test_script_entry>
         </description>
         <specs>
           <spec>
             <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_002_2" priority="P1" purpose="Check if onmessage attribute exist after it defined on WebSocket" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/002.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_002_3" priority="P1" purpose="Check if onerror attribute exist after it defined on WebSocket" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/002.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onerror" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_002_4" priority="P1" purpose="Check if onclose attribute exist after it defined on WebSocket" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/002.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
             <spec_statement />
           </spec>
@@ -2342,9 +2042,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_010_1" priority="P1" purpose="Check if can set onopen event handler to undefined" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_010" priority="P1" purpose="Test WebSockets: setting event handlers to undefined" status="approved" type="compliance" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/010.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -2354,45 +2054,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_010_2" priority="P1" purpose="Check if can set onmessage event handler to undefined" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_011" priority="P1" purpose="Test WebSockets: setting event handlers to 1" status="approved" type="compliance" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_010_3" priority="P1" purpose="Check if can set onerror event handler to undefined" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onerror" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_010_4" priority="P1" purpose="Check if can set onclose event handler to undefined" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_011_1" priority="P1" purpose="Check if can set onopen event handler to 1" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/011.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/011.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -2402,45 +2066,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_011_2" priority="P1" purpose="Check if can set onmessage event handler to 1" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_012" priority="P1" purpose="Test WebSockets: setting event handlers to ';'" status="approved" type="compliance" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/011.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_011_3" priority="P1" purpose="Check if can set onerror event handler to 1" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/011.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onerror" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_011_4" priority="P1" purpose="Check if can set onclose event handler to 1" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/011.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_012_1" priority="P1" purpose="Check if can set onopen event handler to ';'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/012.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/012.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -2450,85 +2078,13 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_012_2" priority="P1" purpose="Check if can set onmessage event handler to ';'" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_014" priority="P1" purpose="Test WebSockets: setting event handlers to null" status="approved" type="compliance" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/012.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_012_3" priority="P1" purpose="Check if can set onerror event handler to ';'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/012.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onerror" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_012_4" priority="P1" purpose="Check if can set onclose event handler to ';'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/012.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_014_1" priority="P1" purpose="Check if can set onopen event handler to null" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/014.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/014.html</test_script_entry>
         </description>
         <specs>
           <spec>
             <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_014_2" priority="P1" purpose="Check if can set onmessage event handler to null" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/014.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_014_3" priority="P1" purpose="Check if can set onerror event handler to null" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/014.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onerror" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_014_4" priority="P1" purpose="Check if can set onclose event handler to null" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/014.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
             <spec_statement />
           </spec>
@@ -2570,49 +2126,13 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_019_1" priority="P1" purpose="Check if can removeEventListener about onopen event handler" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_019" priority="P1" purpose="Test WebSockets: removeEventListener" status="approved" type="compliance" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/019.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/019.html</test_script_entry>
         </description>
         <specs>
           <spec>
             <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_019_2" priority="P1" purpose="Check if can removeEventListener about onmessage event handler" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/019.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_019_3" priority="P1" purpose="Check if can removeEventListener about onerror event handler" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/019.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onerror" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_019_4" priority="P1" purpose="Check if can removeEventListener about onclose event handler" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/019.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
             <spec_statement />
           </spec>
@@ -2738,33 +2258,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_004_1" priority="P1" purpose="Check if throw INVALID_STATE_ERR when send() with lone low surrogate" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_004" priority="P1" purpose="Test WebSockets: send() with unpaired surrogate when readyState is CONNECTING" status="approved" type="compliance" subcase="3">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/send/004.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_004_2" priority="P1" purpose="Check if throw INVALID_STATE_ERR when send() with lone high surrogate" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/send/004.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_004_3" priority="P1" purpose="Check if throw INVALID_STATE_ERR when send() with surrogates in wrong order" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/send/004.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/send/004.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -2846,9 +2342,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_1" priority="P3" purpose="Check if can new WebSocket() with invalid url arg as '/test'" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002" priority="P3" purpose="Test WebSockets: new WebSocket(invalid url)" status="approved" type="compliance" subcase="10">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -2858,115 +2354,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_2" priority="P3" purpose="Check if can new WebSocket() with invalid url arg as 'ws://foo bar.com/'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_3" priority="P3" purpose="Check if can new WebSocket() with invalid url arg as 'wss://foo bar.com/'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_4" priority="P3" purpose="Check if can new WebSocket() with invalid url arg as 'http://location.hostname/'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_5" priority="P3" purpose="Check if can new WebSocket() with invalid url arg as 'mailto:example@example.org'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_6" priority="P3" purpose="Check if can new WebSocket() with invalid url arg as 'about:blank'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_7" priority="P3" purpose="Check if can new WebSocket() with invalid url arg as 'ws://location.hostname/#'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_8" priority="P3" purpose="Check if can new WebSocket() with invalid url arg as 'ws://location.hostname/#test'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_9" priority="P3" purpose="Check if can new WebSocket() with invalid url arg as '?test'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_10" priority="P3" purpose="Check if can new WebSocket() with invalid url arg as '#test'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_004" onload_delay="10" priority="P3" purpose="Check if can new WebSocket() with invalid protocol arg" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_004" onload_delay="10" priority="P3" purpose="Test WebSockets: new WebSocket(url, invalid protocol)" status="approved" type="compliance" subcase="161">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/004.html</test_script_entry>
         </description>
@@ -3002,45 +2390,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_008_1" priority="P3" purpose="Check if can new WebSocket() with invalid port arg as 'ws://example.invalid:80/'" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_008" priority="P3" purpose="Test WebSockets: new WebSocket(url with not blocked port)" status="approved" type="compliance" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/008.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_008_2" priority="P3" purpose="Check if can new WebSocket() with invalid port arg as 'ws://example.invalid:443/'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/008.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_008_3" priority="P3" purpose="Check if can new WebSocket() with invalid port arg as 'wss://example.invalid:80/'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/008.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_008_4" priority="P3" purpose="Check if can new WebSocket() with invalid port arg as 'wss://example.invalid:443/'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/008.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/008.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -3074,45 +2426,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_017_1" priority="P3" purpose="Check if can new WebSocket() with no slash after ws as 'ws:location.hostname/ws/echo'" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_017" priority="P3" purpose="Test WebSockets: too few slashes after ws: and wss:" status="approved" type="compliance" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/017.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_017_2" priority="P3" purpose="Check if can new WebSocket() with one slash after ws as 'ws:/location.hostname/ws/echo'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/017.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_017_3" priority="P3" purpose="Check if can new WebSocket() with no slash after wss as 'wss:location.hostname/ws/echo'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/017.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
-            <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_017_4" priority="P3" purpose="Check if can new WebSocket() with one slash after wss as 'wss:/location.hostname/ws/echo'" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/017.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/017.html</test_script_entry>
         </description>
         <specs>
           <spec>

--- a/webapi/tct-websocket-w3c-tests/tests.full.xml
+++ b/webapi/tct-websocket-w3c-tests/tests.full.xml
@@ -9,9 +9,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="code" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="code" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-closeevent-code</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -21,9 +21,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="reason" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="reason" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-closeevent-reason</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -33,9 +33,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="code" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="code" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-closeevent-code</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -45,9 +45,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="code" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="code" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-closeevent-code</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -57,9 +57,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="code" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="code" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-closeevent-code</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -69,9 +69,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="reason" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="reason" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-closeevent-reason</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -81,9 +81,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="reason" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="reason" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-closeevent-reason</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -93,9 +93,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="reason" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="reason" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-closeevent-reason</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -105,9 +105,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="wasClean" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="wasClean" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-closeevent-wasclean</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -117,9 +117,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="wasClean" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="wasClean" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-closeevent-wasclean</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -129,9 +129,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="wasClean" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="wasClean" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-closeevent-wasclean</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -141,9 +141,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="wasClean" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="wasClean" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-closeevent-wasclean</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -153,9 +153,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="wasClean" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="wasClean" element_type="attribute" interface="CloseEvent" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-closeevent-wasclean</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -165,9 +165,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="binaryType" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="binaryType" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-binarytype</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -177,9 +177,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="binaryType" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="binaryType" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-binarytype</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -189,9 +189,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -201,9 +201,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -213,9 +213,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -225,9 +225,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -237,9 +237,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -249,9 +249,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -261,9 +261,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -273,9 +273,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -285,9 +285,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -297,9 +297,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -309,9 +309,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -321,9 +321,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -333,9 +333,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -345,9 +345,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-bufferedamount</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -357,9 +357,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -369,9 +369,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -381,9 +381,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -393,9 +393,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -405,9 +405,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -417,9 +417,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -429,9 +429,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -441,9 +441,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -453,9 +453,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -465,9 +465,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -477,9 +477,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -489,9 +489,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -501,9 +501,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSED" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSED" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-closed</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -513,9 +513,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSED" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSED" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-closed</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -525,9 +525,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSED" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSED" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-closed</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -537,9 +537,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-closing</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -549,9 +549,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-closing</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -561,9 +561,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CLOSING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-closing</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -573,9 +573,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-connecting</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -585,9 +585,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-connecting</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -597,9 +597,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-connecting</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -609,9 +609,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="extensions" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="extensions" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-extensions</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -621,9 +621,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="extensions" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="extensions" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-extensions</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -633,9 +633,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="extensions" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="extensions" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-extensions</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -645,9 +645,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -657,9 +657,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#handler-websocket-onclose</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -669,9 +669,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#handler-websocket-onclose</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -681,9 +681,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#handler-websocket-onclose</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -693,9 +693,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onerror" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onerror" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#handler-websocket-onerror</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -705,9 +705,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onerror" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onerror" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#handler-websocket-onerror</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -717,9 +717,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#handler-websocket-onmessage</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -729,9 +729,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#handler-websocket-onmessage</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -741,9 +741,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#handler-websocket-onmessage</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -753,9 +753,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#handler-websocket-onopen</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -765,9 +765,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#handler-websocket-onopen</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -777,9 +777,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="eventhandler" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#handler-websocket-onopen</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -789,9 +789,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="OPEN" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="OPEN" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-open</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -801,9 +801,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="OPEN" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="OPEN" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-open</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -813,9 +813,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="OPEN" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="OPEN" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-open</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -825,9 +825,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-protocol</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -837,9 +837,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-protocol</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -849,9 +849,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-protocol</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -861,9 +861,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-protocol</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -873,9 +873,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-protocol</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -885,9 +885,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-protocol</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -897,9 +897,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-protocol</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -909,9 +909,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-readystate</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -921,9 +921,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-readystate</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -933,9 +933,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-readystate</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -945,9 +945,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-readystate</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -957,9 +957,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-readystate</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -969,9 +969,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -981,9 +981,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -993,9 +993,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1005,9 +1005,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1017,9 +1017,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1029,9 +1029,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1041,9 +1041,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1053,9 +1053,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1065,9 +1065,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1077,9 +1077,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1089,9 +1089,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1101,9 +1101,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1113,9 +1113,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1125,9 +1125,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1137,9 +1137,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1149,9 +1149,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1161,9 +1161,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1173,9 +1173,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1185,9 +1185,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1197,7 +1197,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
           </spec>
         </specs>
@@ -1208,7 +1208,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-protocol</spec_url>
           </spec>
         </specs>
@@ -1219,7 +1219,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
           </spec>
         </specs>
@@ -1230,7 +1230,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
           </spec>
         </specs>
@@ -1241,7 +1241,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-protocol</spec_url>
           </spec>
         </specs>
@@ -1252,7 +1252,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="extensions" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="extensions" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-extensions</spec_url>
           </spec>
         </specs>
@@ -1263,7 +1263,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
           </spec>
         </specs>
@@ -1274,7 +1274,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
           </spec>
         </specs>
@@ -1285,7 +1285,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
           </spec>
         </specs>
@@ -1296,7 +1296,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-protocol</spec_url>
           </spec>
         </specs>
@@ -1307,7 +1307,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
           </spec>
         </specs>
@@ -1318,7 +1318,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
           </spec>
         </specs>
@@ -1329,7 +1329,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
           </spec>
         </specs>
@@ -1340,7 +1340,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
           </spec>
         </specs>
@@ -1351,7 +1351,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-readystate</spec_url>
           </spec>
         </specs>
@@ -1362,7 +1362,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
           </spec>
         </specs>
@@ -1373,7 +1373,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-protocol</spec_url>
           </spec>
         </specs>
@@ -1384,7 +1384,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
           </spec>
         </specs>
@@ -1395,7 +1395,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
           </spec>
         </specs>
@@ -1406,7 +1406,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-protocol</spec_url>
           </spec>
         </specs>
@@ -1417,7 +1417,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
           </spec>
         </specs>
@@ -1428,7 +1428,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
           </spec>
         </specs>
@@ -1439,7 +1439,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-readystate</spec_url>
           </spec>
         </specs>
@@ -1450,7 +1450,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
           </spec>
         </specs>
@@ -1461,7 +1461,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
           </spec>
         </specs>
@@ -1472,9 +1472,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1484,9 +1484,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1496,9 +1496,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1508,9 +1508,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-url</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1520,9 +1520,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1532,9 +1532,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1544,9 +1544,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-close</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1556,9 +1556,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1568,9 +1568,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1580,9 +1580,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1592,9 +1592,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1604,9 +1604,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1616,9 +1616,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1628,9 +1628,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1640,9 +1640,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1652,9 +1652,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1664,9 +1664,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1676,9 +1676,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1688,9 +1688,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1700,9 +1700,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1712,9 +1712,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1724,9 +1724,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1736,9 +1736,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1748,9 +1748,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1760,9 +1760,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1772,9 +1772,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#dom-websocket-send</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1784,9 +1784,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1796,9 +1796,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1808,9 +1808,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bufferedAmount" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1820,9 +1820,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1832,9 +1832,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1844,9 +1844,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1856,9 +1856,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="close" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1868,9 +1868,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="CloseEvent" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="CloseEvent" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#closeevent</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1880,9 +1880,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1892,9 +1892,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1904,9 +1904,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1916,9 +1916,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1928,9 +1928,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="CONNECTING" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1940,9 +1940,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1952,9 +1952,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1964,9 +1964,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1976,9 +1976,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1988,9 +1988,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="EventTarget" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="EventTarget" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#eventtarget</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2000,9 +2000,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2012,9 +2012,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onmessage" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2024,9 +2024,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onerror" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onerror" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2036,9 +2036,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onclose" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2048,9 +2048,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2060,9 +2060,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2072,9 +2072,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2084,9 +2084,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2096,9 +2096,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2108,9 +2108,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2120,9 +2120,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2132,9 +2132,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onopen" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2144,9 +2144,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="extensions" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="extensions" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2156,9 +2156,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="protocol" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2168,9 +2168,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2180,9 +2180,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2192,9 +2192,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2204,9 +2204,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2216,9 +2216,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2228,9 +2228,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2240,9 +2240,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2252,9 +2252,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2264,9 +2264,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2276,9 +2276,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="send" element_type="method" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2288,9 +2288,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2300,9 +2300,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2312,9 +2312,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2324,9 +2324,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="url" element_type="attribute" interface="WebSocket" section="Communication" specification="The WebSocket API"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2336,9 +2336,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2348,9 +2348,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2360,9 +2360,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2372,9 +2372,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2384,9 +2384,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2396,9 +2396,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2408,9 +2408,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2420,9 +2420,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2432,9 +2432,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2444,9 +2444,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2456,9 +2456,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2468,9 +2468,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/#websocket</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2480,7 +2480,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="CloseEvent" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="CloseEvent" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/</spec_url>
             <spec_statement>Create an event that uses the CloseEvent interface, with the event name close, which does not bubble, is not cancelable, has no default action, whose wasClean attribute is initialized to true if the connection closed cleanly and false otherwise, whose code attribute is initialized to the WebSocket connection close code, and whose reason attribute is initialized to the WebSocket connection close reason decoded as UTF-8, with error handling, and dispatch the event at the WebSocket object.</spec_statement>
           </spec>
@@ -2492,9 +2492,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2504,7 +2504,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/</spec_url>
             <spec_statement>Offers bi-directional network connectivity</spec_statement>
           </spec>
@@ -2516,9 +2516,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2528,9 +2528,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="WebSocket" section="Communication" specification="The WebSocket API" usage="true"/>
             <spec_url>http://www.w3.org/TR/2012/CR-websockets-20120920/</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>

--- a/webapi/tct-websocket-w3c-tests/tests.xml
+++ b/webapi/tct-websocket-w3c-tests/tests.xml
@@ -73,7 +73,7 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/websocket_WebSocket_binaryType_exists.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="BinaryType_wrong_value" onload_delay="10" purpose="Check if Secure WebSocket created when the binaryType is set to something other than blob/arraybuffer">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="binaryType-wrong-value" onload_delay="10" purpose="Test WebSockets: binaryType wrong value" subcase="2">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/binaryType-wrong-value.htm</test_script_entry>
         </description>
@@ -423,7 +423,7 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/websocket_WebSocket_url_exists.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create_invalid_urls" purpose="Check if the SyntaxError exception thrown when created by an invalid url ">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-invalid-urls" purpose="Test WebSockets: Create invalid urls" subcase="5">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Create-invalid-urls.htm</test_script_entry>
         </description>
@@ -493,52 +493,52 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-before-open.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_65K_data" onload_delay="10" purpose="Check if Secure WebSocket when Send 65K data">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-65K-data" onload_delay="10" purpose="Test WebSockets: Secure Send 65K data" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-65K-data.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_65k_data" onload_delay="10" purpose="Check if 64k byte data can be received after 65k data send on a WebSocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-65K-data" onload_delay="10" purpose="Test WebSockets: Send 65K data" subcase="3">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Send-65K-data.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_protocol_string" onload_delay="10" purpose="Check if connection can be opened or closed after open or close a secure WebSocket with a valid URL and protocol string">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-Secure-valid-url-protocol-string" onload_delay="10" purpose="Test WebSockets: Create Secure valid url protocol string" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-protocol-string.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_server_initiated_close" onload_delay="10" purpose="Check if the connnection works when open or close a secure WebSocket with server initiated close">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-server-initiated-close" onload_delay="10" purpose="Test WebSockets: Secure Close server initiated close" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-server-initiated-close.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_4999_reason" onload_delay="10" purpose="Check if the connection works when open or close a secure WebSocket with 4999 code and reason">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-4999-reason" onload_delay="10" purpose="Test WebSockets: Secure Close 4999 reason" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-4999-reason.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_valid_url_protocol" onload_delay="10" purpose="Check if connection can be opened or closed after open or close a WebSocket with a valid URL and a protocol">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-valid-url-protocol" onload_delay="10" purpose="Test WebSockets: Create valid url protocol" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-valid-url-protocol.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_extensions_empty" onload_delay="10" purpose="Check if the websocket connection with an empty extension can be opened or closed successfully">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-Secure-extensions-empty" onload_delay="10" purpose="Test WebSockets: Create Secure extensions empty" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-extensions-empty.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_send_null" onload_delay="10" purpose="Check if null can be received when null data send on a Secure WebSocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-null" onload_delay="10" purpose="Test WebSockets: Secure Send null" subcase="3">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-null.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_binarytype_blob" onload_delay="10" purpose="Check if a open secure WebSocket which binaryType should be set to 'blob' after connection is established.">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-Secure-valid-url-binaryType-blob" onload_delay="10" purpose="Test WebSockets: Create Secure valid url binaryType blob" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-binaryType-blob.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_valid_url" onload_delay="10" purpose="Check if the connection works when sending the valid URL">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-valid-url" onload_delay="10" purpose="Test WebSockets: Create valid url" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-valid-url.htm</test_script_entry>
         </description>
@@ -548,22 +548,22 @@
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-valid-url-protocol-empty.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_send_binary_blob" onload_delay="10" purpose="Check if binary data should be received in blob form when binary data in blob form send on a Secure Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-blob" onload_delay="10" purpose="Test WebSockets: Secure Send binary blob" subcase="3">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-blob.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_array_protocols" onload_delay="10" purpose="Check if connection works when open or close a secure WebSocket with a valid URL and array of protocol strings">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-Secure-valid-url-array-protocols" onload_delay="10" purpose="Test WebSockets: Create Secure valid url and array protocols" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-array-protocols.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_data" onload_delay="10" purpose="Check if data can be received after send data on a Secure WebSocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-data" onload_delay="10" purpose="Test WebSockets: Secure Send data" subcase="3">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-data.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_3000_reason" onload_delay="10" purpose="Check if the desired wsocket.readyState is equal to 3 and evt.wasClean is true if the websocket call the method close(3000)">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-3000-reason" onload_delay="10" purpose="Test WebSockets: Secure Close 3000 reason" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-3000-reason.htm</test_script_entry>
         </description>
@@ -573,52 +573,52 @@
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-readyState-Closing.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="close_1000" onload_delay="10" purpose="Check if readystate should be in CLOSED state and wasClean is TRUE after close a WebSocket with 1000 code and reason">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Close-1000" onload_delay="10" purpose="Test WebSockets: close(1000)" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Close-1000.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_valid_url_array_protocols" onload_delay="10" purpose="Check if the websocket connection with a valid URL and array of protocols can be opened or closed successfully">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-valid-url-array-protocols" onload_delay="10" purpose="Test WebSockets: Create valid url array protocols" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-valid-url-array-protocols.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="send_null" onload_delay="10" purpose="Check if null can be received after null send on a WebSocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-null" onload_delay="10" purpose="Test WebSockets: Send null" subcase="3">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Send-null.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url" onload_delay="10" purpose="Check if the connection can be opened or closed after open or close a secure WebSocket with a valid URL">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-Secure-valid-url" onload_delay="10" purpose="Test WebSockets: Create Secure valid url" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_protocol_setcorrectly" onload_delay="10" purpose="Check if protocol is set correctly after connection">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Create-Secure-valid-url-protocol-setCorrectly" onload_delay="10" purpose="Test WebSockets: Create Secure valid url protocol setCorrectly" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-protocol-setCorrectly.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="close_1000_reason" onload_delay="10" purpose="Check if readystate can be in CLOSED state and wasClean is TRUE if close a WebSocket with 1000 code and reason">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Close-1000-reason" onload_delay="10" purpose="Test WebSockets: close(1000, reason)" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Close-1000-reason.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_1000" onload_delay="10" purpose="Check if readystate can be in CLOSED state and wasClean is TRUE after close a secure WebSocket with 1000 code">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-1000" onload_delay="10" purpose="Test WebSockets: Secure Close 1000" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1000.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_readystate_closed" onload_delay="10" purpose="Check if readyState is in closed state when onclose is fired">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-readyState-Closed" onload_delay="10" purpose="Test WebSockets: Secure Close readyState Closed" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-readyState-Closed.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_1000_reason" onload_delay="10" purpose="Check if readystate should be in CLOSED state and wasClean is TRUE after close a secure WebSocket with 1000 code and reason">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-1000-reason" onload_delay="10" purpose="Test WebSockets: Secure Close 1000 reason" subcase="2">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1000-reason.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="send_0byte_data" onload_delay="10" purpose="Check if null can be received when 0 byte data send on a WebSocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-0byte-data" onload_delay="10" purpose="Test WebSockets: Send 0byte data" subcase="3">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Send-0byte-data.htm</test_script_entry>
         </description>
@@ -643,112 +643,112 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Create-verify-url-set-non-default-port.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_1000_verify_code" onload_delay="10" purpose="Check if the return code is 1000 when close a secure WebSocket with 1000 code">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-1000-verify-code" onload_delay="10" purpose="Test WebSockets: Secure Close 1000 verify code" subcase="2">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1000-verify-code.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_1005_verify_code" onload_delay="10" purpose="Check if the return code is 1005 when close a secure WebSocket with 1005 code">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-1005-verify-code" onload_delay="10" purpose="Test WebSockets: Secure Close 1005 verify code" subcase="2">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1005-verify-code.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_3000_verify_code" onload_delay="10" purpose="Check if the return code is 3000 when close a secure WebSocket with 3000 code">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Close-3000-verify-code" onload_delay="10" purpose="Test WebSockets: Secure Close 3000 verify code" subcase="2">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-3000-verify-code.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_65K_arraybuffer" onload_delay="10" purpose="Check if 65 byte data can be received after Send 65K binary data on a Secure Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-65K-arraybuffer" onload_delay="10" purpose="Test WebSockets: Secure Send binary 65K arraybuffer" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-65K-arraybuffer.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybuffer" onload_delay="10" purpose="Check if binary data should be received when binary data send on a Secure Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybuffer" onload_delay="10" purpose="Test WebSockets: Secure Send binary arraybuffer" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybuffer.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_paired_surrogates" onload_delay="10" purpose="Check if paired surrogates data should be received when paired surrogates data send on a Secure Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-paired-surrogates" onload_delay="10" purpose="Test WebSockets: Secure Send paired surrogates" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-paired-surrogates.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_unicode_data" onload_delay="10" purpose="Check if unicode data message should be received when unicode data send on a Secure Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-unicode-data" onload_delay="10" purpose="Test WebSockets: Secure Send unicode data" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-unicode-data.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_binary_65K_arraybuffer" onload_delay="10" purpose="Check if 65 byte data can be received after Send 65K binary data send on a WebSocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-binary-65K-arraybuffer" onload_delay="10" purpose="Test WebSockets: Send binary 65K arraybuffer" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-binary-65K-arraybuffer.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_binary_arraybuffer" onload_delay="10" purpose="Check if binary data should be received when binary data send on a Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-binary-arraybuffer" onload_delay="10" purpose="Test WebSockets: Send binary arraybuffer" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-binary-arraybuffer.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_binary_blob" onload_delay="10" purpose="Check if binary data should be received in blob form when binary data in blob form send on a Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-binary-blob" onload_delay="10" purpose="Test WebSockets: Send binary blob" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-binary-blob.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_data" onload_delay="10" purpose="Check if data can be received after data send on a WebSocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-data" onload_delay="10" purpose="Test WebSockets: Send data" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-data.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_paired_surrogates" onload_delay="10" purpose="Check if paired surrogates data should be received when paired surrogates data send on a Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-paired-surrogates" onload_delay="10" purpose="Test WebSockets: Send paired surrogates" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-paired-surrogates.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_unicode_data" onload_delay="10" purpose="Check if unicode data message should be received when unicode data send on a Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-unicode-data" onload_delay="10" purpose="Test WebSockets: Send unicode data" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-unicode-data.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_float32" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Float32Array type">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-float32" onload_delay="5" purpose="Test WebSockets:  Secure Send binary arraybufferview float32" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-float32.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_float64" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Float64Array type">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-float64" onload_delay="5" purpose="Test WebSockets: Secure Send binary arraybufferview float64" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-float64.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_int32" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Int32Array type ">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-int32" onload_delay="5" purpose="Test WebSockets: Secure Send binary arraybufferview int32" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-int32.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint8_offset" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint8Array type with offset ">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-uint8-offset" onload_delay="5" purpose="Test WebSockets: Secure Send binary arraybufferview uint8 offset" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint8-offset.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint8_offset_length" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint8Array type with offset and length ">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-uint8-offset-length" onload_delay="5" purpose="Test WebSockets: Secure Send binary arraybufferview uint8 offset length" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint8-offset-length.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint16_offset_length" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint16Array type with offset and length">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-uint16-offset-length" onload_delay="5" purpose="Test WebSockets: Secure Send binary arraybufferview uint16 offset length" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint16-offset-length.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint32_offset" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint32Array type with offset">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure-Send-binary-arraybufferview-uint32-offset" onload_delay="5" purpose="Test WebSockets: Secure Send binary arraybufferview uint32 offset" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint32-offset.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_binary_arraybufferview_int8" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Int8Array type">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-binary-arraybufferview-int8" onload_delay="5" purpose="Test WebSockets: Send binary arraybufferview int8" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-binary-arraybufferview-int8.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_binary_arraybufferview_int16_offset" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Int16Array type with offset ">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send-binary-arraybufferview-int16-offset" onload_delay="5" purpose="Test WebSockets: Send binary arraybufferview int16 offset" subcase="3">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-binary-arraybufferview-int16-offset.htm</test_script_entry>
         </description>
@@ -793,124 +793,29 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/CloseEvent/001.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_001_1" purpose="Check if WebSocket.CONNECTING exists">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_001" purpose="Test WebSockets: getting constants on constructor" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/001.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_001_2" purpose="Check if WebSocket.OPEN exists">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_003" purpose="Test WebSockets: deleting constants" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/003.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_001_3" purpose="Check if WebSocket.CLOSING exists">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004" purpose="Test WebSockets: getting constants on prototype and object" subcase="8">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_001_4" purpose="Check if WebSocket.CLOSED exists">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_005" purpose="Test WebSockets: defineProperty getter for constants" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/005.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_003_1" purpose="Check if can delete the attribute of WebSocket.CONNECTING">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_006" purpose="Test WebSockets: defineProperty setter for constants" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/003.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_003_2" purpose="Check if can delete the attribute of WebSocket.OPEN">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/003.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_003_3" purpose="Check if can delete the attribute of WebSocket.CLOSING">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/003.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_003_4" purpose="Check if can delete the attribute ofWebSocket.CLOSED">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/003.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_1" purpose="Check if CONNECTING exists in WebSocket.prototype">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_2" purpose="Check if CONNECTING exists in WebSocket instance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_3" purpose="Check if OPEN exists in WebSocket.prototype">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_4" purpose="Check if OPEN exists in WebSocket instance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_5" purpose="Check if CLOSING exists in WebSocket.prototype">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_6" purpose="Check if CLOSING exists in WebSocket instance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_7" purpose="Check if CLOSED exists in WebSocket.prototype">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_004_8" purpose="Check if CLOSED exists in WebSocket instance">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/004.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_005_1" purpose="Check if throw TypeError by defineProperty getter for CONNECTING">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/005.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_005_2" purpose="Check if throw TypeError by defineProperty getter for OPEN">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/005.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_005_3" purpose="Check if throw TypeError by defineProperty getter for CLOSING">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/005.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_005_4" purpose="Check if throw TypeError by defineProperty getter for CLOSED">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/005.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_006_1" purpose="Check if throw TypeError by defineProperty setter for CONNECTING">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/006.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_006_2" purpose="Check if throw TypeError by defineProperty setter for OPEN">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/006.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_006_3" purpose="Check if throw TypeError by defineProperty setter for CLOSING">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/006.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Constants_006_4" purpose="Check if throw TypeError by defineProperty setter for CLOSED">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/006.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/constants/006.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Cookies_004" purpose="Check if the WebSocket response cookies matches document.cookie">
@@ -918,44 +823,14 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/cookies/004.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_001_1" purpose="Check if onopen attribute nonexist when without define it on WebSocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_001" purpose="Test WebSockets: getting event" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/001.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_001_2" purpose="Check if onmessage attribute nonexist when without define it on WebSocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_002" purpose="Test WebSockets: setting event" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_001_3" purpose="Check if onerror attribute nonexist when without define it on WebSocket">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_001_4" purpose="Check if onclose attribute nonexist when without define it on WebSocket">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/001.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_002_1" purpose="Check if onopen attribute exist after it defined on WebSocket">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/002.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_002_2" purpose="Check if onmessage attribute exist after it defined on WebSocket">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/002.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_002_3" purpose="Check if onerror attribute exist after it defined on WebSocket">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/002.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_002_4" purpose="Check if onclose attribute exist after it defined on WebSocket">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/002.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/002.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_003" purpose="Check if can listen event with onopen">
@@ -988,84 +863,24 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/009.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_010_1" purpose="Check if can set onopen event handler to undefined">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_010" purpose="Test WebSockets: setting event handlers to undefined" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/010.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_010_2" purpose="Check if can set onmessage event handler to undefined">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_011" purpose="Test WebSockets: setting event handlers to 1" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/011.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_010_3" purpose="Check if can set onerror event handler to undefined">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_012" purpose="Test WebSockets: setting event handlers to ';'" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/012.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_010_4" purpose="Check if can set onclose event handler to undefined">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_014" purpose="Test WebSockets: setting event handlers to null" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_011_1" purpose="Check if can set onopen event handler to 1">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/011.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_011_2" purpose="Check if can set onmessage event handler to 1">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/011.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_011_3" purpose="Check if can set onerror event handler to 1">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/011.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_011_4" purpose="Check if can set onclose event handler to 1">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/011.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_012_1" purpose="Check if can set onopen event handler to ';'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/012.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_012_2" purpose="Check if can set onmessage event handler to ';'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/012.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_012_3" purpose="Check if can set onerror event handler to ';'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/012.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_012_4" purpose="Check if can set onclose event handler to ';'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/012.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_014_1" purpose="Check if can set onopen event handler to null">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/014.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_014_2" purpose="Check if can set onmessage event handler to null">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/014.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_014_3" purpose="Check if can set onerror event handler to null">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/014.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_014_4" purpose="Check if can set onclose event handler to null">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/014.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/014.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_015" purpose="Check if WebSocket events are instanceof of Event">
@@ -1083,24 +898,9 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/018.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_019_1" purpose="Check if can removeEventListener about onopen event handler">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_019" purpose="Test WebSockets: removeEventListener" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/019.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_019_2" purpose="Check if can removeEventListener about onmessage event handler">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/019.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_019_3" purpose="Check if can removeEventListener about onerror event handler">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/019.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Events_019_4" purpose="Check if can removeEventListener about onclose event handler">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/019.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/events/019.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Extensions_001" purpose="Check if the extensions attribute initially return the empty string">
@@ -1153,19 +953,9 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/send/003.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_004_1" purpose="Check if throw INVALID_STATE_ERR when send() with lone low surrogate">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_004" purpose="Test WebSockets: send() with unpaired surrogate when readyState is CONNECTING" subcase="3">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/send/004.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_004_2" purpose="Check if throw INVALID_STATE_ERR when send() with lone high surrogate">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/send/004.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_004_3" purpose="Check if throw INVALID_STATE_ERR when send() with surrogates in wrong order">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/send/004.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/send/004.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Send_009" purpose="Check if can send() empty message">
@@ -1198,57 +988,12 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/001.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_1" purpose="Check if can new WebSocket() with invalid url arg as '/test'">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002" purpose="Test WebSockets: new WebSocket(invalid url)" subcase="10">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_2" purpose="Check if can new WebSocket() with invalid url arg as 'ws://foo bar.com/'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_3" purpose="Check if can new WebSocket() with invalid url arg as 'wss://foo bar.com/'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_4" purpose="Check if can new WebSocket() with invalid url arg as 'http://location.hostname/'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_5" purpose="Check if can new WebSocket() with invalid url arg as 'mailto:example@example.org'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_6" purpose="Check if can new WebSocket() with invalid url arg as 'about:blank'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_7" purpose="Check if can new WebSocket() with invalid url arg as 'ws://location.hostname/#'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_8" purpose="Check if can new WebSocket() with invalid url arg as 'ws://location.hostname/#test'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_9" purpose="Check if can new WebSocket() with invalid url arg as '?test'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_002_10" purpose="Check if can new WebSocket() with invalid url arg as '#test'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/002.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_004" onload_delay="10" purpose="Check if can new WebSocket() with invalid protocol arg">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_004" onload_delay="10" purpose="Test WebSockets: new WebSocket(url, invalid protocol)" subcase="161">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/004.html</test_script_entry>
         </description>
@@ -1263,24 +1008,9 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/007.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_008_1" purpose="Check if can new WebSocket() with invalid port arg as 'ws://example.invalid:80/'">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_008" purpose="Test WebSockets: new WebSocket(url with not blocked port)" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/008.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_008_2" purpose="Check if can new WebSocket() with invalid port arg as 'ws://example.invalid:443/'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/008.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_008_3" purpose="Check if can new WebSocket() with invalid port arg as 'wss://example.invalid:80/'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/008.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_008_4" purpose="Check if can new WebSocket() with invalid port arg as 'wss://example.invalid:443/'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/008.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/008.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_010" purpose="Check if the protocol in response but no in requested">
@@ -1293,24 +1023,9 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/012.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_017_1" purpose="Check if can new WebSocket() with no slash after ws as 'ws:location.hostname/ws/echo'">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_017" purpose="Test WebSockets: too few slashes after ws: and wss:" subcase="4">
         <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/017.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_017_2" purpose="Check if can new WebSocket() with one slash after ws as 'ws:/location.hostname/ws/echo'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/017.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_017_3" purpose="Check if can new WebSocket() with no slash after wss as 'wss:location.hostname/ws/echo'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/017.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_017_4" purpose="Check if can new WebSocket() with one slash after wss as 'wss:/location.hostname/ws/echo'">
-        <description>
-          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/017.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/017.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="websocket_constructor_019" purpose="Check if can new WebSocket() with uppercase protocal as 'WS:'">

--- a/webapi/webapi-resourcetiming-w3c-tests/tests.full.xml
+++ b/webapi/webapi-resourcetiming-w3c-tests/tests.full.xml
@@ -3,9 +3,9 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="webapi-resourcetiming-w3c-tests">
     <set name="resourcetiming" type="js">
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_frame_initiator_type" priority="P2" purpose="Test checks that the frame initiator type is represented" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_frame_initiator_type" priority="P2" purpose="Test resource frame initiator type" status="approved" type="compliance" subcase="3">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_frame_initiator_type.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_frame_initiator_type.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -15,9 +15,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_ignore_data_url" priority="P3" purpose="Test checks that resources with data: URIs aren't present in the Resource Timing buffer" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_ignore_data_url" priority="P3" purpose="Test resource ignore data url" status="approved" type="compliance" subcase="3">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_ignore_data_url.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_ignore_data_url.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -27,9 +27,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (iframe)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_iframe">
+      <testcase purpose="Test resource timing" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="test_resource_timing" subcase="18">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -39,213 +39,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="PerformanceEntry has correct name, initiatorType, startTime, and duration (iframe)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_correct_attribute_iframe">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_attribute_order" priority="P2" purpose="Test resource attribute order" status="ready" type="compliance" subcase="13">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="PerformanceEntry has correct order of timing attributes (iframe)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_timing_attribute_iframe">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (img)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_img">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="PerformanceEntry has correct name, initiatorType, startTime, and duration (img)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_correct_attribute_img">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="PerformanceEntry has correct order of timing attributes (img)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_timing_attribute_img">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (link)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_link">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="PerformanceEntry has correct name, initiatorType, startTime, and duration (link)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_correct_attribute_link">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="PerformanceEntry has correct order of timing attributes (link)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_timing_attribute_link">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (script)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_script">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="PerformanceEntry has correct name, initiatorType, startTime, and duration (script)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_correct_attribute_script">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="PerformanceEntry has correct order of timing attributes (script)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_timing_attribute_script">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (xmlhttprequest)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_xmlhttprequest">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="PerformanceEntry has correct name, initiatorType, startTime, and duration (xmlhttprequest)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_correct_attribute_xmlhttprequest">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="PerformanceEntry has correct order of timing attributes (xmlhttprequest)" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P3" id="performance_PerformanceEntry_timing_attribute_xmlhttprequest">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion usage="true" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="window.performance.getEntriesByName() is defined" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P1" id="performance_getEntriesByName_defined">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="method" element_name="" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="window.performance.getEntriesByType() is defined" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P1" id="performance_getEntriesByType_defined">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="method" element_name="" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="window.performance.getEntries() is defined" type="compliance" status="approved" component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" priority="P1" id="performance_getEntries_defined">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="method" element_name="" interface="Performance" specification="Resource Timing" section="Performance and Optimization" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performanceEntry_match_one" priority="P2" purpose="Test checks that Only 1 PerformanceEntry should match" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -255,129 +51,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="redirectStart_value_zero" priority="P2" purpose="Test checks that redirectStart should be 0" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_cached" priority="P3" purpose="Test resource cached" status="ready" type="compliance" onload_delay="30" subcase="3">
         <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="redirectStart" element_type="attribute" interface="PerformanceResourceTiming" section="Performance and Optimization" specification="Resource Timing"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="redirectEnd_value_zero" priority="P2" purpose="Test checks that redirectEnd should be 0" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="redirectEnd" element_type="attribute" interface="PerformanceResourceTiming" section="Performance and Optimization" specification="Resource Timing"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="fetchStart_value_non-zero" priority="P2" purpose="Test checks that fetchStart should be non-zero" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="fetchStart" element_type="attribute" interface="PerformanceResourceTiming" section="Performance and Optimization" specification="Resource Timing"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="domainLookupStart_greater_or_equal_fetchStart" priority="P2" purpose="Test checks that domainLookupStart should be greater than or equal to fetchStart" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="domainLookupStart" element_type="attribute" interface="PerformanceResourceTiming" section="Performance and Optimization" specification="Resource Timing"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="domainLookupEnd_greater_or_equal_domainLookupStart" priority="P2" purpose="Test checks that domainLookupEnd should be greater than or equal to domainLookupStart" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="domainLookupEnd" element_type="attribute" interface="PerformanceResourceTiming" section="Performance and Optimization" specification="Resource Timing"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="connectStart_greater_or_equal_domainLookupEnd" priority="P2" purpose="Test checks that connectStart should be greater than or equal to domainLookupEnd" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="connectStart" element_type="attribute" interface="PerformanceResourceTiming" section="Performance and Optimization" specification="Resource Timing"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="connectEnd_greater_or_equal_connectStart" priority="P2" purpose="Test checks that connectEnd should be greater than or equal to connectStart" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="connectEnd" element_type="attribute" interface="PerformanceResourceTiming" section="Performance and Optimization" specification="Resource Timing"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="requestStart_greater_or_equal_connectEnd" priority="P2" purpose="Test checks that requestStart should be greater than or equal to connectEnd" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="requestStart" element_type="attribute" interface="PerformanceResourceTiming" section="Performance and Optimization" specification="Resource Timing"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="responseStart_greater_or_equal_requestStart" priority="P2" purpose="Test checks that responseStart should be greater than or equal to requestStart" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="responseStart" element_type="attribute" interface="PerformanceResourceTiming" section="Performance and Optimization" specification="Resource Timing"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="responseEnd_greater_or_equal_responseStart" priority="P2" purpose="Test checks that responseEnd should be greater than or equal to responseStart" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="responseEnd" element_type="attribute" interface="PerformanceResourceTiming" section="Performance and Optimization" specification="Resource Timing"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_cached_not_Modified" priority="P3" purpose="Test checks that a 304 Not Modified resource appears in the buffer" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_cached.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_cached.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -387,9 +63,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_connection_reuse" priority="P3" purpose="Test checks that connectStart and connectEnd are the same when a connection is reused" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_connection_reuse" priority="P3" purpose="Test resource connection reuse" status="ready" type="compliance" onload_delay="30" subcase="4">
         <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_connection_reuse.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_connection_reuse.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -399,9 +75,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_dynamic_insertion_type_link" priority="P3" purpose="Test checks that the link initiator type is represented even when dynamically inserted" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_dynamic_insertion" priority="P3" purpose="Test resource dynamic insertion" status="ready" type="compliance" subcase="5">
         <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_dynamic_insertion.html?total_num=5&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_dynamic_insertion.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -411,9 +87,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_dynamic_insertion_type_img" priority="P3" purpose="Test checks that the img initiator type is represented even when dynamically inserted" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_iframe_self_navigation" priority="P3" purpose="Test resource iframe self navigation" status="ready" type="compliance" subcase="3">
         <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_dynamic_insertion.html?total_num=5&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_iframe_self_navigation.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -423,9 +99,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_dynamic_insertion_type_iframe" priority="P3" purpose="Test checks that the iframe initiator type is represented even when dynamically inserted" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_ignore_failures" priority="P3" purpose="Test resource ignore failures" status="ready" type="compliance" subcase="3">
         <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_dynamic_insertion.html?total_num=5&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_ignore_failures.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -435,9 +111,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_iframe_self_navigation" priority="P3" purpose="Test checks that iframes that navigate themselves don't appear in the buffer" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_initiator_types" priority="P3" purpose="Test resource initiator types" status="ready" type="compliance" onload_delay="30" subcase="18">
         <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_iframe_self_navigation.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -447,9 +123,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_ignore_failures" priority="P3" purpose="Test checks that failed resources aren't present in the Resource Timing buffer" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_redirects" priority="P3" purpose="Test resource redirects" status="ready" type="compliance" subcase="7">
         <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_ignore_failures.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_redirects.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -459,9 +135,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_001" priority="P3" purpose="Test checks that this initiator type('resources/Ahem.ttf') is represented" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_reparenting" priority="P3" purpose="Test resource reparenting" status="ready" type="compliance" subcase="3">
         <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_reparenting.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -471,345 +147,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_002" priority="P3" purpose="Test checks that this initiator type('resources/1x1-blue.png') is represented" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_script_types" priority="P3" purpose="Test resource script types" status="ready" type="compliance" subcase="11">
         <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_003" priority="P3" purpose="Test checks that this initiator type('resources/blank_page_green.htm') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_004" priority="P3" purpose="Test checks that this initiator type('resources/empty_script.js') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_005" priority="P3" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=css id=embed') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_006" priority="P3" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=css id=n1') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_007" priority="P3" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=font id=n1') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_008" priority="P3" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=1') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_009" priority="P3" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=2') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_010" priority="P3" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=async_xhr') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_011" priority="P3" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=body') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_012" priority="P3" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=input') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_013" priority="P3" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=n1') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_014" priority="P3" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=object') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_015" priority="P3" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=poster') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_016" priority="P3" purpose="Test checks that this initiator type('resources/nested.css') is represented" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_redirects_initiatorType_link" priority="P3" purpose="Test checks that resource is expected to have initiatorType link" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_redirects.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_redirects_initiatorType_script" priority="P3" purpose="Test checks that resource is expected to have initiatorType script" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_redirects.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_redirects_img" priority="P3" purpose="Test checks that resource redirect img is expected to be in the Resource Timing buffer" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_redirects.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_redirects_script" priority="P3" purpose="Test checks that resource redirect script is expected to be in the Resource Timing buffer" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_redirects.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_reparenting" priority="P3" purpose="Test checks that reparenting an element doesn't change the initiator document" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_reparenting.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_001" priority="P3" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=1') loads is reported with the correct initiator" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_002" priority="P3" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=2') loads is reported with the correct initiator" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_003" priority="P3" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=3') loads is reported with the correct initiator" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_004" priority="P3" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=4') loads is reported with the correct initiator" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_005" priority="P3" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=5') loads is reported with the correct initiator" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_006" priority="P3" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=6') loads is reported with the correct initiator" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_007" priority="P3" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=7') loads is reported with the correct initiator" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_008" priority="P3" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=8') loads is reported with the correct initiator" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" interface="Performance" section="Performance and Optimization" specification="Resource Timing" usage="true"/>
-            <spec_url>http://www.w3.org/TR/resource-timing/#performanceresourcetiming</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_009" priority="P3" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=9') loads is reported with the correct initiator" status="ready" type="compliance">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html</test_script_entry>
         </description>
         <specs>
           <spec>

--- a/webapi/webapi-resourcetiming-w3c-tests/tests.xml
+++ b/webapi/webapi-resourcetiming-w3c-tests/tests.xml
@@ -3,344 +3,69 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="webapi-resourcetiming-w3c-tests">
     <set name="resourcetiming" type="js">
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_frame_initiator_type" purpose="Test checks that the frame initiator type is represented">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_frame_initiator_type" purpose="Test resource frame initiator type" subcase="3">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_frame_initiator_type.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_frame_initiator_type.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_ignore_data_url" purpose="Test checks that resources with data: URIs aren't present in the Resource Timing buffer">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_ignore_data_url" purpose="Test resource ignore data url" subcase="3">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_ignore_data_url.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_ignore_data_url.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_iframe" purpose="window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (iframe)">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_timing" purpose="Test resource timing" subcase="18">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_correct_attribute_iframe" purpose="PerformanceEntry has correct name, initiatorType, startTime, and duration (iframe)">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_attribute_order" purpose="Test resource attribute order" subcase="13">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_timing_attribute_iframe" purpose="PerformanceEntry has correct order of timing attributes (iframe)">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_cached" onload_delay="30" purpose="Test resource cached" subcase="3">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_cached.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_img" purpose="window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (img)">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_connection_reuse" onload_delay="30" purpose="Test resource connection reuse" subcase="4">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_connection_reuse.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_correct_attribute_img" purpose="PerformanceEntry has correct name, initiatorType, startTime, and duration (img)">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_dynamic_insertion" purpose="Test resource dynamic insertion" subcase="5">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_dynamic_insertion.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_timing_attribute_img" purpose="PerformanceEntry has correct order of timing attributes (img)">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_iframe_self_navigation" purpose="Test resource iframe self navigation" subcase="3">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_iframe_self_navigation.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_link" purpose="window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (link)">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_ignore_failures" purpose="Test resource ignore failures" subcase="3">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_ignore_failures.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_correct_attribute_link" purpose="PerformanceEntry has correct name, initiatorType, startTime, and duration (link)">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_initiator_types" onload_delay="30" purpose="Test resource initiator types" subcase="18">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_timing_attribute_link" purpose="PerformanceEntry has correct order of timing attributes (link)">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_redirects" purpose="Test resource redirects" subcase="7">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_redirects.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_script" purpose="window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (script)">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_reparenting" purpose="Test resource reparenting" subcase="3">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_reparenting.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_correct_attribute_script" purpose="PerformanceEntry has correct name, initiatorType, startTime, and duration (script)">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="test_resource_script_types" purpose="Test resource script types" subcase="11">
         <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_timing_attribute_script" purpose="PerformanceEntry has correct order of timing attributes (script)">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_xmlhttprequest" purpose="window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (xmlhttprequest)">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_correct_attribute_xmlhttprequest" purpose="PerformanceEntry has correct name, initiatorType, startTime, and duration (xmlhttprequest)">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_PerformanceEntry_timing_attribute_xmlhttprequest" purpose="PerformanceEntry has correct order of timing attributes (xmlhttprequest)">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_getEntriesByName_defined" purpose="window.performance.getEntriesByName() is defined">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_getEntriesByType_defined" purpose="window.performance.getEntriesByType() is defined">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performance_getEntries_defined" purpose="window.performance.getEntries() is defined">
-        <description>
-          <test_script_entry>/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/test_resource_timing.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="performanceEntry_match_one" purpose="Test checks that Only 1 PerformanceEntry should match">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="redirectStart_value_zero" purpose="Test checks that redirectStart should be 0">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="redirectEnd_value_zero" purpose="Test checks that redirectEnd should be 0">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="fetchStart_value_non-zero" purpose="Test checks that fetchStart should be non-zero">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="domainLookupStart_greater_or_equal_fetchStart" purpose="Test checks that domainLookupStart should be greater than or equal to fetchStart">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="domainLookupEnd_greater_or_equal_domainLookupStart" purpose="Test checks that domainLookupEnd should be greater than or equal to domainLookupStart">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="connectStart_greater_or_equal_domainLookupEnd" purpose="Test checks that connectStart should be greater than or equal to domainLookupEnd">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="connectEnd_greater_or_equal_connectStart" purpose="Test checks that connectEnd should be greater than or equal to connectStart">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="requestStart_greater_or_equal_connectEnd" purpose="Test checks that requestStart should be greater than or equal to connectEnd">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="responseStart_greater_or_equal_requestStart" purpose="Test checks that responseStart should be greater than or equal to requestStart">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="responseEnd_greater_or_equal_responseStart" purpose="Test checks that responseEnd should be greater than or equal to responseStart">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_attribute_order.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_cached_not_Modified" purpose="Test checks that a 304 Not Modified resource appears in the buffer">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_cached.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_connection_reuse" purpose="Test checks that connectStart and connectEnd are the same when a connection is reused">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_connection_reuse.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_dynamic_insertion_type_link" purpose="Test checks that the link initiator type is represented even when dynamically inserted">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_dynamic_insertion.html?total_num=5&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_dynamic_insertion_type_img" purpose="Test checks that the img initiator type is represented even when dynamically inserted">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_dynamic_insertion.html?total_num=5&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_dynamic_insertion_type_iframe" purpose="Test checks that the iframe initiator type is represented even when dynamically inserted">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_dynamic_insertion.html?total_num=5&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_iframe_self_navigation" purpose="Test checks that iframes that navigate themselves don't appear in the buffer">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_iframe_self_navigation.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_ignore_failures" purpose="Test checks that failed resources aren't present in the Resource Timing buffer">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_ignore_failures.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_001" purpose="Test checks that this initiator type('resources/Ahem.ttf') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_002" purpose="Test checks that this initiator type('resources/1x1-blue.png') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_003" purpose="Test checks that this initiator type('resources/blank_page_green.htm') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_004" purpose="Test checks that this initiator type('resources/empty_script.js') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_005" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=css id=embed') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_006" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=css id=n1') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_007" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=font id=n1') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_008" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=1') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_009" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=2') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_010" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=async_xhr') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_011" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=body') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_012" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=input') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_013" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=n1') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_014" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=object') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_015" purpose="Test checks that this initiator type('resources/generate_resource.cgi?types=image id=poster') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_initiator_types_016" purpose="Test checks that this initiator type('resources/nested.css') is represented">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_initiator_types.html?total_num=18&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_redirects_initiatorType_link" purpose="Test checks that resource is expected to have initiatorType link">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_redirects.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_redirects_initiatorType_script" purpose="Test checks that resource is expected to have initiatorType script">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_redirects.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_redirects_img" purpose="Test checks that resource redirect img is expected to be in the Resource Timing buffer">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_redirects.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_redirects_script" purpose="Test checks that resource redirect script is expected to be in the Resource Timing buffer">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_redirects.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_reparenting" purpose="Test checks that reparenting an element doesn't change the initiator document">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_reparenting.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_001" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=1') loads is reported with the correct initiator">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_002" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=2') loads is reported with the correct initiator">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_003" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=3') loads is reported with the correct initiator">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_004" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=4') loads is reported with the correct initiator">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_005" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=5') loads is reported with the correct initiator">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_006" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=6') loads is reported with the correct initiator">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_007" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=7') loads is reported with the correct initiator">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_008" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=8') loads is reported with the correct initiator">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/Resource Timing" execution_type="auto" id="resource_script_types_009" purpose="Test checks that this type of script('resources/generate_resource.cgi?types=script id=9') loads is reported with the correct initiator">
-        <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_script_types.html</test_script_entry>
         </description>
       </testcase>
     </set>

--- a/webapi/webapi-usertiming-w3c-tests/tests.full.xml
+++ b/webapi/webapi-usertiming-w3c-tests/tests.full.xml
@@ -9,9 +9,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="clearMarks" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
+            <spec_assertion category="W3C API Specifications" element_name="clearMarks" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing"/>
             <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -21,9 +21,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="clearMeasures" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
+            <spec_assertion category="W3C API Specifications" element_name="clearMeasures" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing"/>
             <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -33,9 +33,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name=" mark" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
+            <spec_assertion category="W3C API Specifications" element_name=" mark" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing"/>
             <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -45,9 +45,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name=" mark" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
+            <spec_assertion category="W3C API Specifications" element_name=" mark" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing"/>
             <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -57,9 +57,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name=" mark" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
+            <spec_assertion category="W3C API Specifications" element_name=" mark" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing"/>
             <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -69,9 +69,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name=" mark" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
+            <spec_assertion category="W3C API Specifications" element_name=" mark" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing"/>
             <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -81,9 +81,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
+            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing"/>
             <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -93,9 +93,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
+            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing"/>
             <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -105,9 +105,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
+            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing"/>
             <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>

--- a/webapi/webapi-usertiming-w3c-tests/tests.full.xml
+++ b/webapi/webapi-usertiming-w3c-tests/tests.full.xml
@@ -3,9 +3,9 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="webapi-usertiming-w3c-tests">
     <set name="usertiming" type="js">
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_marks_003" priority="P1" purpose="Check if the performance.clearMarks() is called with a non-existent mark which shouldn't change the state of the Performance Timeline" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_marks" priority="P1" purpose="Test user timing clear marks" status="approved" type="compliance" subcase="7">
         <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_marks.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_marks.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -15,33 +15,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_marks_005" priority="P1" purpose="Check if the performance.clearMarks() is called with a existed mark which should no longer be present in the Performance Timeline" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_measures" priority="P1" purpose="Test user timing clear measures" status="approved" type="compliance" subcase="7">
         <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_marks.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="clearMarks" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
-            <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_marks_007" priority="P2" purpose="Check if the performance.clearMarks() is called that clear all marks then window.performance.getEntriesByType('mark') returns an empty object" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_marks.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="clearMarks" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
-            <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_measures_003" priority="P1" purpose="Check if the performance.clearMeasures() is called with a non-existent measure which shouldn't change the state of the Performance Timeline" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_measures.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_measures.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -51,31 +27,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_measures_005" priority="P1" purpose="Check if the performance.clearMeasures() is called with a existed measure which should no longer be present in the Performance Timeline" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_measures.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="clearMeasures" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
-            <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_measures_007" priority="P2" purpose="Check if the performance.clearMeasures() is called that clear all measures then window.performance.getEntriesByType('measure') returns an empty object" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_measures.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="clearMeasures" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
-            <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_mark" priority="P1" purpose="Check if this test validates that the performance.mark() method is working properly" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_mark" priority="P1" purpose="Test user timing mark" status="approved" type="compliance" subcase="21">
         <description>
           <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_mark.html</test_script_entry>
         </description>
@@ -87,9 +39,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="usertiming_mark_without_parameter" priority="P1" purpose="Check if the window.performance.mark() threw a TYPE_ERR exception when invoke without a parameter" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_mark_and_measure_exception_without_parameter" priority="P1" purpose="Test user timing mark and measure exception without parameter" status="approved" type="compliance" subcase="5">
         <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_mark_and_measure_exception_when_invoke_without_parameter.html?total_num=5&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_mark_and_measure_exception_when_invoke_without_parameter.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -99,19 +51,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="usertiming_measure_without_parameter" priority="P1" purpose="Check if the window.performance.measure() threw a TYPE_ERR exception when invoke without a parameter" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_mark_and_measure_exception_when_invoke_without_parameter.html?total_num=5&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
-            <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_mark_exceptions" priority="P1" purpose="Check if throws a SYNTAX_ERR exception if the markName argument is the same name as an attribute in the PerformanceTiming interface" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_mark_exceptions" priority="P1" purpose="Test user timing mark exceptions" status="approved" type="compliance" subcase="41">
         <description>
           <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_mark_exceptions.html</test_script_entry>
         </description>
@@ -123,7 +63,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="usertiming_mark_with_name_optional_attribute" priority="P2" purpose="Check if this test validates exception scenarios of invoking performance.mark() with param of 'secureConnectionStart'" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="usertiming_mark_with_name_optional_attribute" priority="P2" purpose="Test user timing mark with name of navigation timing optional attribute" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_mark_with_name_of_navigation_timing_optional_attribute.html</test_script_entry>
         </description>
@@ -135,7 +75,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure" priority="P1" purpose="Check if this test validates that the performance.measure() method is working properly" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure" priority="P1" purpose="Test user timing measure" status="approved" type="compliance" subcase="31">
         <description>
           <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure.html</test_script_entry>
         </description>
@@ -147,9 +87,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_003" priority="P1" purpose="Check if the window.performance.measure() throws a SYNTAX_ERR exception whenever a non-existent mark is provided as the startMark or endMark" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions" priority="P1" purpose="Test user timing measure exceptions" status="approved" type="compliance" subcase="17">
         <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -159,91 +99,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_005" priority="P1" purpose="Check if the window.performance.measure() throws a SYNTAX_ERR exception whenever a non-existent mark is provided as the startMark" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
-            <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_007" priority="P1" purpose="Check if the window.performance.measure() throws a SYNTAX_ERR exception whenever a non-existent mark is provided as the endMark" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
-            <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_009" priority="P1" purpose="Check if the window.performance.measure() throws a SYNTAX_ERR exception whenever a non-existent marks are provided as the startMark and endMark" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
-            <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_011" priority="P1" purpose="Check if the window.performance.measure() throws a INVALID_ACCESS_ERR whenever a navigation timing attribute with a value of zero is provided as the startMark or endMark" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
-            <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_013" priority="P1" purpose="Check if the window.performance.measure() throws a INVALID_ACCESS_ERR whenever a navigation timing attribute with a value of zero is provided as the startMark" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
-            <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_015" priority="P1" purpose="Check if the window.performance.measure() throws a INVALID_ACCESS_ERR whenever a navigation timing attribute with a value of zero is provided as the endMark" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
-            <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_017" priority="P1" purpose="Check if the window.performance.measure() throws a INVALID_ACCESS_ERR whenever a navigation timing attribute with a value of zero is provided as the startMark and endMark" status="approved" type="compliance">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="W3C API Specifications" element_name="measure" element_type="method" interface="Performance" section="Performance and Optimization" specification="User Timing" />
-            <spec_url>http://www.w3.org/TR/user-timing/#extensions-performance-interface</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_navigation_timing" priority="P2" purpose="Check if the performance.measure() method is working properly when navigation timing attributes are used in place of mark names" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_navigation_timing" priority="P2" purpose="Test user timing measure navigation timing" status="approved" type="compliance" subcase="17">
         <description>
           <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_navigation_timing.html</test_script_entry>
         </description>

--- a/webapi/webapi-usertiming-w3c-tests/tests.xml
+++ b/webapi/webapi-usertiming-w3c-tests/tests.xml
@@ -3,107 +3,47 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="webapi-usertiming-w3c-tests">
     <set name="usertiming" type="js">
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_marks_003" purpose="Check if the performance.clearMarks() is called with a non-existent mark which shouldn't change the state of the Performance Timeline">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_marks" purpose="Test user timing clear marks" subcase="7">
         <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_marks.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_marks.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_marks_005" purpose="Check if the performance.clearMarks() is called with a existed mark which should no longer be present in the Performance Timeline">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_measures" purpose="Test user timing clear measures" subcase="7">
         <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_marks.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_measures.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_marks_007" purpose="Check if the performance.clearMarks() is called that clear all marks then window.performance.getEntriesByType('mark') returns an empty object">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_marks.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_measures_003" purpose="Check if the performance.clearMeasures() is called with a non-existent measure which shouldn't change the state of the Performance Timeline">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_measures.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_measures_005" purpose="Check if the performance.clearMeasures() is called with a existed measure which should no longer be present in the Performance Timeline">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_measures.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_clear_measures_007" purpose="Check if the performance.clearMeasures() is called that clear all measures then window.performance.getEntriesByType('measure') returns an empty object">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_clear_measures.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_mark" purpose="Check if this test validates that the performance.mark() method is working properly">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_mark" purpose="Test user timing mark" subcase="21">
         <description>
           <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_mark.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="usertiming_mark_without_parameter" purpose="Check if the window.performance.mark() threw a TYPE_ERR exception when invoke without a parameter">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_mark_and_measure_exception_without_parameter" purpose="Test user timing mark and measure exception without parameter" subcase="5">
         <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_mark_and_measure_exception_when_invoke_without_parameter.html?total_num=5&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_mark_and_measure_exception_when_invoke_without_parameter.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="usertiming_measure_without_parameter" purpose="Check if the window.performance.measure() threw a TYPE_ERR exception when invoke without a parameter">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_mark_and_measure_exception_when_invoke_without_parameter.html?total_num=5&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_mark_exceptions" purpose="Check if throws a SYNTAX_ERR exception if the markName argument is the same name as an attribute in the PerformanceTiming interface">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_mark_exceptions" purpose="Test user timing mark exceptions" subcase="41">
         <description>
           <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_mark_exceptions.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="usertiming_mark_with_name_optional_attribute" purpose="Check if this test validates exception scenarios of invoking performance.mark() with param of 'secureConnectionStart'">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="usertiming_mark_with_name_optional_attribute" purpose="Test user timing mark with name of navigation timing optional attribute" subcase="3">
         <description>
           <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_mark_with_name_of_navigation_timing_optional_attribute.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure" purpose="Check if this test validates that the performance.measure() method is working properly">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure" purpose="Test user timing measure" subcase="31">
         <description>
           <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_003" purpose="Check if the window.performance.measure() throws a SYNTAX_ERR exception whenever a non-existent mark is provided as the startMark or endMark">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions" purpose="Test user timing measure exceptions" subcase="17">
         <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_005" purpose="Check if the window.performance.measure() throws a SYNTAX_ERR exception whenever a non-existent mark is provided as the startMark">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_007" purpose="Check if the window.performance.measure() throws a SYNTAX_ERR exception whenever a non-existent mark is provided as the endMark">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_009" purpose="Check if the window.performance.measure() throws a SYNTAX_ERR exception whenever a non-existent marks are provided as the startMark and endMark">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_011" purpose="Check if the window.performance.measure() throws a INVALID_ACCESS_ERR whenever a navigation timing attribute with a value of zero is provided as the startMark or endMark">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_013" purpose="Check if the window.performance.measure() throws a INVALID_ACCESS_ERR whenever a navigation timing attribute with a value of zero is provided as the startMark">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_015" purpose="Check if the window.performance.measure() throws a INVALID_ACCESS_ERR whenever a navigation timing attribute with a value of zero is provided as the endMark">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_exceptions_017" purpose="Check if the window.performance.measure() throws a INVALID_ACCESS_ERR whenever a navigation timing attribute with a value of zero is provided as the startMark and endMark">
-        <description>
-          <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_exceptions.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_navigation_timing" purpose="Check if the performance.measure() method is working properly when navigation timing attributes are used in place of mark names">
+      <testcase component="W3C_HTML5 APIs/Performance and Optimization/User Timing" execution_type="auto" id="test_user_timing_measure_navigation_timing" purpose="Test user timing measure navigation timing" subcase="17">
         <description>
           <test_script_entry>/opt/webapi-usertiming-w3c-tests/usertiming/w3c/test_user_timing_measure_navigation_timing.html</test_script_entry>
         </description>


### PR DESCRIPTION
- Add subcase support for Transitions,Resourcetiming,Websocket,Usertiming
- Format tests.full.xml by:
xmllint --format tests.full.xml > tests.full.new.xml
- Remove 'Partial' for CSS Transitions

tct-transitions-css3-tests:
Impacted tests(approved): new 108, update 0, delete 0
Unit test platform: Crosswalk for Android 15.44.384.0
Unit result summary: pass 132, fail 21, block 0

webapi-resourcetiming-w3c-tests:
Impacted tests(approved): new 26, update 0, delete 0
Unit test platform: Crosswalk for Android 15.44.384.0
Unit result summary: pass 73, fail 2, block 19

tct-websocket-w3c-tests:
Impacted tests(approved): new 237, update 0, delete 0
Unit test platform: Crosswalk for Android 15.44.384.0
Unit result summary: pass 497, fail 7, block 3

webapi-usertiming-w3c-tests:
Impacted tests(approved): new 128, update 0, delete 0
Unit test platform: Crosswalk for Android 15.44.384.0
Unit result summary: pass 149, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4770
https://crosswalk-project.org/jira/browse/XWALK-4782