### PR TITLE
[webapi] Update test type to auto for Gumallow manual tests

### DIFF
--- a/webapi/tct-gumallow-w3c-tests/tests.full.xml
+++ b/webapi/tct-gumallow-w3c-tests/tests.full.xml
@@ -9,7 +9,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia-20111130.html</spec_url>
             <spec_statement>Navigator implements NavigatorUserMedia</spec_statement>
           </spec>
@@ -21,7 +21,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" usage="true"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia-20111130.html#navigatorusermedia</spec_url>
             <spec_statement>Set to true if a audio track is requested, default is false</spec_statement>
           </spec>
@@ -33,7 +33,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" usage="true"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia-20111130.html#navigatorusermedia</spec_url>
             <spec_statement>Access to multimedia streams (video, audio, or both) from local devices (video cameras, microphones, Web cams) can have a number of uses, such as real-time communication, recording, surveillance.</spec_statement>
           </spec>
@@ -45,7 +45,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" usage="true"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia-20111130.html#navigatorusermedia</spec_url>
             <spec_statement>Set to true if a audio track is requested, default is false</spec_statement>
           </spec>
@@ -57,7 +57,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" usage="true"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia-20111130.html#navigatorusermedia</spec_url>
             <spec_statement>Set to true if an video track is requested, default is false</spec_statement>
           </spec>
@@ -69,7 +69,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" usage="true" />
+            <spec_assertion category="Tizen W3C API Specifications" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" usage="true"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia-20111130.html#navigatorusermedia</spec_url>
             <spec_statement>Set to true if an video track is requested, default is false</spec_statement>
           </spec>
@@ -81,9 +81,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -93,9 +93,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -105,9 +105,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -117,9 +117,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -129,9 +129,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -141,9 +141,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -153,9 +153,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getUserMedia" element_type="method" interface="NavigatorUserMedia" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -165,9 +165,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getAudioTracks" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getAudioTracks" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -177,9 +177,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getVideoTracks" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getVideoTracks" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -189,9 +189,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getAudioTracks" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getAudioTracks" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -201,9 +201,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="addTrack" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="addTrack" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -213,9 +213,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="addTrack" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="addTrack" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -225,9 +225,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getTrackById" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getTrackById" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -237,9 +237,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getTrackById" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getTrackById" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -249,9 +249,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getTrackById" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getTrackById" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -261,9 +261,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="onremovetrack" element_type="method" interface="MediaStreamTrack" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="onremovetrack" element_type="method" interface="MediaStreamTrack" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -273,9 +273,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="ended" element_type="method" interface="MediaStreamTrack" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="ended" element_type="method" interface="MediaStreamTrack" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -285,9 +285,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="getVideoTracks" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="getVideoTracks" element_type="method" interface="MediaStream" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -297,9 +297,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="MediaStreamTrack" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="readyState" element_type="attribute" interface="MediaStreamTrack" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -309,9 +309,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="Tizen W3C API Specifications" element_name="id" element_type="attribute" interface="MediaStreamTrack" section="Media" specification="getUserMedia" />
+            <spec_assertion category="Tizen W3C API Specifications" element_name="id" element_type="attribute" interface="MediaStreamTrack" section="Media" specification="getUserMedia"/>
             <spec_url>http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>

--- a/webapi/tct-gumallow-w3c-tests/tests.full.xml
+++ b/webapi/tct-gumallow-w3c-tests/tests.full.xml
@@ -75,7 +75,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="video-assignment-manual" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia can be properly assigned to a video element via the srcObject attribute" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="video-assignment" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia can be properly assigned to a video element via the srcObject attribute" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/mediastreams-as-media-elements/video-assignment-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -159,7 +159,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="disabled-audio-silence" priority="P2" purpose="Test checks that a disabled audio track in a MediaStream is rendered as silence" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="disabled-audio-silence" priority="P2" purpose="Test checks that a disabled audio track in a MediaStream is rendered as silence" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/introduction/disabled-audio-silence-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -171,7 +171,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="disabled-video-black" priority="P2" purpose="Test checks that a disabled video track in a MediaStream is rendered as blackness" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="disabled-video-black" priority="P2" purpose="Test checks that a disabled video track in a MediaStream is rendered as blackness" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/introduction/disabled-video-black-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -183,7 +183,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="audio" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one audio track" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="audio" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one audio track" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/audio-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -195,7 +195,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastream-addtrack" priority="P2" purpose="Test checks that adding a track to a MediaStream works as expected" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastream-addtrack" priority="P2" purpose="Test checks that adding a track to a MediaStream works as expected" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-addtrack-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -207,7 +207,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastream-finished-add" priority="P2" purpose="Test checks that adding a track to a finished MediaStream raises an INVALID_STATE_ERR exception" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastream-finished-add" priority="P2" purpose="Test checks that adding a track to a finished MediaStream raises an INVALID_STATE_ERR exception" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-finished-add-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -219,7 +219,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastream-gettrackid" priority="P2" purpose="Test checks that MediaStream.getTrackById behaves as expected" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastream-gettrackid" priority="P2" purpose="Test checks that MediaStream.getTrackById behaves as expected" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-gettrackid-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -231,7 +231,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastream-idl" priority="P2" purpose="Test checks that the MediaStream constructor follows the algorithm set in the spec" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastream-idl" priority="P2" purpose="Test checks that the MediaStream constructor follows the algorithm set in the spec" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-idl-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -243,7 +243,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastream-id-manual" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has a correct id" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastream-id" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has a correct id" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-id-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -255,7 +255,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastream-removetrack" priority="P2" purpose="Test checks that removinging a track from a MediaStream works as expected" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastream-removetrack" priority="P2" purpose="Test checks that removinging a track from a MediaStream works as expected" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-removetrack-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -267,7 +267,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="stream-ended" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has a ended set to false at start, and triggers 'onended' when it is set to true" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="stream-ended" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has a ended set to false at start, and triggers 'onended' when it is set to true" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/stream-ended-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -279,7 +279,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="video" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one video track and no audio" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="video" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one video track and no audio" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/video-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -291,7 +291,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastreamtrack-end" priority="P2" purpose="Test checks that the video and audio tracks of MediaStream object returned by the success callback in getUserMedia are correctly set into ended state when permission is revoked" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastreamtrack-end" priority="P2" purpose="Test checks that the video and audio tracks of MediaStream object returned by the success callback in getUserMedia are correctly set into ended state when permission is revoked" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastreamtrack/mediastreamtrack-end-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -303,7 +303,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastreamtrack-id" priority="P2" purpose="Test checks that distinct mediastream tracks have distinct ids" status="ready" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastreamtrack-id" priority="P2" purpose="Test checks that distinct mediastream tracks have distinct ids" status="ready" type="compliance">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastreamtrack/mediastreamtrack-id-manual.html?usePrefixes=1</test_script_entry>
         </description>

--- a/webapi/tct-gumallow-w3c-tests/tests.xml
+++ b/webapi/tct-gumallow-w3c-tests/tests.xml
@@ -33,7 +33,7 @@
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/navigator_video_not_getting_datastream.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="video-assignment-manual" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia can be properly assigned to a video element via the srcObject attribute">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="video-assignment" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia can be properly assigned to a video element via the srcObject attribute">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/mediastreams-as-media-elements/video-assignment-manual.html?usePrefixes=1</test_script_entry>
         </description>
@@ -68,67 +68,67 @@
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/unknownkey-option-param.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="disabled-audio-silence" purpose="Test checks that a disabled audio track in a MediaStream is rendered as silence">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="disabled-audio-silence" purpose="Test checks that a disabled audio track in a MediaStream is rendered as silence">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/introduction/disabled-audio-silence-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="disabled-video-black" purpose="Test checks that a disabled video track in a MediaStream is rendered as blackness">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="disabled-video-black" purpose="Test checks that a disabled video track in a MediaStream is rendered as blackness">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/introduction/disabled-video-black-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="audio" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one audio track">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="audio" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one audio track">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/audio-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastream-addtrack" purpose="Test checks that adding a track to a MediaStream works as expected">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastream-addtrack" purpose="Test checks that adding a track to a MediaStream works as expected">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-addtrack-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastream-finished-add" purpose="Test checks that adding a track to a finished MediaStream raises an INVALID_STATE_ERR exception">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastream-finished-add" purpose="Test checks that adding a track to a finished MediaStream raises an INVALID_STATE_ERR exception">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-finished-add-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastream-gettrackid" purpose="Test checks that MediaStream.getTrackById behaves as expected">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastream-gettrackid" purpose="Test checks that MediaStream.getTrackById behaves as expected">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-gettrackid-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastream-idl" purpose="Test checks that the MediaStream constructor follows the algorithm set in the spec">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastream-idl" purpose="Test checks that the MediaStream constructor follows the algorithm set in the spec">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-idl-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastream-id-manual" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has a correct id">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastream-id" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has a correct id">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-id-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastream-removetrack" purpose="Test checks that removinging a track from a MediaStream works as expected">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastream-removetrack" purpose="Test checks that removinging a track from a MediaStream works as expected">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-removetrack-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="stream-ended" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has a ended set to false at start, and triggers 'onended' when it is set to true">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="stream-ended" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has a ended set to false at start, and triggers 'onended' when it is set to true">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/stream-ended-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="video" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one video track and no audio">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="video" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one video track and no audio">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/video-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastreamtrack-end" purpose="Test checks that the video and audio tracks of MediaStream object returned by the success callback in getUserMedia are correctly set into ended state when permission is revoked">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastreamtrack-end" purpose="Test checks that the video and audio tracks of MediaStream object returned by the success callback in getUserMedia are correctly set into ended state when permission is revoked">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastreamtrack/mediastreamtrack-end-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="manual" id="mediastreamtrack-id" purpose="Test checks that distinct mediastream tracks have distinct ids">
+      <testcase component="W3C_HTML5 APIs/Media/getUserMedia" execution_type="auto" id="mediastreamtrack-id" purpose="Test checks that distinct mediastream tracks have distinct ids">
         <description>
           <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastreamtrack/mediastreamtrack-id-manual.html?usePrefixes=1</test_script_entry>
         </description>


### PR DESCRIPTION
Dialog on video/audio stream didn't prompt in zte or memo, no need user interact. So change tests type from manual to auto. Automation these tests if dialog prompt again in later crosswalk release

Impacted tests(approved): new 0, update 14, delete 0
Unit test platform: Crosswalk for Android 16.44.395.0
Unit result summary: pass 17, fail 7, block 2