### PR TITLE
[ATIP] Add new step to check startswith and endswith of test content

### DIFF
--- a/tools/atip/README.md
+++ b/tools/atip/README.md
@@ -117,6 +117,14 @@ def i_visit_url(context, url):
                 <td>Find element(s) by partial link text</td>
         </tr>
         <tr>
+                <td></td>
+                <td>Find text in element by startswith</td>
+        </tr>
+        <tr>
+                <td></td>
+                <td>Find text in element by endswith</td>
+        </tr>
+        <tr>
                 <td>Window Management</td>
                 <td>get current window handle</td>
         </tr>
@@ -369,6 +377,8 @@ def i_visit_url(context, url):
 @step(u'I should see "{text}" in {timeout:d} seconds')
 @step(u'I should not see "{text}" in {timeout:d} seconds')
 @step(u'I should see "{text}" in "{key}" area')
+@step(u'I should see text in "{key}" area startswith "{text}"')
+@step(u'I should see text in "{key}" area endswith "{text}"')
 @step(u'I press "{key}"')
 @step(u'press "{key_c}" in "{key_p}"')
 @step(u'I click "{key}"')

--- a/tools/atip/atip/web/steps.py
+++ b/tools/atip/atip/web/steps.py
@@ -159,6 +159,16 @@ def should_not_see_text_element(context, text, key):
         text, key, display=True), u'Text was found!'
 
 
+@step(u'I should see text in "{key}" area startswith "{text}"')
+def should_see_text_startswith(context, text, key):
+    assert context.web.should_see_text_startswith(text, key)
+
+
+@step(u'I should see text in "{key}" area endswith "{text}"')
+def should_see_text_endswith(context, text, key):
+    assert context.web.should_see_text_endswith(text, key)
+
+
 @step(u'I press "{key}"')
 def i_press(context, key):
     assert context.web.press_element_by_key(key)

--- a/tools/atip/atip/web/web.py
+++ b/tools/atip/atip/web/web.py
@@ -502,6 +502,32 @@ class WebAPP(common.APP):
         except Exception as e:
             print "Failed to get element text: %s" % e
 
+    def should_see_text_startswith(self, text=None, key=None):
+        try:
+            js_script = 'var text=document.getElementById(\"' + \
+                key + '\").innerText; return text'
+            content = self.driver.execute_script(js_script)
+            if content.strip().startswith(text):
+                return True
+            else:
+                return False
+        except Exception as e:
+            print "Failed to find text startswith %s" % text
+            return False
+
+    def should_see_text_endswith(self, text=None, key=None):
+        try:
+            js_script = 'var text=document.getElementById(\"' + \
+                key + '\").innerText; return text'
+            content = self.driver.execute_script(js_script)
+            if content.strip().endswith(text):
+                return True
+            else:
+                return False
+        except Exception as e:
+            print "Failed to find text endswith %s" % text
+            return False
+
     def press_element_by_key(self, key, display=True):
         element = self.__get_element_by_key(key, display)
         print "%s == %s" % (element.get_attribute("id"), element.get_attribute("class"))


### PR DESCRIPTION
I should see text in "{key}" area startswith "{text}"
I should see text in "{key}" area endswith "{text}"

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: Crosswalk Project for Android 15.44.402.0
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4877