### PR TITLE
[webapi] Sync notification tag same test to latest W3C

### DIFF
--- a/webapi/tct-notification-w3c-tests/notification/w3c/tag-same-manual.html
+++ b/webapi/tct-notification-w3c-tests/notification/w3c/tag-same-manual.html
@@ -17,9 +17,9 @@ if (hasNotificationPermission()) {
                 notifications = [],
                 text1 = "This is the body: Room 101",
                 text2 = "This is the body: Room 202"
-            createPassFail("If two notifications appear: First one with the"
-                + " text \"" + text1 + "\", followed by one with the text \""
-                + text2 + "\"",
+            createPassFail("If a notification with the text \""
+                + text2 + "\", replaces the notification with the text \""
+                + text1 + "\" in the same position",
                 t, closeNotifications, notifications)
             notification1 = new Notification("New Email Received", {
                 body: text1,


### PR DESCRIPTION
As per http://www.w3.org/TR/notifications/#showing-a-notification,
a notification in the list of pending notifications or the list of active notifications
whose tag equals notification's tag and whose origin equals notification's origin,
in the same position, close old and show new.

A example introduced http://www.w3.org/TR/notifications/#tags-example

Impacted TCs num(approved): New 0, Update 1, Delete 0
Unit test Platform: Crosswalk Project for Android 16.44.396.0
Unit test result summary: Pass 1, Fail 0, Blocked 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4841