### PR TITLE
[apptools-windows] MSI name should contain version number for apptools windows

### DIFF
--- a/apptools/apptools-windows-tests/apptools/Check_VersionName.html
+++ b/apptools/apptools-windows-tests/apptools/Check_VersionName.html
@@ -45,14 +45,14 @@ Authors:
         Update "xwalk_app_version" in app\manifest.json file <br/>
         $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Install the app <br/>
-        Open Control Center->Programs panel, then search for the app, check if the app version is same with "xwalk_app_version" which you update in manifest.json file
+        Open Control Center->Programs panel, then search for the app, check if the app version contains "xwalk_app_version" which you update in manifest.json file
     </li>
   </ol>
   <p>
     <strong>Expected Results:</strong>
   </p>
   <ol>
-    <li>The app version is same with "xwalk_app_version" which you update in manifest.json file</li>
+    <li>The app version contains "xwalk_app_version" which you update in manifest.json file</li>
   </ol>
 </body>
 

--- a/apptools/apptools-windows-tests/apptools/apk_name.py
+++ b/apptools/apptools-windows-tests/apptools/apk_name.py
@@ -47,7 +47,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         appVersion = comm.build(self, buildcmd)
         comm.clear("org.xwalk.test")
         self.assertEquals(data['xwalk_app_version'].strip(os.linesep), "0.1")
-        self.assertEquals(data['xwalk_app_version'].strip(os.linesep), appVersion)
+        self.assertIn(data['xwalk_app_version'].strip(os.linesep), appVersion)
 
     def test_update_app_version(self):
         comm.setUp()
@@ -62,7 +62,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
         appVersion = comm.build(self, buildcmd)
         comm.clear("org.xwalk.test")
-        self.assertEquals(appVersion, "0.0.1")
+        self.assertIn("0.0.1", appVersion)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Impacted tests(approved): new 0, update 3, delete 0
Unit test platform: [Windows]
Unit test result summary: pass 3, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4915