### PR TITLE
[Embeddingapi] Add usecase for xwalk onReceivedLoadError toast api

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/ResourceAndUIClientsActivityAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/ResourceAndUIClientsActivityAsync.java
@@ -138,7 +138,7 @@ public class ResourceAndUIClientsActivityAsync extends Activity implements XWalk
         mess.append("Test Purpose: \n\n")
         .append("Verifies XWalkView can set resource client and UI client.\n\n")
         .append("Expected Result:\n\n")
-        .append("Test passes if app get attention \"Bad SSL client authentication certificate\".");
+        .append("Test passes if app get toast attention \"Bad SSL client authentication certificate\".");
         new  AlertDialog.Builder(this)
         .setTitle("Info" )
         .setMessage(mess.toString())

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/ResourceAndUIClientsActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/ResourceAndUIClientsActivity.java
@@ -120,7 +120,7 @@ public class ResourceAndUIClientsActivity extends XWalkActivity {
         mess.append("Test Purpose: \n\n")
         .append("Verifies XWalkView can set resource client and UI client.\n\n")
         .append("Expected Result:\n\n")
-        .append("Test passes if app get attention \"Bad SSL client authentication certificate\".");
+        .append("Test passes if app get toast attention \"Bad SSL client authentication certificate\".");
         new  AlertDialog.Builder(this)
         .setTitle("Info" )
         .setMessage(mess.toString())


### PR DESCRIPTION
-Add usecase for xwalk onReceivedLoadError toast api
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4804