### PR TITLE
[EmbeddingApi] Add usecase for xwalk onReceivedLoadError toast api

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -440,5 +440,14 @@
                 <category android:name="android.intent.category.SAMPLE_CODE" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".XWalkWithOnReceivedLoadErrorAsync"
+            android:label="XWalkWithOnReceivedLoadErrorAsync"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -445,3 +445,13 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load, setOnLongClickListener, setLongClickable methods
 
+
+
+
+### 44. The [XWalkWithOnReceivedLoadErrorAsync](XWalkWithOnReceivedLoadErrorAsync.java) sample check whether XWalkView change dialog of onReceivedLoadError to toast, include:
+
+* onReceivedLoadError can work
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, onReceivedLoadError methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkWithOnReceivedLoadErrorAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkWithOnReceivedLoadErrorAsync.java
@@ -1,0 +1,94 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.asyncsample;
+
+import org.xwalk.core.ClientCertRequest;
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.TextView;
+
+public class XWalkWithOnReceivedLoadErrorAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private TextView mTextView;    
+    private XWalkInitializer mXWalkInitializer;   
+    private static final String TAG = XWalkWithOnReceivedLoadErrorAsync.class.getName();
+    private static final String BAD_SSL_WEBSITE = "https://egov.privasphere.com/";    
+
+    class ResourceClient extends XWalkResourceClient {
+
+        public ResourceClient(XWalkView xwalkView) {
+            super(xwalkView);
+        }
+
+        public void onReceivedLoadError(XWalkView view, int errorCode, String description,
+                String failingUrl) {
+            Log.d(TAG, "Load Failed:" + description);
+            super.onReceivedLoadError(view, errorCode, description, failingUrl);
+            mTextView.setText(mTextView.getText().toString() + "Load Failed: " + description
+            		+ "\n");            
+        }
+
+        public void onReceivedClientCertRequest(XWalkView view,
+                ClientCertRequest handler) {
+            // TODO Auto-generated method stub
+            Log.d(TAG, "ClientCert Request:" + handler);
+            super.onReceivedClientCertRequest(view, handler);
+            mTextView.setText(mTextView.getText().toString() + "ClientCert Request: " + handler
+            		+ "\n");              
+        }
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView change dialog of onReceivedLoadError to toast.\n\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if app get toast attention \"Bad SSL client authentication certificate\".");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        setContentView(R.layout.version_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mTextView = (TextView) findViewById(R.id.text1);
+        mTextView.setText("XWalkView is handling a Bad SSL client certificate request. The load website is "
+        		+ BAD_SSL_WEBSITE + "\n\n");
+        		
+        mXWalkView.setResourceClient(new ResourceClient(mXWalkView));
+        mXWalkView.load(BAD_SSL_WEBSITE, null);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -439,7 +439,21 @@
         </activity>
         <activity
             android:name=".BlankWindowForVisibilityTesting"
-            android:label="@string/title_activity_blank_window_for_visibility_testing" >
+            android:label="@string/title_activity_blank_window_for_visibility_testing"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
+        <activity       
+            android:name=".XWalkWithOnReceivedLoadError"
+            android:label="XWalkWithOnReceivedLoadError"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.SAMPLE_CODE" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -454,3 +454,11 @@ This usecase covers following interface and methods:
 * XWalkView interface: load, setOnLongClickListener, setLongClickable methods
 
 
+
+### 44. The [XWalkWithOnReceivedLoadError](XWalkWithOnReceivedLoadError.java) sample check whether XWalkView change dialog of onReceivedLoadError to toast, include:
+
+* onReceivedLoadError can work
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, onReceivedLoadError methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkWithOnReceivedLoadError.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkWithOnReceivedLoadError.java
@@ -1,0 +1,75 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.sample;
+
+import org.xwalk.core.ClientCertRequest;
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.TextView;
+
+
+public class XWalkWithOnReceivedLoadError extends XWalkActivity {
+    private XWalkView mXWalkView;
+    private TextView mTextView;
+    private static final String TAG = XWalkWithOnReceivedLoadError.class.getName();
+    private static final String BAD_SSL_WEBSITE = "https://egov.privasphere.com/";
+
+    class ResourceClient extends XWalkResourceClient {
+
+        public ResourceClient(XWalkView xwalkView) {
+            super(xwalkView);
+        }
+
+        public void onReceivedLoadError(XWalkView view, int errorCode, String description,
+                String failingUrl) {
+            Log.d(TAG, "Load Failed:" + description);
+            super.onReceivedLoadError(view, errorCode, description, failingUrl);
+            mTextView.setText(mTextView.getText().toString() + "Load Failed: " + description
+            		+ "\n");
+        }
+
+        public void onReceivedClientCertRequest(XWalkView view,
+                ClientCertRequest handler) {
+            // TODO Auto-generated method stub
+            Log.d(TAG, "ClientCert Request:" + handler);
+            super.onReceivedClientCertRequest(view, handler);
+            mTextView.setText(mTextView.getText().toString() + "ClientCert Request: " + handler
+            		+ "\n");            
+        }
+    }
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.version_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mTextView = (TextView) findViewById(R.id.text1);
+        mTextView.setText("XWalkView is handling a Bad SSL client certificate request. The load website is "
+        		+ BAD_SSL_WEBSITE + "\n\n");
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView change dialog of onReceivedLoadError to toast.\n\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if app get toast attention \"Bad SSL client authentication certificate\".");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView.setResourceClient(new ResourceClient(mXWalkView));
+        mXWalkView.load(BAD_SSL_WEBSITE, null);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -542,6 +542,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithOnReceivedLoadError" purpose="XWalkWithOnReceivedLoadError Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewUIInflationAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -1072,6 +1084,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithDisableLongClickAsync" purpose="XWalkViewWithDisableLongClickAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithOnReceivedLoadErrorAsync" purpose="XWalkWithOnReceivedLoadErrorAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -627,6 +627,19 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithOnReceivedLoadError" platform="android" priority="P0" purpose="XWalkWithOnReceivedLoadError Test With XWalkActivity" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewUIInflationAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -1137,6 +1150,19 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithDisableLongClickAsync" platform="android" priority="P0" purpose="XWalkViewWithDisableLongClickAsync Test With XWalkInitializer" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkWithOnReceivedLoadErrorAsync" platform="android" priority="P0" purpose="XWalkWithOnReceivedLoadErrorAsync Test With XWalkInitializer" status="approved" type="functional_positive">
         <description>
           <pre_condition />
           <post_condition />


### PR DESCRIPTION
-Add usecase for xwalk onReceivedLoadError toast api
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4804