### PR TITLE
[EmbeddingApi] Add autocase for API computeHorizontalScrollOffset & c…

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/ScrollXWalkView.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/ScrollXWalkView.java
@@ -1,0 +1,82 @@
+package org.xwalk.embedding.base;
+
+import android.app.Activity;
+import android.content.Context;
+import android.util.AttributeSet;
+import android.util.Log;
+
+import org.xwalk.core.XWalkView;
+
+
+public class ScrollXWalkView extends XWalkView {
+
+    public final static String TAG = "ScrollXWalkView";
+
+    public ScrollXWalkView(Context context) {
+        super(context);
+    }
+
+    public ScrollXWalkView(Context context, Activity activity) {
+        super(context, activity);
+    }
+
+    public ScrollXWalkView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    private OnMeasureListener mOnMeasureListener;
+
+    public interface OnMeasureListener{
+        public void informOnMeasure(String msg);
+    }
+
+    public void setOnMeasureListener(OnMeasureListener listener){
+        this.mOnMeasureListener = listener;
+    }
+    
+    private OverScrollModeListener mOverScrollModeListener;
+
+    public interface OverScrollModeListener{
+        public void informOverScrollMode(String msg);
+    }
+
+    public void setOverScrollModeListener(OverScrollModeListener listener){
+        this.mOverScrollModeListener = listener;
+    }    
+
+	@Override
+	protected int computeHorizontalScrollOffset() {
+		// TODO Auto-generated method stub
+		Log.i(TAG, "computeHorizontalScrollOffset is invoked");
+		return super.computeHorizontalScrollOffset();
+	}
+
+	@Override
+	protected int computeVerticalScrollRange() {
+		// TODO Auto-generated method stub
+		Log.i(TAG, "computeVerticalScrollRange is invoked");
+		return super.computeVerticalScrollRange();
+	}
+
+	@Override
+	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+		// TODO Auto-generated method stub
+		Log.i(TAG, "onMeasure is invoked, widthMeasureSpec:" + widthMeasureSpec + " heightMeasureSpec:" + heightMeasureSpec);
+        if(null != mOnMeasureListener) {
+            mOnMeasureListener.informOnMeasure("onMeasure is invoked");
+        }
+		super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+	}
+
+	@Override
+	public void setOverScrollMode(int overScrollMode) {
+		// TODO Auto-generated method stub
+		Log.i(TAG, "setOverScrollMode is invoked, overScrollMode is " + overScrollMode);
+        if(null != mOverScrollModeListener) {
+            mOverScrollModeListener.informOverScrollMode("setOverScrollMode is invoked");
+        }
+		super.setOverScrollMode(overScrollMode);
+	}
+    
+}
+

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewOverrideTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewOverrideTest.java
@@ -11,6 +11,9 @@ import org.xwalk.embedding.base.OnDrawXWalkView;
 import org.xwalk.embedding.base.OnCreateInputConnectionXWalkView;
 import org.xwalk.embedding.base.RequestFocusXWalkView;
 import org.xwalk.embedding.base.RequestFocusXWalkView.FocusChangedListener;
+import org.xwalk.embedding.base.ScrollXWalkView;
+import org.xwalk.embedding.base.ScrollXWalkView.OnMeasureListener;
+import org.xwalk.embedding.base.ScrollXWalkView.OverScrollModeListener;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 import android.annotation.SuppressLint;
 import android.test.suitebuilder.annotation.SmallTest;
@@ -86,5 +89,73 @@ public class XWalkViewOverrideTest extends XWalkViewTestBase {
             assertTrue(false);
         }
     }    
+    
+    @SmallTest
+    public void testComputeHorizontalScrollOffset() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable(){
+                @Override
+                public void run() {
+                    ScrollXWalkView mScrollXWalkView = new ScrollXWalkView(mainActivity, mainActivity);
+                    mScrollXWalkView.load("http://www.sina.com.cn", null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+    
+    @SmallTest
+    public void testComputeVerticalScrollRange() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable(){
+                @Override
+                public void run() {
+                    ScrollXWalkView mScrollXWalkView = new ScrollXWalkView(mainActivity, mainActivity);
+                    mScrollXWalkView.load("http://www.sina.com.cn", null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }    
+
+    @SmallTest
+    public void testOnMeasure() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable(){
+                @Override
+                public void run() {
+                    ScrollXWalkView mScrollXWalkView = new ScrollXWalkView(mainActivity, mainActivity);
+                    mScrollXWalkView.load("http://www.sina.com.cn", null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }   
+    
+    @SmallTest
+    public void testSetOverScrollMode() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable(){
+                @Override
+                public void run() {
+                    ScrollXWalkView mScrollXWalkView = new ScrollXWalkView(mainActivity, mainActivity);
+                    mScrollXWalkView.load("http://www.sina.com.cn", null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }        
 
 }

--- a/embeddingapi/embedding-api-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-api-android-tests/tests.full.xml
@@ -103,7 +103,7 @@
           <test_script_entry>org.xwalk.embedding.test.v5.CookieManagerTest</test_script_entry>
         </description>
       </testcase>      
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewOverrideTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView Override interface can be executed correctly." status="approved" type="functional_positive" subcase="3">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewOverrideTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView Override interface can be executed correctly." status="approved" type="functional_positive" subcase="7">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewOverrideTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-api-android-tests/tests_v5.xml
+++ b/embeddingapi/embedding-api-android-tests/tests_v5.xml
@@ -23,7 +23,7 @@
           <test_script_entry>org.xwalk.embedding.test.v5.CookieManagerTest</test_script_entry>
         </description>
       </testcase>       
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewOverrideTest" purpose="Check if the methods of XWalkView Override interface can be executed correctly." subcase="3">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewOverrideTest" purpose="Check if the methods of XWalkView Override interface can be executed correctly." subcase="7">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewOverrideTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/ScrollXWalkView.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/ScrollXWalkView.java
@@ -1,0 +1,82 @@
+package org.xwalk.embedding.base;
+
+import android.app.Activity;
+import android.content.Context;
+import android.util.AttributeSet;
+import android.util.Log;
+
+import org.xwalk.core.XWalkView;
+
+
+public class ScrollXWalkView extends XWalkView {
+
+    public final static String TAG = "ScrollXWalkView";
+
+    public ScrollXWalkView(Context context) {
+        super(context);
+    }
+
+    public ScrollXWalkView(Context context, Activity activity) {
+        super(context, activity);
+    }
+
+    public ScrollXWalkView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    private OnMeasureListener mOnMeasureListener;
+
+    public interface OnMeasureListener{
+        public void informOnMeasure(String msg);
+    }
+
+    public void setOnMeasureListener(OnMeasureListener listener){
+        this.mOnMeasureListener = listener;
+    }
+    
+    private OverScrollModeListener mOverScrollModeListener;
+
+    public interface OverScrollModeListener{
+        public void informOverScrollMode(String msg);
+    }
+
+    public void setOverScrollModeListener(OverScrollModeListener listener){
+        this.mOverScrollModeListener = listener;
+    }    
+
+	@Override
+	protected int computeHorizontalScrollOffset() {
+		// TODO Auto-generated method stub
+		Log.i(TAG, "computeHorizontalScrollOffset is invoked");
+		return super.computeHorizontalScrollOffset();
+	}
+
+	@Override
+	protected int computeVerticalScrollRange() {
+		// TODO Auto-generated method stub
+		Log.i(TAG, "computeVerticalScrollRange is invoked");
+		return super.computeVerticalScrollRange();
+	}
+
+	@Override
+	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+		// TODO Auto-generated method stub
+		Log.i(TAG, "onMeasure is invoked, widthMeasureSpec:" + widthMeasureSpec + " heightMeasureSpec:" + heightMeasureSpec);
+        if(null != mOnMeasureListener) {
+            mOnMeasureListener.informOnMeasure("onMeasure is invoked");
+        }
+		super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+	}
+
+	@Override
+	public void setOverScrollMode(int overScrollMode) {
+		// TODO Auto-generated method stub
+		Log.i(TAG, "setOverScrollMode is invoked, overScrollMode is " + overScrollMode);
+        if(null != mOverScrollModeListener) {
+            mOverScrollModeListener.informOverScrollMode("setOverScrollMode is invoked");
+        }
+		super.setOverScrollMode(overScrollMode);
+	}
+    
+}
+

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewOverrideTestAsync.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewOverrideTestAsync.java
@@ -11,6 +11,9 @@ import org.xwalk.embedding.base.OnDrawXWalkView;
 import org.xwalk.embedding.base.OnCreateInputConnectionXWalkView;
 import org.xwalk.embedding.base.RequestFocusXWalkView;
 import org.xwalk.embedding.base.RequestFocusXWalkView.FocusChangedListener;
+import org.xwalk.embedding.base.ScrollXWalkView;
+import org.xwalk.embedding.base.ScrollXWalkView.OnMeasureListener;
+import org.xwalk.embedding.base.ScrollXWalkView.OverScrollModeListener;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 import android.annotation.SuppressLint;
 import android.test.suitebuilder.annotation.SmallTest;
@@ -85,5 +88,73 @@ public class XWalkViewOverrideTestAsync extends XWalkViewTestBase {
             e.printStackTrace();
             assertTrue(false);
         }
-    }  
+    }
+    
+    @SmallTest
+    public void testComputeHorizontalScrollOffset() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable(){
+                @Override
+                public void run() {
+                    ScrollXWalkView mScrollXWalkView = new ScrollXWalkView(mainActivity, mainActivity);
+                    mScrollXWalkView.load("http://www.sina.com.cn", null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+    
+    @SmallTest
+    public void testComputeVerticalScrollRange() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable(){
+                @Override
+                public void run() {
+                    ScrollXWalkView mScrollXWalkView = new ScrollXWalkView(mainActivity, mainActivity);
+                    mScrollXWalkView.load("http://www.sina.com.cn", null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }    
+
+    @SmallTest
+    public void testOnMeasure() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable(){
+                @Override
+                public void run() {
+                    ScrollXWalkView mScrollXWalkView = new ScrollXWalkView(mainActivity, mainActivity);
+                    mScrollXWalkView.load("http://www.sina.com.cn", null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }   
+    
+    @SmallTest
+    public void testSetOverScrollMode() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable(){
+                @Override
+                public void run() {
+                    ScrollXWalkView mScrollXWalkView = new ScrollXWalkView(mainActivity, mainActivity);
+                    mScrollXWalkView.load("http://www.sina.com.cn", null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }          
 }

--- a/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
@@ -103,7 +103,7 @@
           <test_script_entry>org.xwalk.embedding.test.v5.CookieManagerTestAsync</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewOverrideTestAsync" platform="android" priority="P1" purpose="Check if the methods of XWalkView Override interface can be executed correctly." status="approved" type="functional_positive" subcase="3">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewOverrideTestAsync" platform="android" priority="P1" purpose="Check if the methods of XWalkView Override interface can be executed correctly." status="approved" type="functional_positive" subcase="7">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewOverrideTestAsync</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/tests_v5.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests_v5.xml
@@ -23,7 +23,7 @@
           <test_script_entry>org.xwalk.embedding.test.v5.CookieManagerTestAsync</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewOverrideTestAsync" purpose="Check if the methods of XWalkView Override interface can be executed correctly." subcase="3">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewOverrideTestAsync" purpose="Check if the methods of XWalkView Override interface can be executed correctly." subcase="7">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewOverrideTestAsync</test_script_entry>
         </description>


### PR DESCRIPTION
…omputeVerticalScrollRange & onMeasure & setOverScrollMode

-Add autocase for API computeHorizontalScrollOffset & computeVerticalScrollRange & onMeasure & setOverScrollMode
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 8, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 8, fail 0, block 0