### PR TITLE
[apptools-iOS] Do not allow user to name the project as 'www' for apptools iOS

### DIFF
--- a/apptools/apptools-ios-tests/apptools/allpairs.py
+++ b/apptools/apptools-ios-tests/apptools/allpairs.py
@@ -54,7 +54,8 @@ def generate_cmd():
         'org.123example.xwalk',
         'org.example._xwalk',
         'org.xwalk.Tests',
-        '_org.example.xwalk']
+        '_org.example.xwalk',
+        'org.xwalk.www']
     flag = ''
     num = 0
     os.chdir(comm.ConstPath + '/../')

--- a/apptools/apptools-ios-tests/apptools/pkgName.py
+++ b/apptools/apptools-ios-tests/apptools/pkgName.py
@@ -152,5 +152,12 @@ class TestCaseUnit(unittest.TestCase):
                 "negative16",
                 "crosswalk-app create _org.example.xwalk"))
 
+    def test_pkgName_negative17(self):
+        self.assertEqual(
+            "PASS",
+            allpairs.tryRunApp(
+                "negative17",
+                "crosswalk-app create org.xwalk.www"))
+
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-ios-tests/report/cmd.txt
+++ b/apptools/apptools-ios-tests/report/cmd.txt
@@ -14,3 +14,4 @@ negative13	crosswalk-app create org.123example.xwalk
 negative14	crosswalk-app create org.example._xwalk
 negative15	crosswalk-app create org.xwalk.Tests
 negative16	crosswalk-app create _org.example.xwalk
+negative17	crosswalk-app create org.xwalk.www

--- a/apptools/apptools-ios-tests/tests.full.xml
+++ b/apptools/apptools-ios-tests/tests.full.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite category="Crosswalk App Tools" name="apptools-ios-tests">
     <set name="CLI" type="pyunit">
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" priority="P1" purpose="iOS - Validate project can be created with validate package naming rule" status="approved" type="Functional" subcase="16">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" priority="P1" purpose="iOS - Validate project can be created with validate package naming rule" status="approved" type="Functional" subcase="17">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/pkgName.py</test_script_entry>
         </description>

--- a/apptools/apptools-ios-tests/tests.xml
+++ b/apptools/apptools-ios-tests/tests.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite category="Crosswalk App Tools" name="apptools-ios-tests">
     <set name="CLI" type="pyunit">
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" purpose="iOS - Validate project can be created with validate package naming rule" subcase="16">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" purpose="iOS - Validate project can be created with validate package naming rule" subcase="17">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/pkgName.py</test_script_entry>
         </description>


### PR DESCRIPTION
Do not allow user to name the project as "www"

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4813