### PR TITLE
[ATIP] Add new autocase for usecase AcceptFileSchemeCookies & XWalkVi…

### DIFF
--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -1361,6 +1361,26 @@
           <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/VersionsAsync.feature</bdd_test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="AcceptFileSchemeCookies" purpose="AcceptFileSchemeCookiesActivity Test With XWalkActivity">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/AcceptFileSchemeCookies.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="AcceptFileSchemeCookiesAsync" purpose="AcceptFileSchemeCookiesActivity Test With XWalkInitializer">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/AcceptFileSchemeCookiesAsync.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="XWalkViewWithWindowsVisibilityChanged" purpose="onWindowVisibilityChanged() Test With XWalkActivity">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/XWalkViewWithWindowsVisibilityChanged.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="XWalkViewWithWindowsVisibilityChangedAsync" purpose="onWindowVisibilityChanged() Test With XWalkInitializer">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/XWalkViewWithWindowsVisibilityChangedAsync.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/usecase/usecase-embedding-android-tests/tests.auto.xml
+++ b/usecase/usecase-embedding-android-tests/tests.auto.xml
@@ -73,6 +73,26 @@
           <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/VersionsAsync.feature</bdd_test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="AcceptFileSchemeCookies" purpose="AcceptFileSchemeCookiesActivity Test With XWalkActivity">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/AcceptFileSchemeCookies.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="AcceptFileSchemeCookiesAsync" purpose="AcceptFileSchemeCookiesActivity Test With XWalkInitializer">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/AcceptFileSchemeCookiesAsync.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="XWalkViewWithWindowsVisibilityChanged" purpose="onWindowVisibilityChanged() Test With XWalkActivity">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/XWalkViewWithWindowsVisibilityChanged.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="XWalkViewWithWindowsVisibilityChangedAsync" purpose="onWindowVisibilityChanged() Test With XWalkInitializer">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/XWalkViewWithWindowsVisibilityChangedAsync.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -1429,6 +1429,26 @@
           <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/VersionsAsync.feature</bdd_test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="AcceptFileSchemeCookies" platform="android" priority="P0" purpose="AcceptFileSchemeCookiesActivity Test With XWalkActivity" status="approved" type="functional_positive">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/AcceptFileSchemeCookies.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="AcceptFileSchemeCookiesAsync" platform="android" priority="P0" purpose="AcceptFileSchemeCookiesActivity Test With XWalkInitializer" status="approved" type="functional_positive">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/AcceptFileSchemeCookiesAsync.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="XWalkViewWithWindowsVisibilityChanged" platform="android" priority="P0" purpose="onWindowVisibilityChanged() Test With XWalkActivity" status="approved" type="functional_positive">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/XWalkViewWithWindowsVisibilityChanged.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="XWalkViewWithWindowsVisibilityChangedAsync" platform="android" priority="P0" purpose="onWindowVisibilityChanged() Test With XWalkInitializer" status="approved" type="functional_positive">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-embedding-android-tests/testscripts/XWalkViewWithWindowsVisibilityChangedAsync.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/usecase/usecase-embedding-android-tests/testscripts/AcceptFileSchemeCookies.feature
+++ b/usecase/usecase-embedding-android-tests/testscripts/AcceptFileSchemeCookies.feature
@@ -1,0 +1,16 @@
+Feature: Embedding api usecase tests
+    Scenario: Check XWalkCookieManager can setAcceptFileSchemeCookies & allowFileSchemeCookies
+        When I launch "usecase-embedding-android-test" with "org.xwalk.embedded.api.sample" and "AcceptFileSchemeCookiesActivity" on android
+         And I register watcher "ClearInfoWindow" when "Info" click "confirm"
+         And I force to run all watchers
+         And I wait for 3 seconds
+         And I click view "text=getCookie"
+         Then I should not see view "textContains=test123"
+         And I click view "text=setAcceptFileSchemeCookies True"
+         And I click view "text=getCookie"
+         And I click view "text=getCookie"
+         Then I should see view "textContains=test123"
+         And I click view "text=setAcceptFileSchemeCookies False"
+         And I click view "text=getCookie"
+         Then I should not see view "textContains=test123"
+         And I remove all watchers

--- a/usecase/usecase-embedding-android-tests/testscripts/AcceptFileSchemeCookiesAsync.feature
+++ b/usecase/usecase-embedding-android-tests/testscripts/AcceptFileSchemeCookiesAsync.feature
@@ -1,0 +1,16 @@
+Feature: Embedding api usecase tests
+    Scenario: Check XWalkCookieManager can setAcceptFileSchemeCookies & allowFileSchemeCookies
+        When I launch "usecase-embedding-android-test" with "org.xwalk.embedded.api.asyncsample" and "AcceptFileSchemeCookiesActivityAsync" on android
+         And I register watcher "ClearInfoWindow" when "Info" click "confirm"
+         And I force to run all watchers
+         And I wait for 3 seconds
+         And I click view "text=getCookie"
+         Then I should not see view "textContains=test123"
+         And I click view "text=setAcceptFileSchemeCookies True"
+         And I click view "text=getCookie"
+         And I click view "text=getCookie"
+         Then I should see view "textContains=test123"
+         And I click view "text=setAcceptFileSchemeCookies False"
+         And I click view "text=getCookie"
+         Then I should not see view "textContains=test123"
+         And I remove all watchers

--- a/usecase/usecase-embedding-android-tests/testscripts/XWalkViewWithWindowsVisibilityChanged.feature
+++ b/usecase/usecase-embedding-android-tests/testscripts/XWalkViewWithWindowsVisibilityChanged.feature
@@ -1,0 +1,10 @@
+Feature: Embedding api usecase tests
+    Scenario: get API version and xwalk version
+        When I launch "usecase-embedding-android-test" with "org.xwalk.embedded.api.sample" and "XWalkViewWithWindowsVisibilityChanged" on android
+         And I register watcher "ClearInfoWindow" when "Info" click "confirm"
+         And I force to run all watchers
+         And I wait for 3 seconds
+         And I click view "text=Open a new Window"
+         And I click view "text=Return"
+        Then I should see view "textContains=GONE->VISIBLE"
+         And I remove all watchers

--- a/usecase/usecase-embedding-android-tests/testscripts/XWalkViewWithWindowsVisibilityChangedAsync.feature
+++ b/usecase/usecase-embedding-android-tests/testscripts/XWalkViewWithWindowsVisibilityChangedAsync.feature
@@ -1,0 +1,10 @@
+Feature: Embedding api usecase tests
+    Scenario: get API version and xwalk version
+        When I launch "usecase-embedding-android-test" with "org.xwalk.embedded.api.asyncsample" and "XWalkViewWithWindowsVisibilityChangedAsync" on android
+         And I register watcher "ClearInfoWindow" when "Info" click "confirm"
+         And I force to run all watchers
+         And I wait for 3 seconds
+         And I click view "text=Open a new Window"
+         And I click view "text=Return"
+        Then I should see view "textContains=GONE->VISIBLE"
+         And I remove all watchers


### PR DESCRIPTION
…ewWithWindowsVisibilityChanged

-Add new autocase for usecase AcceptFileSchemeCookies & XWalkViewWithWindowsVisibilityChanged
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 4, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 4, fail 0, block 0