### PR TITLE
[usecase-linux] Add usecase for Icon Display

### DIFF
--- a/usecase/usecase-wrt-linux-tests/samples/IconDisplay/README.md
+++ b/usecase/usecase-wrt-linux-tests/samples/IconDisplay/README.md
@@ -1,0 +1,7 @@
+## Usecase Design
+
+This sample demonstrates icon display support in taskbar.
+
+## Spec Link
+
+https://crosswalk-project.org/jira/browse/XWALK-4764

--- a/usecase/usecase-wrt-linux-tests/samples/IconDisplay/index.html
+++ b/usecase/usecase-wrt-linux-tests/samples/IconDisplay/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, width=device-width">
+    <link rel="stylesheet" type="text/css" href="../../css/bootstrap.css">
+    <link rel="stylesheet" type="text/css" href="../../css/main.css">
+    <script src="../../js/jquery-2.1.3.min.js"></script>
+    <script src="../../js/bootstrap.min.js"></script>
+    <script src="../../js/common.js"></script>
+    <script src="../../js/tests.js"></script>
+  </head>
+  <body>
+    <div id="header">
+      <h3 id="main_page_title"></h3>
+    </div>
+    <div class="content">
+      <h2>Test Steps:</h2>
+      <ol>
+        <li>Access website with command like:<br>
+            xwalk --app-icon=/path/to/icon.png https://crosswalk-project.org/
+        </li>
+      </ol>
+      <h2>Expected Result:</h2>
+      <ol>
+        <li>The icon specified in the command line should be shown in taskbar</li>
+      </ol>
+    </div>
+    <div class="footer">
+      <div id="footer"></div>
+    </div>
+    <div class="modal fade" id="popup_info">
+      <p>Verifies icon display support in taskbar</p>
+    </div>
+  </body>
+</html>

--- a/usecase/usecase-wrt-linux-tests/steps/IconDisplay/step.js
+++ b/usecase/usecase-wrt-linux-tests/steps/IconDisplay/step.js
@@ -1,0 +1,4 @@
+var step = '<font class="fontSize">'
+            +'<p>Test Purpose:</p>'
+            +'<p>Verifies icon display support in taskbar</p>'
+          +'</font>';

--- a/usecase/usecase-wrt-linux-tests/tests.full.xml
+++ b/usecase/usecase-wrt-linux-tests/tests.full.xml
@@ -28,6 +28,8 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="SystemIMEs" platform="linux" priority="P1" purpose="SystemIMEs" status="approved" subcase="2" type="functional_positive">
       </testcase>
+      <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="IconDisplay" platform="linux" priority="P1" purpose="IconDisplay" status="approved" subcase="2" type="functional_positive">
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/usecase/usecase-wrt-linux-tests/tests.xml
+++ b/usecase/usecase-wrt-linux-tests/tests.xml
@@ -27,6 +27,8 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="SystemIMEs" purpose="SystemIMEs">
       </testcase>
+      <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="IconDisplay" purpose="IconDisplay">
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: Crosswalk for Linux 15.44.384
Unit test result summary: pass 0, fail 1, block 0

Icon specified in the command line is not shown in taskbar

BUG=https://crosswalk-project.org/jira/browse/XWALK-4764