### PR TITLE
[apptools-android] Default version for app should be 0.1 on apptools android

### DIFF
--- a/apptools/apptools-android-tests/apptools/apk_name.py
+++ b/apptools/apptools-android-tests/apptools/apk_name.py
@@ -46,6 +46,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
         appVersion = comm.build(self, buildcmd)
         comm.clear("org.xwalk.test")
+        self.assertEquals(data['xwalk_app_version'].strip(os.linesep), "0.1")
         self.assertEquals(data['xwalk_app_version'].strip(os.linesep), appVersion)
 
     def test_update_app_version(self):
@@ -56,12 +57,12 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         jsons = jsonfile.read()
         jsonfile.close()
         jsonDict = json.loads(jsons)
-        jsonDict["xwalk_app_version"] = "0.1"
+        jsonDict["xwalk_app_version"] = "0.0.1"
         json.dump(jsonDict, open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "w"))
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
         appVersion = comm.build(self, buildcmd)
         comm.clear("org.xwalk.test")
-        self.assertEquals(appVersion, "0.1")
+        self.assertEquals(appVersion, "0.0.1")
 
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-android-tests/apptools/versionCode.py
+++ b/apptools/apptools-android-tests/apptools/versionCode.py
@@ -58,7 +58,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.clear("org.xwalk.test")
         self.assertEquals(versionCode, versionCode_xml)
 
-    def test_update_app_version_onedot(self):
+    def test_update_app_version(self):
         comm.setUp()
         comm.create(self)
         os.chdir('org.xwalk.test')
@@ -66,7 +66,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         jsons = jsonfile.read()
         jsonfile.close()
         jsonDict = json.loads(jsons)
-        jsonDict["xwalk_app_version"] = "0.1"
+        jsonDict["xwalk_app_version"] = "1"
         json.dump(jsonDict, open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "w"))
         with open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json") as json_file:
             data = json.load(json_file)
@@ -85,7 +85,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
                 versionCode_xml = attributes[x]
                 break
         comm.clear("org.xwalk.test")
-        self.assertEquals(data['xwalk_app_version'].strip(os.linesep), "0.1")
+        self.assertEquals(data['xwalk_app_version'].strip(os.linesep), "1")
         self.assertEquals(versionCode, versionCode_xml)
 
     def test_update_app_version_twodot(self):

--- a/apptools/apptools-android-tests/apptools/versionName.py
+++ b/apptools/apptools-android-tests/apptools/versionName.py
@@ -53,6 +53,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
                 break
         comm.clear("org.xwalk.test")
         self.assertEquals(buildstatus, 0)
+        self.assertEquals(data['xwalk_app_version'].strip("\n\t"), "0.1")
         self.assertEquals(data['xwalk_app_version'].strip("\n\t"), versionName_xml)
 
     def test_update_app_version(self):
@@ -63,7 +64,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         jsons = jsonfile.read()
         jsonfile.close()
         jsonDict = json.loads(jsons)
-        jsonDict["xwalk_app_version"] = "0.1"
+        jsonDict["xwalk_app_version"] = "0.0.1"
         json.dump(jsonDict, open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "w"))
         with open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json") as json_file:
             data = json.load(json_file)
@@ -76,7 +77,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
                 versionName_xml = attributes[x]
                 break
         comm.clear("org.xwalk.test")
-        self.assertEquals(data['xwalk_app_version'].strip("\n\t"), "0.1")
+        self.assertEquals(data['xwalk_app_version'].strip("\n\t"), "0.0.1")
         self.assertEquals(buildstatus, 0)
         self.assertEquals(data['xwalk_app_version'].strip("\n\t"), versionName_xml)
 


### PR DESCRIPTION
Impacted tests(approved): new 0, update 5, delete 0
Unit test platform: [Android]
Unit result summary: pass 5, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4870
https://crosswalk-project.org/jira/browse/XWALK-4852