### PR TITLE
[EmbeddingAPI] Add usecase for xwalkview clearFormData API

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -400,5 +400,14 @@
                 <category android:name="android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".XWalkWithClearFormDataAsync"
+            android:label="XWalkWithClearFormDataAsync"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>        
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/datalist.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/datalist.html
@@ -1,0 +1,10 @@
+<input type="hidden" value="input_type_url" class="form-control"/>
+<input type="url" name="location" list="urls" class="form-control">
+<datalist id="urls">
+  <option label="MIME: Format of Internet Message Bodies" value="http://tools.ietf.org/html/rfc2045">
+  <option label="HTML 4.01 Specification" value="http://www.w3.org/TR/html4/">
+  <option label="Form Controls" value="http://www.w3.org/TR/xforms/slice8.html#ui-commonelems-hint">
+  <option label="Scalable Vector Graphics (SVG) 1.1 Specification" value="http://www.w3.org/TR/SVG/">
+  <option label="Feature Sets - SVG 1.1 - 20030114" value="http://www.w3.org/TR/SVG/feature.html">
+  <option label="The Single UNIX Specification, Version 3" value="http://www.unix-systems.org/version3/">
+</datalist>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -317,6 +317,7 @@ This usecase covers following interface and methods:
 * XWalkView interface: dispatchDraw methods
 
 
+
 ### 30. The [CookieManagerTestActivityAsync](CookieManagerTestActivityAsync.java) sample check whether XWalkCookieManager apis can work, include:
 
 * XWalkCookieManager apis can work
@@ -325,6 +326,7 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load method
 * XWalkCookieManager interface: setAcceptCookie, acceptCookie, setCookie, getCookie, removeSessionCookie, removeAllCookie, hasCookies, removeExpiredCookie, flushCookieStore
+
 
 
 ### 31. The [XWalkViewWithOnDrawAsync](XWalkViewWithOnDrawAsync.java) sample check whether onDraw method work as same as WebView, include:
@@ -346,6 +348,7 @@ This usecase covers following interface and methods:
 * XWalkView interface: onOverScrolled methods
 
 
+
 ### 33. The [AcceptFileSchemeCookiesActivityAsync](AcceptFileSchemeCookiesActivityAsync.java) sample check whether XWalkCookieManager can set AcceptFileSchemeCookies, include:
 
 * XWalkCookieManager apis can work
@@ -354,6 +357,8 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: onDraw method
 * XWalkCookieManager interface: setAcceptFileSchemeCookies, allowFileSchemeCookies methods
+
+
 
 ### 34. The [XWalkViewWithOnTouchEventAsync](XWalkViewWithOnTouchEventAsyc.java) sample check whether onTouchEvent method work as same as WebView, include:
 
@@ -374,6 +379,7 @@ This usecase covers following interface and methods:
 * XWalkView interface: onFocusChanged method
 
 
+
 ### 37. The [XWalkViewWithScrollChangedAsync](XWalkViewWithScrollChangedAsync.java) sample check whether onScrollChanged method work as same as WebView, include:
 
 * onScrollChanged can be override
@@ -381,6 +387,7 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkView interface: onScrollChanged method
+
 
 
 ### 38. The [XWalkViewWithSizeChangedAsync](XWalkViewWithSizeChangedAsync.java) sample check whether onSizeChanged method work as same as WebView, include:
@@ -392,6 +399,7 @@ This usecase covers following interface and methods:
 * XWalkView interface: onSizeChanged method
 
 
+
 ### 39. The [XWalkViewWithVisibilityChangedAsync](XWalkViewWithVisibilityChangedAsync.java) sample check whether onVisibilityChanged method work as same as WebView, include:
 
 * onVisibilityChanged can be override
@@ -399,3 +407,13 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkView interface: onVisibilityChanged method
+
+
+
+### 40. The [XWalkWithClearFormDataAsync](XWalkWithClearFormDataAsync.java) sample check whether clearFormData method work as same as WebView, include:
+
+* clearFormData can work
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, clearFormData methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkWithClearFormDataAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkWithClearFormDataAsync.java
@@ -1,0 +1,75 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.asyncsample;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkView;
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.Button;
+
+public class XWalkWithClearFormDataAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private Button clearFormData;
+    private XWalkInitializer mXWalkInitializer;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can clear form data.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Input a 'h' on the edit text.\n\n")
+        .append("2. Then the pull-down list will show.\n\n")
+        .append("3. Click the 'clearFormData' button.\n\n")
+        .append("4. Then the pull-down list will disappear.\n\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if the pull-down list will disappear.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+        
+        setContentView(R.layout.animatable_xwview_layout);
+        clearFormData = (Button) findViewById(R.id.run_animation);
+        clearFormData.setText("ClearFormData");
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);        
+
+        clearFormData.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+            	mXWalkView.clearFormData();
+            }
+        });
+        mXWalkView.load("file:///android_asset/datalist.html", null);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -401,5 +401,14 @@
                 <category android:name="android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".XWalkWithClearFormData"
+            android:label="XWalkWithClearFormData"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/assets/datalist.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/assets/datalist.html
@@ -1,0 +1,10 @@
+<input type="hidden" value="input_type_url" class="form-control"/>
+<input type="url" name="location" list="urls" class="form-control">
+<datalist id="urls">
+  <option label="MIME: Format of Internet Message Bodies" value="http://tools.ietf.org/html/rfc2045">
+  <option label="HTML 4.01 Specification" value="http://www.w3.org/TR/html4/">
+  <option label="Form Controls" value="http://www.w3.org/TR/xforms/slice8.html#ui-commonelems-hint">
+  <option label="Scalable Vector Graphics (SVG) 1.1 Specification" value="http://www.w3.org/TR/SVG/">
+  <option label="Feature Sets - SVG 1.1 - 20030114" value="http://www.w3.org/TR/SVG/feature.html">
+  <option label="The Single UNIX Specification, Version 3" value="http://www.unix-systems.org/version3/">
+</datalist>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -347,6 +347,7 @@ This usecase covers following interface and methods:
 * XWalkView interface: onOverScrolled method
 
 
+
 ### 33. The [AcceptFileSchemeCookiesActivity](AcceptFileSchemeCookiesActivity.java) sample check whether XWalkCookieManager can set AcceptFileSchemeCookies, include:
 
 * XWalkCookieManager apis can work
@@ -354,6 +355,7 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkCookieManager interface: setAcceptFileSchemeCookies, allowFileSchemeCookies methods
+
 
 
 ### 34. The [XWalkViewWithOnTouchEvent](XWalkViewWithOnTouchEvent.java) sample check whether onTouchEvent method work as same as WebView, include:
@@ -365,6 +367,7 @@ This usecase covers following interface and methods:
 * XWalkView interface: onTouchEvent method
 
 
+
 ### 35. The [XWalkViewWithOverScrollBy](XWalkViewWithOverScrollBy.java) sample check whether overScrollBy method work as same as WebView, include:
 
 * overScrollBy can be override
@@ -374,6 +377,7 @@ This usecase covers following interface and methods:
 * XWalkView interface: overScrollBy method
 
 
+
 ### 36. The [XWalkViewWithFocusChanged](XWalkViewWithFocusChanged.java) sample check whether onFocusChanged method work as same as WebView, include:
 
 * onFocusChanged can be override
@@ -381,6 +385,7 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkView interface: onFocusChanged method
+
 
 
 ### 37. The [XWalkViewWithScrollChanged](XWalkViewWithScrollChanged.java) sample check whether onScrollChanged method work as same as WebView, include:
@@ -401,6 +406,7 @@ This usecase covers following interface and methods:
 * XWalkView interface: onSizeChanged method
 
 
+
 ### 39. The [XWalkViewWithVisibilityChanged](XWalkViewWithVisibilityChanged.java) sample check whether onVisibilityChanged method work as same as WebView, include:
 
 * onVisibilityChanged can be override
@@ -408,3 +414,13 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkView interface: onVisibilityChanged method
+
+
+
+### 40. The [XWalkWithClearFormData](XWalkWithClearFormData.java) sample check whether clearFormData method work as same as WebView, include:
+
+* clearFormData can work
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, clearFormData methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkWithClearFormData.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkWithClearFormData.java
@@ -1,0 +1,54 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.sample;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkView;
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.Button;
+
+public class XWalkWithClearFormData extends XWalkActivity {
+    private XWalkView mXWalkView;
+    private Button clearFormData;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.animatable_xwview_layout);
+        clearFormData = (Button) findViewById(R.id.run_animation);
+        clearFormData.setText("ClearFormData");
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can clear form data.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Input a 'h' on the edit text.\n\n")
+        .append("2. Then the pull-down list will show.\n\n")
+        .append("3. Click the 'clearFormData' button.\n\n")
+        .append("4. Then the pull-down list will disappear.\n\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if the pull-down list will disappear.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        clearFormData.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+            	mXWalkView.clearFormData();
+            }
+        });
+        mXWalkView.load("file:///android_asset/datalist.html", null);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -492,6 +492,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithClearFormData" purpose="XWalkWithClearFormData Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewUIInflationAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -972,6 +984,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="AcceptFileSchemeCookiesAsync" purpose="AcceptFileSchemeCookiesActivity Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithClearFormDataAsync" purpose="XWalkWithClearFormDataAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -549,6 +549,19 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithClearFormData" platform="android" priority="P0" purpose="XWalkWithClearFormData Test With XWalkActivity" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewUIInflationAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -1033,6 +1046,19 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="AcceptFileSchemeCookiesAsync" platform="android" priority="P0" purpose="AcceptFileSchemeCookiesActivity Test With XWalkInitializer" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithClearFormDataAsync" platform="android" priority="P0" purpose="XWalkWithClearFormDataAsync Test With XWalkInitializer" status="approved" type="functional_positive">
         <description>
           <pre_condition />
           <post_condition />


### PR DESCRIPTION
-Add usecase for xwalkview clearFormData API
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4243