### PR TITLE
[Linux] Update manifest.json to support the update of apptools

### DIFF
--- a/misc/webappmanu-linux-tests/inst.deb.py
+++ b/misc/webappmanu-linux-tests/inst.deb.py
@@ -40,9 +40,8 @@ def getUSERID():
 
 def getPKGID(pkg_name=None):
     pkg_id = None
-    pkg_name = pkg_name.split('.')
-    num = len(pkg_name)
-    pkg_id = pkg_name[num - 1]
+    pkg_name = pkg_name.split('_')
+    pkg_id = pkg_name[0]
     return pkg_id
 
 

--- a/misc/webappmanu-linux-tests/manifest.json
+++ b/misc/webappmanu-linux-tests/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "webappmanu-linux-tests",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "./index.html"
+    "start_url": "./index.html",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.test.webappmanulinuxtests",
+    "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baiduhi/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baiduhi/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-baidu-hi",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://web.im.baidu.com"
+  "start_url": "http://web.im.baidu.com",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.baiduhi",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baidumap/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baidumap/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-baidu-map",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://map.baidu.com"
+  "start_url": "http://map.baidu.com",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.baidumap",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baidumusic/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baidumusic/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-baidu-music",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://fm.baidu.com"
+  "start_url": "http://fm.baidu.com",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.baidumusic",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baiduonlinestorage/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baiduonlinestorage/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-baidu-online-storage",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://pan.baidu.com"
+  "start_url": "http://pan.baidu.com",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.baiduonlinestorage",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.cargobridge/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.cargobridge/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-cargo-bridge",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://webstore.limexgames.net/ag_cargo_bridge/index.html"
+  "start_url": "http://webstore.limexgames.net/ag_cargo_bridge/index.html",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.cargobridge",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.chainrxn/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.chainrxn/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-chainrxn",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://www.yvoschaap.com/chainrxn/"
+  "start_url": "http://www.yvoschaap.com/chainrxn/",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.chainrxn",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.dbankonlinestorage/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.dbankonlinestorage/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-dbank-online-storage",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://ww.dbank.com"
+  "start_url": "http://ww.dbank.com",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.dbankonlinestorage",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.doitim/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.doitim/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-doit-im",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://doit.im"
+  "start_url": "http://doit.im",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.doitim",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.douban/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.douban/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-douban",
-  "xwalk_version": "0.0.1",
-      "start_url": "http://douban.fm"
+  "start_url": "http://douban.fm",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.douban",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.fetion/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.fetion/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-fetion",
-  "xwalk_version": "0.0.1",
-  "start_url": "https://webim.feixin.10086.cn"
+  "start_url": "https://webim.feixin.10086.cn",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.fetion",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.hangonman/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.hangonman/manifest.json
@@ -6,7 +6,6 @@
     }
   },
   "description": "Classic Hangman Game",
-  "xwalk_version": "0.0.1",
   "icons": {
     "16": "icon_16.png",
     "48": "icon_64.png",
@@ -15,5 +14,8 @@
   "permissions": [],
   "required_version": "1.29.4.0",
   "plugin": [],
-  "fullscreen": "True"
+  "fullscreen": "True",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.hangonman",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.hexgl/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.hexgl/manifest.json
@@ -18,5 +18,8 @@
 	},
        	"installs_allowed_from": ["*"],
  	"default_locale": "en",
-	"orientation": ["landscape"]
+	"orientation": ["landscape"],
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.webapps.hexgl",
+    "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kingsoftfastdocs/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kingsoftfastdocs/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-kingsoft-fast-docs",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://w.wps.cn"
+  "start_url": "http://w.wps.cn",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.kingsoftfastdocs",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kingsoftonlinestorage/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kingsoftonlinestorage/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-kingsoft-online-storage",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://www.kuaipan.cn"
+  "start_url": "http://www.kuaipan.cn",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.kingsoftonlinestorage",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kugoumusic/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kugoumusic/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-kugou-music",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://web.kugou.com/default.html"
+  "start_url": "http://web.kugou.com/default.html",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.kugoumusic",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kuwomusic/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kuwomusic/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-kuwo-music",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://player.kuwo.cn/webmusic/play"
+  "start_url": "http://player.kuwo.cn/webmusic/play",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.kuwomusic",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.memorygame/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.memorygame/manifest.json
@@ -12,6 +12,8 @@
   "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC+BIaBW+xj11Ea9rwawrZ0+06jT68d2h2g5vEOS6AJJGf/N6DRplmlCozqmCkYzZLdS3Hiwaz3baMg0GCQpuG+Ylh4+vyL6Pk7GJTudG8hhkiulSvTCx3/19Kqd/VOHbMFsh8gCZAx28s3fH26USIMbwj6az0OwI30hXUgGun+fQIDAQAB",
   "name": "MemoryGameOlderKids",
   "permissions": [  ],
-  "xwalk_version": "0.0.8",
-  "homepage_url" : "https://01.org/html5webapps/webapps/memorygameolderkids"
+  "homepage_url" : "https://01.org/html5webapps/webapps/memorygameolderkids",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.memorygame",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.microsoftskydrive/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.microsoftskydrive/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-microsoft-skydrive",
-  "xwalk_version": "0.0.1",
-  "start_url": "https://skydrive.live.com"
+  "start_url": "https://skydrive.live.com",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.microsoftskydrive",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.paulrouget/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.paulrouget/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-paulrouget",
-  "xwalk_version": "0.0.1",
-  "start_url": "https://developer.cdn.mozilla.net/media/uploads/demos/p/a/paulrouget/47e916de488e745f95aee0bc32d5fd31/runfield_1327576901_demo_package/index.html"
+  "start_url": "https://developer.cdn.mozilla.net/media/uploads/demos/p/a/paulrouget/47e916de488e745f95aee0bc32d5fd31/runfield_1327576901_demo_package/index.html",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.paulrouget",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.pirateslovedaisies/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.pirateslovedaisies/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-pirateslovedaisies",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://www.pirateslovedaisies.com"
+  "start_url": "http://www.pirateslovedaisies.com",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.pirateslovedaisies",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.sinaweibo/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.sinaweibo/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-sina-weibo",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://weibo.com"
+  "start_url": "http://weibo.com",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.sinaweibo",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.test12306/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.test12306/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-12306",
-  "xwalk_version": "0.0.1",
-  "start_url": "https://kyfw.12306.cn/otn"
+  "start_url": "https://kyfw.12306.cn/otn",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.test12306",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.towerim/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.towerim/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-towerim",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://tower.im"
+  "start_url": "http://tower.im",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.towerim",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.ttpod/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.ttpod/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-ttpod",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://www.dongting.com"
+  "start_url": "http://www.dongting.com",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.ttpod",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.xiamimusic/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.xiamimusic/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-xiami-music",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://www.xiami.com/radio"
+  "start_url": "http://www.xiami.com/radio",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.xiamimusic",
+  "xwalk_target_platforms": "deb"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.youdaonote/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.youdaonote/manifest.json
@@ -1,5 +1,7 @@
 {
   "name": "deepin-webapps-youdao-note",
-  "xwalk_version": "0.0.1",
-  "start_url": "http://note.youdao.com"
+  "start_url": "http://note.youdao.com",
+  "xwalk_app_version": "0.1",
+  "xwalk_package_id": "org.webapps.youdaonote",
+  "xwalk_target_platforms": "deb"
 }

--- a/tools/build/pack_deb.py
+++ b/tools/build/pack_deb.py
@@ -408,9 +408,7 @@ def packDEB(build_json=None, app_src=None, app_dest=None, app_name=None):
         return False
 
     # After build successfully, copy the .deb from app_src+"pkg" to app_dest
-    if not doCopy(
-            os.path.join(app_src, "pkg"),
-            app_dest):
+    if not doCMD("cp -rf %s/*deb %s" % (app_src, app_dest)):
         return False
     return True
 

--- a/usecase/usecase-wrt-linux-tests/inst.deb.py
+++ b/usecase/usecase-wrt-linux-tests/inst.deb.py
@@ -34,7 +34,7 @@ def uninstPKGs():
         for file in files:
             if file.endswith(".deb"):
                 debName = os.path.basename(os.path.splitext(file)[0])
-                pkg_id = debName.split(".")[-1]
+                pkg_id = debName.split("_")[0]
                 if doCMD("which %s" % pkg_id)[0] == 0:
                     (return_code, output) = doCMD(
                         "sudo dpkg -P %s" % pkg_id)

--- a/usecase/usecase-wrt-linux-tests/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "usecase-wrt-linux-tests",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "./index.html"
+    "start_url": "./index.html",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.usecase.usecasewrtlinuxtests",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.csp.cspdefaultsrc/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.csp.cspdefaultsrc/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "csp_default-src",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "index.html",
-    "csp": "default-src 'self' 'unsafe-inline'"
+    "csp": "default-src 'self' 'unsafe-inline'",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.csp.cspdefaultsrc",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.display.defaultmode/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.display.defaultmode/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "display_default",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "index.html"
+    "start_url": "index.html",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.display.defaultmode",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.display.fullscreen/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.display.fullscreen/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "display_fullscreen",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "index.html",
-    "display": "fullscreen"
+    "display": "fullscreen",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.display.fullscreen",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.display.minimalui/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.display.minimalui/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "display_minimal-ui",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "index.html",
-    "display": "minimal-ui"
+    "display": "minimal-ui",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.display.minimalui",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.display.standalone/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.display.standalone/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "display_standalone",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "index.html",
-    "display": "standalone"
+    "display": "standalone",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.display.standalone",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.cookies/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.cookies/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "cookies",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "http://www.quirksmode.org/js/cookies.html"
+    "start_url": "http://www.quirksmode.org/js/cookies.html",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.packagemanage.cookies",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.cookiesupgrade/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.cookiesupgrade/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "cookies",
-    "xwalk_version": "0.0.2",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "http://www.quirksmode.org/js/cookies.html"
+    "start_url": "http://www.quirksmode.org/js/cookies.html",
+    "xwalk_app_version": "0.2",
+    "xwalk_package_id": "org.packagemanage.cookiesupgrade",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.indexdb/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.indexdb/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "indexDB",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "./index.html"
+    "start_url": "./index.html",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.packagemanage.indexdb",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.indexdbupgrade/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.indexdbupgrade/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "indexDB",
-    "xwalk_version": "0.0.2",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "./index.html"
+    "start_url": "./index.html",
+    "xwalk_app_version": "0.2",
+    "xwalk_package_id": "org.packagemanage.indexdbupgrade",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.localstorage/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.localstorage/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "localStorage",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "./index.html"
+    "start_url": "./index.html",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.packagemanage.localstorage",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.localstorageupgrade/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.localstorageupgrade/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "localStorage",
-    "xwalk_version": "0.0.2",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "./index.html"
+    "start_url": "./index.html",
+    "xwalk_app_version": "0.2",
+    "xwalk_package_id": "org.packagemanage.localstorageupgrade",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.externalurl/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.externalurl/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "runtime_externalurl",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "scope": "/res/",
-    "start_url": "index.html"
+    "start_url": "index.html",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.runtime.externalurl",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.flashplugin/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.flashplugin/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "runtime_flashplugin",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "./index.html"
+    "start_url": "./index.html",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.runtime.flashplugin",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.systemimes/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.systemimes/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "runtime_systemimes",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "index.html"
+    "start_url": "index.html",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.runtime.systemimes",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.webnotification/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.runtime.webnotification/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "runtime_webnotification",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "index.html"
+    "start_url": "index.html",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.runtime.webnotification",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.starturl.localsource/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.starturl.localsource/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "starturl_localsource",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "index.html"
+    "start_url": "index.html",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.starturl.localsource",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.starturl.websource/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.starturl.websource/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "starturl_websource",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -9,5 +8,8 @@
             "density": "1.0"
         }
     ],
-    "start_url": "https://crosswalk-project.org/"
+    "start_url": "https://crosswalk-project.org/",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.starturl.websource",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.windowsize.allmembersspecified/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.windowsize.allmembersspecified/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "windowsize_allmembersspecified",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -18,5 +17,8 @@
         "max-height": 500
     },
     "start_url": "index.html",
-    "display": "standalone"
+    "display": "standalone",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.windowsize.allmembersspecified",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.windowsize.widthheight/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.windowsize.widthheight/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "windowsize_widthheight",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -13,5 +12,8 @@
         "width": 500,
         "height": 500
     },
-    "start_url": "index.html"
+    "start_url": "index.html",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.windowsize.widthheight",
+    "xwalk_target_platforms": "deb"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.windowsize.xwalkboundsfullscreen/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.windowsize.xwalkboundsfullscreen/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "windowsize_fullscreenoverride",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -14,5 +13,8 @@
         "height": 500
     },
     "start_url": "index.html",
-    "display": "fullscreen"
+    "display": "fullscreen",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.windowsize.xwalkboundsfullscreen",
+    "xwalk_target_platforms": "deb"
 }

--- a/webapi/tct-notification-w3c-tests/inst.deb.py
+++ b/webapi/tct-notification-w3c-tests/inst.deb.py
@@ -34,7 +34,7 @@ def uninstPKGs():
         for file in files:
             if file.endswith(".deb"):
                 debName = os.path.basename(os.path.splitext(file)[0])
-                pkg_id = debName.split(".")[-1]
+                pkg_id = debName.split("_")[0]
                 (return_code, output) = doCMD(
                     "sudo dpkg -P %s" % pkg_id)
                 if return_code != 0:

--- a/webapi/tct-notification-w3c-tests/manifest.json
+++ b/webapi/tct-notification-w3c-tests/manifest.json
@@ -11,5 +11,8 @@
     },
     "icons": {
         "128": "icon.png"
-    }
+    },
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.test.tctnotificationw3ctests",
+    "xwalk_target_platforms": "deb"
 }

--- a/wrt/wrt-rt-linux-tests/inst.deb.py
+++ b/wrt/wrt-rt-linux-tests/inst.deb.py
@@ -34,7 +34,7 @@ def uninstPKGs():
         for file in files:
             if file.endswith(".deb"):
                 debName = os.path.basename(os.path.splitext(file)[0])
-                pkg_id = debName.split(".")[-1]
+                pkg_id = debName.split("_")[0]
                 (return_code, output) = doCMD(
                     "sudo dpkg -P %s" % pkg_id)
                 if return_code != 0:

--- a/wrt/wrt-rt-linux-tests/org.csp.connectsrccrossoriginmultixmlhttprequestallowedtwo/manifest.json
+++ b/wrt/wrt-rt-linux-tests/org.csp.connectsrccrossoriginmultixmlhttprequestallowedtwo/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "csp_connect-src_cross-origin_multi_allowed_two",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "./index.html",
-    "csp": "connect-src http://www.w3.org https://www.tizen.org http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'"
+    "csp": "connect-src http://www.w3.org https://www.tizen.org http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.csp.connectsrccrossoriginmultixmlhttprequestallowedtwo",
+    "xwalk_target_platforms": "deb"
 }

--- a/wrt/wrt-rt-linux-tests/org.csp.connectsrccrossoriginmultixmlhttprequestblocked/manifest.json
+++ b/wrt/wrt-rt-linux-tests/org.csp.connectsrccrossoriginmultixmlhttprequestblocked/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "csp_connect-src_cross-origin_multi_xmlhttprequest_blocked",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "./index.html",
-    "csp": "connect-src http://www.w3.org https://www.tizen.org http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'"
+    "csp": "connect-src http://www.w3.org https://www.tizen.org http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.csp.connectsrccrossoriginmultixmlhttprequestblocked",
+    "xwalk_target_platforms": "deb"
 }

--- a/wrt/wrt-rt-linux-tests/org.csp.connectsrccrossoriginmultixmlhttprequestblockedint/manifest.json
+++ b/wrt/wrt-rt-linux-tests/org.csp.connectsrccrossoriginmultixmlhttprequestblockedint/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "csp_connect-src_cross-origin_multi_xmlhttprequest_blocked_int",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "./index.html",
-    "csp": "connect-src http://www.w3.org https://www.tizen.org http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'"
+    "csp": "connect-src http://www.w3.org https://www.tizen.org http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.csp.connectsrccrossoriginmultixmlhttprequestblockedint",
+    "xwalk_target_platforms": "deb"
 }

--- a/wrt/wrt-rt-linux-tests/org.csp.connectsrccrossoriginxmlhttprequestallowed/manifest.json
+++ b/wrt/wrt-rt-linux-tests/org.csp.connectsrccrossoriginxmlhttprequestallowed/manifest.json
@@ -1,6 +1,5 @@
 {
-  "name": "csp_connect-src_cross-origin_xmlhttprequest_allowed",
-  "xwalk_version": "0.0.1",
+    "name": "csp_connect-src_cross-origin_xmlhttprequest_allowed",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "./index.html",
-    "csp": "connect-src http://www.w3.org http://127.0.0.1:8000"
+    "csp": "connect-src http://www.w3.org http://127.0.0.1:8000",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.csp.connectsrccrossoriginxmlhttprequestallowed",
+    "xwalk_target_platforms": "deb"
 }

--- a/wrt/wrt-rt-linux-tests/org.csp.connectsrccrossoriginxmlhttprequestblocked/manifest.json
+++ b/wrt/wrt-rt-linux-tests/org.csp.connectsrccrossoriginxmlhttprequestblocked/manifest.json
@@ -1,6 +1,5 @@
 {
-  "name": "CSP Test: csp_connect-src_cross-origin_xmlhttprequest_blocked",
-  "xwalk_version": "0.0.1",
+    "name": "CSP Test: csp_connect-src_cross-origin_xmlhttprequest_blocked",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "./index.html",
-    "csp": "connect-src http://www.w3.org http://127.0.0.1:8000"
+    "csp": "connect-src http://www.w3.org http://127.0.0.1:8000",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.csp.connectsrccrossoriginxmlhttprequestblocked",
+    "xwalk_target_platforms": "deb"
 }

--- a/wrt/wrt-rt-linux-tests/org.csp.connectsrcnonexmlhttprequestblocked/manifest.json
+++ b/wrt/wrt-rt-linux-tests/org.csp.connectsrcnonexmlhttprequestblocked/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "csp_connect-src_none_xmlhttprequest_blocked",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "./index.html",
-    "csp": "connect-src 'none' http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'"
+    "csp": "connect-src 'none' http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.csp.connectsrcnonexmlhttprequestblocked",
+    "xwalk_target_platforms": "deb"
 }

--- a/wrt/wrt-rt-linux-tests/org.csp.connectsrcnonexmlhttprequestblockedext/manifest.json
+++ b/wrt/wrt-rt-linux-tests/org.csp.connectsrcnonexmlhttprequestblockedext/manifest.json
@@ -1,6 +1,5 @@
 {
-  "name": "csp_connect-src_none_xmlhttprequest_blocked_ext",
-  "xwalk_version": "0.0.1",
+    "name": "csp_connect-src_none_xmlhttprequest_blocked_ext",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "./index.html",
-    "csp": "connect-src 'none' http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'"
+    "csp": "connect-src 'none' http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.csp.connectsrcnonexmlhttprequestblockedext",
+    "xwalk_target_platforms": "deb"
 }

--- a/wrt/wrt-rt-linux-tests/org.csp.connectsrcselfxmlhttprequestallowed/manifest.json
+++ b/wrt/wrt-rt-linux-tests/org.csp.connectsrcselfxmlhttprequestallowed/manifest.json
@@ -1,6 +1,5 @@
 {
-  "name": "csp_connect-src_self_xmlhttprequest_allowed",
-  "xwalk_version": "0.0.1",
+    "name": "csp_connect-src_self_xmlhttprequest_allowed",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "./index.html",
-    "csp": "connect-src 'self' http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'"
+    "csp": "connect-src 'self' http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.csp.connectsrcselfxmlhttprequestallowed",
+    "xwalk_target_platforms": "deb"
 }

--- a/wrt/wrt-rt-linux-tests/org.csp.connectsrcselfxmlhttprequestblocked/manifest.json
+++ b/wrt/wrt-rt-linux-tests/org.csp.connectsrcselfxmlhttprequestblocked/manifest.json
@@ -1,6 +1,5 @@
 {
-  "name": "csp_connect-src_self_xmlhttprequest_blocked",
-  "xwalk_version": "0.0.1",
+    "name": "csp_connect-src_self_xmlhttprequest_blocked",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "./index.html",
-    "csp": "connect-src 'self' http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'"
+    "csp": "connect-src 'self' http://127.0.0.1:8000; script-src 'self' 'unsafe-inline'",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.csp.connectsrcselfxmlhttprequestblocked",
+    "xwalk_target_platforms": "deb"
 }

--- a/wrt/wrt-rt-linux-tests/org.csp.defaultsrcasteriskunsafeinlinelocal/manifest.json
+++ b/wrt/wrt-rt-linux-tests/org.csp.defaultsrcasteriskunsafeinlinelocal/manifest.json
@@ -1,6 +1,5 @@
 {
-  "name": "csp_default-src_asterisk_script_allowed_int",
-  "xwalk_version": "0.0.1",
+    "name": "csp_default-src_asterisk_script_allowed_int",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "./index.html",
-    "csp": "default-src * 'unsafe-inline'"
+    "csp": "default-src * 'unsafe-inline'",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.csp.defaultsrcasteriskunsafeinlinelocal",
+    "xwalk_target_platforms": "deb"
 }

--- a/wrt/wrt-rt-linux-tests/org.csp.roscriptsrcselfunsafeinlineunsafeeval/manifest.json
+++ b/wrt/wrt-rt-linux-tests/org.csp.roscriptsrcselfunsafeinlineunsafeeval/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "csp_ro_script-src_self_unsafe-inline_unsafe-eval",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "./index.html",
-    "csp": "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+    "csp": "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.csp.roscriptsrcselfunsafeinlineunsafeeval",
+    "xwalk_target_platforms": "deb"
 }

--- a/wrt/wrt-rt-linux-tests/org.csp.stylesrcunsafeinlineblockedint/manifest.json
+++ b/wrt/wrt-rt-linux-tests/org.csp.stylesrcunsafeinlineblockedint/manifest.json
@@ -1,6 +1,5 @@
 {
     "name": "csp_style-src_unsafe-inline_blocked_int",
-    "xwalk_version": "0.0.1",
     "icons": [
         {
             "src": "icon.png",
@@ -10,5 +9,8 @@
         }
     ],
     "start_url": "./index.html",
-    "csp": "default *;style-src 'unsafe-inline'"
+    "csp": "default *;style-src 'unsafe-inline'",
+    "xwalk_app_version": "0.1",
+    "xwalk_package_id": "org.csp.stylesrcunsafeinlineblockedint",
+    "xwalk_target_platforms": "deb"
 }


### PR DESCRIPTION
- Update manifest.json to support the update of apptools

Installation package could be generated successfully except usecase-wrt-linux-tests

Unable to build project when "display" section of manifest.json is "minimal-ui",
issue tracked by XWALK-5028.