### PR TITLE
[apptools] Windows platforms is only support on Microsoft Windows

### DIFF
--- a/apptools/apptools-android-tests/apptools/create_with_target_platform.py
+++ b/apptools/apptools-android-tests/apptools/create_with_target_platform.py
@@ -40,14 +40,9 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir(comm.XwalkPath)
         cmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app create org.xwalk.test --platforms=android"
         packstatus = os.system(cmd)
-        comm.clear("org.xwalk.test")
-        self.assertEquals(packstatus, 0)
-
-    def test_create_with_platform_windows(self):
-        comm.setUp()
-        os.chdir(comm.XwalkPath)
-        cmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app create org.xwalk.test --platforms=windows"
-        packstatus = os.system(cmd)
+        os.chdir('org.xwalk.test')
+        buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
+        comm.build(self, buildcmd)
         comm.clear("org.xwalk.test")
         self.assertEquals(packstatus, 0)
 

--- a/apptools/apptools-android-tests/apptools/target_platforms.py
+++ b/apptools/apptools-android-tests/apptools/target_platforms.py
@@ -41,7 +41,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         cmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app platforms"
         status = os.popen(cmd).readlines()
         self.assertEquals("android", status[0].strip(" * " + os.linesep))
-        self.assertEquals("windows", status[1].strip(" * " + os.linesep))
 
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-android-tests/tests.full.xml
+++ b/apptools/apptools-android-tests/tests.full.xml
@@ -63,7 +63,7 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/versionCode.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_with_target_platform" priority="P1" purpose="Android - Validate project can be created with validate platform" status="approved" type="Functional" subcase="5">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_with_target_platform" priority="P1" purpose="Android - Validate project can be created with validate platform" status="approved" type="Functional" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/create_with_target_platform.py</test_script_entry>
         </description>

--- a/apptools/apptools-android-tests/tests.xml
+++ b/apptools/apptools-android-tests/tests.xml
@@ -63,7 +63,7 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/versionCode.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_with_target_platform" purpose="Android - Validate project can be created with validate platform" subcase="5">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_with_target_platform" purpose="Android - Validate project can be created with validate platform" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/create_with_target_platform.py</test_script_entry>
         </description>

--- a/apptools/apptools-ios-tests/apptools/create_with_target_platform.py
+++ b/apptools/apptools-ios-tests/apptools/create_with_target_platform.py
@@ -42,6 +42,9 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir(comm.XwalkPath)
         cmd = comm.PackTools + "crosswalk-app create org.xwalk.test --platforms=ios"
         packstatus = commands.getstatusoutput(cmd)
+        os.chdir('org.xwalk.test')
+        buildcmd = comm.PackTools + "crosswalk-app build"
+        comm.build(self, buildcmd)
         comm.clear("org.xwalk.test")
         self.assertEquals(packstatus[0], 0)
 
@@ -50,14 +53,9 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir(comm.XwalkPath)
         cmd = comm.PackTools + "crosswalk-app create org.xwalk.test --platforms=android"
         packstatus = commands.getstatusoutput(cmd)
-        comm.clear("org.xwalk.test")
-        self.assertEquals(packstatus[0], 0)
-
-    def test_create_with_platform_windows(self):
-        comm.setUp()
-        os.chdir(comm.XwalkPath)
-        cmd = comm.PackTools + "crosswalk-app create org.xwalk.test --platforms=windows"
-        packstatus = commands.getstatusoutput(cmd)
+        os.chdir('org.xwalk.test')
+        buildcmd = comm.PackTools + "crosswalk-app build"
+        comm.build(self, buildcmd)
         comm.clear("org.xwalk.test")
         self.assertEquals(packstatus[0], 0)
 

--- a/apptools/apptools-ios-tests/apptools/target_platforms.py
+++ b/apptools/apptools-ios-tests/apptools/target_platforms.py
@@ -43,7 +43,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         status = os.popen(cmd).readlines()
         self.assertEquals("ios", status[0].strip(" *\n"))
         self.assertEquals("android", status[1].strip(" *\n"))
-        self.assertEquals("windows", status[2].strip(" *\n"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-ios-tests/tests.full.xml
+++ b/apptools/apptools-ios-tests/tests.full.xml
@@ -28,7 +28,7 @@
           <test_script_entry>/opt/apptools-ios-tests/apptools/target_platforms.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_with_target_platform" priority="P1" purpose="iOS - Validate project can be created with validate platform" status="approved" type="Functional" subcase="5">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_with_target_platform" priority="P1" purpose="iOS - Validate project can be created with validate platform" status="approved" type="Functional" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/create_with_target_platform.py</test_script_entry>
         </description>

--- a/apptools/apptools-ios-tests/tests.xml
+++ b/apptools/apptools-ios-tests/tests.xml
@@ -28,7 +28,7 @@
           <test_script_entry>/opt/apptools-ios-tests/apptools/target_platforms.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_with_target_platform" purpose="iOS - Validate project can be created with validate platform" subcase="5">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_with_target_platform" purpose="iOS - Validate project can be created with validate platform" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-ios-tests/apptools/create_with_target_platform.py</test_script_entry>
         </description>

--- a/apptools/apptools-linux-tests/apptools/create_with_target_platform.py
+++ b/apptools/apptools-linux-tests/apptools/create_with_target_platform.py
@@ -42,6 +42,9 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir(comm.TEMP_DATA_PATH)
         cmd = "crosswalk-app create " + comm.TEST_PROJECT_COMM + " --platforms=deb"
         packstatus = commands.getstatusoutput(cmd)
+        os.chdir(comm.TEST_PROJECT_COMM)
+        buildcmd = "crosswalk-app build"
+        comm.build(self, buildcmd)
         comm.cleanTempData(comm.TEST_PROJECT_COMM)
         self.assertEquals(packstatus[0], 0)
 
@@ -50,14 +53,9 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir(comm.TEMP_DATA_PATH)
         cmd = "crosswalk-app create " + comm.TEST_PROJECT_COMM + " --platforms=android"
         packstatus = commands.getstatusoutput(cmd)
-        comm.cleanTempData(comm.TEST_PROJECT_COMM)
-        self.assertEquals(packstatus[0], 0)
-
-    def test_create_with_platform_windows(self):
-        comm.setUp()
-        os.chdir(comm.TEMP_DATA_PATH)
-        cmd = "crosswalk-app create " + comm.TEST_PROJECT_COMM + " --platforms=windows"
-        packstatus = commands.getstatusoutput(cmd)
+        os.chdir(comm.TEST_PROJECT_COMM)
+        buildcmd = "crosswalk-app build"
+        comm.build(self, buildcmd)
         comm.cleanTempData(comm.TEST_PROJECT_COMM)
         self.assertEquals(packstatus[0], 0)
 

--- a/apptools/apptools-linux-tests/apptools/target_platforms.py
+++ b/apptools/apptools-linux-tests/apptools/target_platforms.py
@@ -43,7 +43,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         status = os.popen(cmd).readlines()
         self.assertEquals("deb", status[0].strip(" *\n"))
         self.assertEquals("android", status[1].strip(" *\n"))
-        self.assertEquals("windows", status[2].strip(" *\n"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-linux-tests/tests.full.xml
+++ b/apptools/apptools-linux-tests/tests.full.xml
@@ -28,7 +28,7 @@
           <test_script_entry>/opt/apptools-linux-tests/apptools/target_platforms.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_with_target_platform" priority="P1" purpose="Linux - Validate project can be created with validate platform" status="approved" type="Functional" subcase="5">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_with_target_platform" priority="P1" purpose="Linux - Validate project can be created with validate platform" status="approved" type="Functional" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/apptools/create_with_target_platform.py</test_script_entry>
         </description>

--- a/apptools/apptools-linux-tests/tests.xml
+++ b/apptools/apptools-linux-tests/tests.xml
@@ -28,7 +28,7 @@
           <test_script_entry>/opt/apptools-linux-tests/apptools/target_platforms.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_with_target_platform" purpose="Linux - Validate project can be created with validate platform" subcase="5">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_with_target_platform" purpose="Linux - Validate project can be created with validate platform" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-linux-tests/apptools/create_with_target_platform.py</test_script_entry>
         </description>


### PR DESCRIPTION
https://crosswalk-project.org/jira/browse/XWALK-5005
https://crosswalk-project.org/jira/browse/XWALK-5006

Due to windows platforms is only support on Microsoft Windows, so delete these cases

Impacted tests(approved): new 0, update 8, delete 3
Unit test platform: [Android]
Unit test result summary: pass 6, fail 2, block 0

https://crosswalk-project.org/jira/browse/XWALK-4665