### PR TITLE
[apptools] Remove nodeunit cases for apptools

### DIFF
--- a/apptools/apptools-ios-tests/tests.full.xml
+++ b/apptools/apptools-ios-tests/tests.full.xml
@@ -100,11 +100,6 @@
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/test-util.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_windows_main" priority="P1" purpose="iOS - Validate if project can be created with windows platforms" status="approved" type="Functional" subcase="2">
-        <description>
-          <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/windows/test/main.js</test_script_entry>
-        </description>
-      </testcase>
     </set>
     <set name="CLI_manual" type="js">
       <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="AppTools_Help" priority="P1" purpose="iOS - Validate if all usages work well as description" status="approved" type="Functional">

--- a/apptools/apptools-ios-tests/tests.xml
+++ b/apptools/apptools-ios-tests/tests.xml
@@ -100,11 +100,6 @@
           <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/test/test-util.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_windows_main" purpose="iOS - Validate if project can be created with windows platforms" subcase="2">
-        <description>
-          <test_script_entry>/opt/apptools-ios-tests/tools/crosswalk-app-tools/windows/test/main.js</test_script_entry>
-        </description>
-      </testcase>
     </set>
     <set name="CLI_manual" type="js">
       <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="AppTools_Help" priority="P1" purpose="iOS - Validate if all usages work well as description">

--- a/apptools/apptools-linux-tests/tests.full.xml
+++ b/apptools/apptools-linux-tests/tests.full.xml
@@ -100,11 +100,6 @@
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/test-util.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_windows_main" priority="P1" purpose="Linux - Validate if project can be created with windows platforms" status="approved" type="Functional" subcase="2">
-        <description>
-          <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/windows/test/main.js</test_script_entry>
-        </description>
-      </testcase>
     </set>
     <set name="CLI_manual" type="js">
       <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="AppTools_Help" purpose="Linux - Validate if help command can display usage information" status="approved" type="Functional">

--- a/apptools/apptools-linux-tests/tests.xml
+++ b/apptools/apptools-linux-tests/tests.xml
@@ -100,11 +100,6 @@
           <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/test/test-util.js</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_windows_main" purpose="Linux - Validate if project can be created with windows platforms" subcase="2">
-        <description>
-          <test_script_entry>/opt/apptools-linux-tests/tools/crosswalk-app-tools/windows/test/main.js</test_script_entry>
-        </description>
-      </testcase>
     </set>
     <set name="CLI_manual" type="js">
       <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="AppTools_Help" purpose="Linux - Validate if help command can display usage information">


### PR DESCRIPTION
Due to windows tests only work on windows, so delete them