### PR TITLE
[apptools-windows] Files starting with '.' should not be packaged for apptools windows

### DIFF
--- a/apptools/apptools-windows-tests/apptools/file_name.py
+++ b/apptools/apptools-windows-tests/apptools/file_name.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2015 Intel Corporation.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of works must retain the original copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the original copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of Intel Corporation nor the names of its contributors
+#   may be used to endorse or promote products derived from this work without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Authors:
+#         Liu, Yun <yunx.liu@intel.com>
+
+import unittest
+import os
+import comm
+from xml.etree import ElementTree
+import json
+
+
+class TestCrosswalkApptoolsFunctions(unittest.TestCase):
+
+    def test_update_fileName(self):
+        comm.setUp()
+        comm.create(self)
+        os.chdir('org.xwalk.test')
+        jsonfile = open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "r")
+        jsons = jsonfile.read()
+        jsonfile.close()
+        jsonDict = json.loads(jsons)
+        jsonDict["start_url"] = ".index.html"
+        json.dump(jsonDict, open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "w"))
+        os.rename("app/index.html", "app/.index.html")
+        buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
+        return_code = os.system(buildcmd)
+        comm.clear("org.xwalk.test")
+        self.assertNotEquals(return_code, 0)
+
+    def test_update_iconName(self):
+        comm.setUp()
+        comm.create(self)
+        os.chdir('org.xwalk.test')
+        jsonfile = open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "r")
+        jsons = jsonfile.read()
+        jsonfile.close()
+        jsonDict = json.loads(jsons)
+        jsonDict["icons"][0]["src"] = ".icon.png"
+        json.dump(jsonDict, open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "w"))
+        os.rename("app/icon.png", "app/.icon.png")
+        buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
+        return_code = os.system(buildcmd)
+        comm.clear("org.xwalk.test")
+        self.assertNotEquals(return_code, 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apptools/apptools-windows-tests/tests.full.xml
+++ b/apptools/apptools-windows-tests/tests.full.xml
@@ -58,6 +58,11 @@
           <test_script_entry>/opt/apptools-windows-tests/apptools/check_host.py</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_file_name" priority="P1" purpose="Windows - Validate if file name must not start with '.'" status="approved" type="Functional" subcase="2">
+        <description>
+          <test_script_entry>/opt/apptools-windows-tests/apptools/file_name.py</test_script_entry>
+        </description>
+      </testcase>
     </set>
     <set name="common_module" type="nodeunit">
       <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" priority="P1" purpose="Windows - Validate if the config and log message are correct when create a new project" status="approved" type="Functional" subcase="10">

--- a/apptools/apptools-windows-tests/tests.xml
+++ b/apptools/apptools-windows-tests/tests.xml
@@ -58,6 +58,11 @@
           <test_script_entry>/opt/apptools-windows-tests/apptools/check_host.py</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_file_name" purpose="Windows - Validate if file name must not start with '.'" subcase="2">
+        <description>
+          <test_script_entry>/opt/apptools-windows-tests/apptools/file_name.py</test_script_entry>
+        </description>
+      </testcase>
     </set>
     <set name="common_module" type="nodeunit">
       <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" purpose="Windows - Validate if the config and log message are correct when create a new project" subcase="10">


### PR DESCRIPTION
Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Windows]
Unit test result summary: pass 2, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4835
https://crosswalk-project.org/jira/browse/XWALK-4854