### PR TITLE
[webapi] Update suite.json to support bdd for aio package

### DIFF
--- a/webapi/tct-geoallow-w3c-tests/suite.json
+++ b/webapi/tct-geoallow-w3c-tests/suite.json
@@ -44,7 +44,18 @@
             "blacklist": [],
             "copylist": {
                 "PACK-TOOL-ROOT/resources/testharness": "resources",
-                "PACK-TOOL-ROOT/resources/webrunner": "webrunner"
+                "PACK-TOOL-ROOT/resources/webrunner": "webrunner",
+                "PACK-TOOL-ROOT/atip/tests/environment.py": "HOST_RESOURCES/w3c-geoallow-app/testscripts/environment.py",
+                "w3c-geoallow-app/testscripts": "HOST_RESOURCES/w3c-geoallow-app/testscripts"
+            },
+            "subapp-list": {
+                "w3c-geoallow-app": {
+                    "apk-common-opts": "--enable-remote-debugging",
+                    "apk-icon-opt": "",
+                    "copylist": {
+                        "../geoallow/w3c/bdd": "geoallow/w3c/bdd"
+                    }
+                }
             }
         },
         "wgt": {

--- a/webapi/tct-geodeny-w3c-tests/suite.json
+++ b/webapi/tct-geodeny-w3c-tests/suite.json
@@ -46,7 +46,20 @@
             "blacklist": [],
             "copylist": {
                 "PACK-TOOL-ROOT/resources/testharness": "resources",
-                "PACK-TOOL-ROOT/resources/webrunner": "webrunner"
+                "PACK-TOOL-ROOT/resources/webrunner": "webrunner",
+                "PACK-TOOL-ROOT/atip/tests/environment.py": "HOST_RESOURCES/w3c-geodeny-app/testscripts/environment.py",
+                "w3c-geodeny-app/testscripts": "HOST_RESOURCES/w3c-geodeny-app/testscripts"
+            },
+            "subapp-list": {
+                "w3c-geodeny-app": {
+                    "apk-common-opts": "--enable-remote-debugging",
+                    "apk-icon-opt": "",
+                    "copylist": {
+                        "../geodeny/w3c/bdd": "geodeny/w3c/bdd",
+                        "../geodeny/bdd": "geodeny/bdd",
+                        "PACK-TOOL-ROOT/resources/testharness": "resources"
+                    }
+                }
             }
         },
         "wgt": {

--- a/webapi/tct-notification-w3c-tests/suite.json
+++ b/webapi/tct-notification-w3c-tests/suite.json
@@ -46,7 +46,20 @@
             "blacklist": [],
             "copylist": {
                 "PACK-TOOL-ROOT/resources/testharness": "resources",
-                "PACK-TOOL-ROOT/resources/webrunner": "webrunner"
+                "PACK-TOOL-ROOT/resources/webrunner": "webrunner",
+                "notification/support": "notification/bdd/support",
+                "PACK-TOOL-ROOT/atip/tests/environment.py": "HOST_RESOURCES/w3c-notification-app/testscripts/environment.py",
+                "w3c-notification-app/testscripts": "HOST_RESOURCES/w3c-notification-app/testscripts"
+            },
+            "subapp-list": {
+                "w3c-notification-app": {
+                    "apk-common-opts": "--enable-remote-debugging",
+                    "apk-icon-opt": "",
+                    "copylist": {
+                        "../notification/bdd": "notification",
+                        "../notification/support": "notification/support"
+                    }
+                }
             }
         },
         "wgt": {


### PR DESCRIPTION
Update suite.json to support bdd for aio package in tct-geoallow-w3c-tests,
tct-geodeny-w3c-tests, tct-notification-w3c-tests

tct-geoallow-w3c-tests
Impacted tests(approved): new 0, update 0, delete 0
Unit test platform: Crosswalk for Android 16.44.395.0
Unit test result summary: pass 3, fail 0, block 0

tct-geodeny-w3c-tests
Impacted tests(approved): new 0, update 0, delete 0
Unit test platform: Crosswalk for Android 16.44.395.0
Unit test result summary: pass 3, fail 0, block 0

tct-notification-w3c-tests
Impacted tests(approved): new 0, update 0, delete 0
Unit test platform: Crosswalk for Android 16.44.395.0
Unit test result summary: pass 2, fail 0, block 0