### PR TITLE
[webapi] Clean tail space in js, xml and html

### DIFF
--- a/webapi/tct-2dtransforms-css3-tests/tests.full.xml
+++ b/webapi/tct-2dtransforms-css3-tests/tests.full.xml
@@ -14,7 +14,7 @@
             <spec_statement/>
           </spec>
         </specs>
-      </testcase>    
+      </testcase>
       <testcase purpose="this should make a small green square rotated 30 degrees and the browser should return the rotation as 30 degrees as the computed value NOT a matrix" type="compliance" status="approved" component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Transforms" execution_type="auto" priority="P2" id="2d-rotate-js">
         <description>
           <test_script_entry>/opt/tct-2dtransforms-css3-tests/2dtransforms/csswg/2d-rotate-js.html</test_script_entry>

--- a/webapi/tct-appcache-html5-tests/common/domtestcase.js
+++ b/webapi/tct-appcache-html5-tests/common/domtestcase.js
@@ -9,7 +9,7 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 See W3C License http://www.w3.org/Consortium/Legal/ for more details.
 */
-  
+
 //
 // Log to console wrapper, use this so one doesn't create script errors on
 // user agents that don't support console.log

--- a/webapi/tct-appcache-html5-tests/common/media.js
+++ b/webapi/tct-appcache-html5-tests/common/media.js
@@ -8,7 +8,7 @@ function isResolvedURI(absolute, relative)
     // contains the current host, and ends with 'relative'
     var regex = new RegExp('^' + location.protocol + '\/\/' + '.*' +
         location.hostname + '.*' + relative + '$', 'i');
-    
+
     return absolute.match(regex);
 }
 
@@ -68,7 +68,7 @@ function getVideoType(codecs)
     var codecs_param = 'avc1.42E01E, mp4a.40.2';
 
     var videotag = document.createElement("video");
-    
+
     if ( videotag.canPlayType  &&
          videotag.canPlayType('video/ogg; codecs="theora, vorbis"') )
     {
@@ -151,7 +151,7 @@ function setPassTimeout(milliseconds)
 function findUnbufferedTime(media)
 {
     var max = 0;
-        
+
     for (var i=0; i < media.buffered.length; i++)
     {
         if (media.buffered.end(i) > max)
@@ -193,8 +193,8 @@ function checkPlaybackRate_check()
 
     checkPlaybackRate_callback(
         isApprox(
-            rate, 
-            checkPlaybackRate_playbackRate, 
+            rate,
+            checkPlaybackRate_playbackRate,
             checkPlaybackRate_tolerance
             )
         );

--- a/webapi/tct-audio-html5-tests/common/domtestcase.js
+++ b/webapi/tct-audio-html5-tests/common/domtestcase.js
@@ -9,7 +9,7 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 See W3C License http://www.w3.org/Consortium/Legal/ for more details.
 */
-  
+
 //
 // Log to console wrapper, use this so one doesn't create script errors on
 // user agents that don't support console.log

--- a/webapi/tct-audio-html5-tests/common/media.js
+++ b/webapi/tct-audio-html5-tests/common/media.js
@@ -8,7 +8,7 @@ function isResolvedURI(absolute, relative)
     // contains the current host, and ends with 'relative'
     var regex = new RegExp('^' + location.protocol + '\/\/' + '.*' +
         location.hostname + '.*' + relative + '$', 'i');
-    
+
     return absolute.match(regex);
 }
 
@@ -68,7 +68,7 @@ function getVideoType(codecs)
     var codecs_param = 'avc1.42E01E, mp4a.40.2';
 
     var videotag = document.createElement("video");
-    
+
     if ( videotag.canPlayType  &&
          videotag.canPlayType('video/ogg; codecs="theora, vorbis"') )
     {
@@ -151,7 +151,7 @@ function setPassTimeout(milliseconds)
 function findUnbufferedTime(media)
 {
     var max = 0;
-        
+
     for (var i=0; i < media.buffered.length; i++)
     {
         if (media.buffered.end(i) > max)
@@ -193,8 +193,8 @@ function checkPlaybackRate_check()
 
     checkPlaybackRate_callback(
         isApprox(
-            rate, 
-            checkPlaybackRate_playbackRate, 
+            rate,
+            checkPlaybackRate_playbackRate,
             checkPlaybackRate_tolerance
             )
         );

--- a/webapi/tct-browserstate-html5-tests/common/domtestcase.js
+++ b/webapi/tct-browserstate-html5-tests/common/domtestcase.js
@@ -9,7 +9,7 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 See W3C License http://www.w3.org/Consortium/Legal/ for more details.
 */
-  
+
 //
 // Log to console wrapper, use this so one doesn't create script errors on
 // user agents that don't support console.log

--- a/webapi/tct-browserstate-html5-tests/common/media.js
+++ b/webapi/tct-browserstate-html5-tests/common/media.js
@@ -8,7 +8,7 @@ function isResolvedURI(absolute, relative)
     // contains the current host, and ends with 'relative'
     var regex = new RegExp('^' + location.protocol + '\/\/' + '.*' +
         location.hostname + '.*' + relative + '$', 'i');
-    
+
     return absolute.match(regex);
 }
 
@@ -68,7 +68,7 @@ function getVideoType(codecs)
     var codecs_param = 'avc1.42E01E, mp4a.40.2';
 
     var videotag = document.createElement("video");
-    
+
     if ( videotag.canPlayType  &&
          videotag.canPlayType('video/ogg; codecs="theora, vorbis"') )
     {
@@ -151,7 +151,7 @@ function setPassTimeout(milliseconds)
 function findUnbufferedTime(media)
 {
     var max = 0;
-        
+
     for (var i=0; i < media.buffered.length; i++)
     {
         if (media.buffered.end(i) > max)
@@ -193,8 +193,8 @@ function checkPlaybackRate_check()
 
     checkPlaybackRate_callback(
         isApprox(
-            rate, 
-            checkPlaybackRate_playbackRate, 
+            rate,
+            checkPlaybackRate_playbackRate,
             checkPlaybackRate_tolerance
             )
         );

--- a/webapi/tct-canvas-html5-tests/common/domtestcase.js
+++ b/webapi/tct-canvas-html5-tests/common/domtestcase.js
@@ -9,7 +9,7 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 See W3C License http://www.w3.org/Consortium/Legal/ for more details.
 */
-  
+
 //
 // Log to console wrapper, use this so one doesn't create script errors on
 // user agents that don't support console.log

--- a/webapi/tct-canvas-html5-tests/common/media.js
+++ b/webapi/tct-canvas-html5-tests/common/media.js
@@ -8,7 +8,7 @@ function isResolvedURI(absolute, relative)
     // contains the current host, and ends with 'relative'
     var regex = new RegExp('^' + location.protocol + '\/\/' + '.*' +
         location.hostname + '.*' + relative + '$', 'i');
-    
+
     return absolute.match(regex);
 }
 
@@ -68,7 +68,7 @@ function getVideoType(codecs)
     var codecs_param = 'avc1.42E01E, mp4a.40.2';
 
     var videotag = document.createElement("video");
-    
+
     if ( videotag.canPlayType  &&
          videotag.canPlayType('video/ogg; codecs="theora, vorbis"') )
     {
@@ -151,7 +151,7 @@ function setPassTimeout(milliseconds)
 function findUnbufferedTime(media)
 {
     var max = 0;
-        
+
     for (var i=0; i < media.buffered.length; i++)
     {
         if (media.buffered.end(i) > max)
@@ -193,8 +193,8 @@ function checkPlaybackRate_check()
 
     checkPlaybackRate_callback(
         isApprox(
-            rate, 
-            checkPlaybackRate_playbackRate, 
+            rate,
+            checkPlaybackRate_playbackRate,
             checkPlaybackRate_tolerance
             )
         );

--- a/webapi/tct-dnd-html5-tests/common/domtestcase.js
+++ b/webapi/tct-dnd-html5-tests/common/domtestcase.js
@@ -9,7 +9,7 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 See W3C License http://www.w3.org/Consortium/Legal/ for more details.
 */
-  
+
 //
 // Log to console wrapper, use this so one doesn't create script errors on
 // user agents that don't support console.log

--- a/webapi/tct-dnd-html5-tests/common/media.js
+++ b/webapi/tct-dnd-html5-tests/common/media.js
@@ -8,7 +8,7 @@ function isResolvedURI(absolute, relative)
     // contains the current host, and ends with 'relative'
     var regex = new RegExp('^' + location.protocol + '\/\/' + '.*' +
         location.hostname + '.*' + relative + '$', 'i');
-    
+
     return absolute.match(regex);
 }
 
@@ -68,7 +68,7 @@ function getVideoType(codecs)
     var codecs_param = 'avc1.42E01E, mp4a.40.2';
 
     var videotag = document.createElement("video");
-    
+
     if ( videotag.canPlayType  &&
          videotag.canPlayType('video/ogg; codecs="theora, vorbis"') )
     {
@@ -151,7 +151,7 @@ function setPassTimeout(milliseconds)
 function findUnbufferedTime(media)
 {
     var max = 0;
-        
+
     for (var i=0; i < media.buffered.length; i++)
     {
         if (media.buffered.end(i) > max)
@@ -193,8 +193,8 @@ function checkPlaybackRate_check()
 
     checkPlaybackRate_callback(
         isApprox(
-            rate, 
-            checkPlaybackRate_playbackRate, 
+            rate,
+            checkPlaybackRate_playbackRate,
             checkPlaybackRate_tolerance
             )
         );

--- a/webapi/tct-extra-html5-tests/common/domtestcase.js
+++ b/webapi/tct-extra-html5-tests/common/domtestcase.js
@@ -9,7 +9,7 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 See W3C License http://www.w3.org/Consortium/Legal/ for more details.
 */
-  
+
 //
 // Log to console wrapper, use this so one doesn't create script errors on
 // user agents that don't support console.log

--- a/webapi/tct-extra-html5-tests/common/media.js
+++ b/webapi/tct-extra-html5-tests/common/media.js
@@ -8,7 +8,7 @@ function isResolvedURI(absolute, relative)
     // contains the current host, and ends with 'relative'
     var regex = new RegExp('^' + location.protocol + '\/\/' + '.*' +
         location.hostname + '.*' + relative + '$', 'i');
-    
+
     return absolute.match(regex);
 }
 
@@ -68,7 +68,7 @@ function getVideoType(codecs)
     var codecs_param = 'avc1.42E01E, mp4a.40.2';
 
     var videotag = document.createElement("video");
-    
+
     if ( videotag.canPlayType  &&
          videotag.canPlayType('video/ogg; codecs="theora, vorbis"') )
     {
@@ -151,7 +151,7 @@ function setPassTimeout(milliseconds)
 function findUnbufferedTime(media)
 {
     var max = 0;
-        
+
     for (var i=0; i < media.buffered.length; i++)
     {
         if (media.buffered.end(i) > max)
@@ -193,8 +193,8 @@ function checkPlaybackRate_check()
 
     checkPlaybackRate_callback(
         isApprox(
-            rate, 
-            checkPlaybackRate_playbackRate, 
+            rate,
+            checkPlaybackRate_playbackRate,
             checkPlaybackRate_tolerance
             )
         );

--- a/webapi/tct-forms-html5-tests/common/domtestcase.js
+++ b/webapi/tct-forms-html5-tests/common/domtestcase.js
@@ -9,7 +9,7 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 See W3C License http://www.w3.org/Consortium/Legal/ for more details.
 */
-  
+
 //
 // Log to console wrapper, use this so one doesn't create script errors on
 // user agents that don't support console.log

--- a/webapi/tct-forms-html5-tests/common/media.js
+++ b/webapi/tct-forms-html5-tests/common/media.js
@@ -8,7 +8,7 @@ function isResolvedURI(absolute, relative)
     // contains the current host, and ends with 'relative'
     var regex = new RegExp('^' + location.protocol + '\/\/' + '.*' +
         location.hostname + '.*' + relative + '$', 'i');
-    
+
     return absolute.match(regex);
 }
 
@@ -68,7 +68,7 @@ function getVideoType(codecs)
     var codecs_param = 'avc1.42E01E, mp4a.40.2';
 
     var videotag = document.createElement("video");
-    
+
     if ( videotag.canPlayType  &&
          videotag.canPlayType('video/ogg; codecs="theora, vorbis"') )
     {
@@ -151,7 +151,7 @@ function setPassTimeout(milliseconds)
 function findUnbufferedTime(media)
 {
     var max = 0;
-        
+
     for (var i=0; i < media.buffered.length; i++)
     {
         if (media.buffered.end(i) > max)
@@ -193,8 +193,8 @@ function checkPlaybackRate_check()
 
     checkPlaybackRate_callback(
         isApprox(
-            rate, 
-            checkPlaybackRate_playbackRate, 
+            rate,
+            checkPlaybackRate_playbackRate,
             checkPlaybackRate_tolerance
             )
         );

--- a/webapi/tct-jsenhance-html5-tests/common/domtestcase.js
+++ b/webapi/tct-jsenhance-html5-tests/common/domtestcase.js
@@ -9,7 +9,7 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 See W3C License http://www.w3.org/Consortium/Legal/ for more details.
 */
-  
+
 //
 // Log to console wrapper, use this so one doesn't create script errors on
 // user agents that don't support console.log

--- a/webapi/tct-jsenhance-html5-tests/common/media.js
+++ b/webapi/tct-jsenhance-html5-tests/common/media.js
@@ -8,7 +8,7 @@ function isResolvedURI(absolute, relative)
     // contains the current host, and ends with 'relative'
     var regex = new RegExp('^' + location.protocol + '\/\/' + '.*' +
         location.hostname + '.*' + relative + '$', 'i');
-    
+
     return absolute.match(regex);
 }
 
@@ -68,7 +68,7 @@ function getVideoType(codecs)
     var codecs_param = 'avc1.42E01E, mp4a.40.2';
 
     var videotag = document.createElement("video");
-    
+
     if ( videotag.canPlayType  &&
          videotag.canPlayType('video/ogg; codecs="theora, vorbis"') )
     {
@@ -151,7 +151,7 @@ function setPassTimeout(milliseconds)
 function findUnbufferedTime(media)
 {
     var max = 0;
-        
+
     for (var i=0; i < media.buffered.length; i++)
     {
         if (media.buffered.end(i) > max)
@@ -193,8 +193,8 @@ function checkPlaybackRate_check()
 
     checkPlaybackRate_callback(
         isApprox(
-            rate, 
-            checkPlaybackRate_playbackRate, 
+            rate,
+            checkPlaybackRate_playbackRate,
             checkPlaybackRate_tolerance
             )
         );

--- a/webapi/tct-sessionhistory-html5-tests/common/domtestcase.js
+++ b/webapi/tct-sessionhistory-html5-tests/common/domtestcase.js
@@ -9,7 +9,7 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 See W3C License http://www.w3.org/Consortium/Legal/ for more details.
 */
-  
+
 //
 // Log to console wrapper, use this so one doesn't create script errors on
 // user agents that don't support console.log

--- a/webapi/tct-sessionhistory-html5-tests/common/media.js
+++ b/webapi/tct-sessionhistory-html5-tests/common/media.js
@@ -8,7 +8,7 @@ function isResolvedURI(absolute, relative)
     // contains the current host, and ends with 'relative'
     var regex = new RegExp('^' + location.protocol + '\/\/' + '.*' +
         location.hostname + '.*' + relative + '$', 'i');
-    
+
     return absolute.match(regex);
 }
 
@@ -68,7 +68,7 @@ function getVideoType(codecs)
     var codecs_param = 'avc1.42E01E, mp4a.40.2';
 
     var videotag = document.createElement("video");
-    
+
     if ( videotag.canPlayType  &&
          videotag.canPlayType('video/ogg; codecs="theora, vorbis"') )
     {
@@ -151,7 +151,7 @@ function setPassTimeout(milliseconds)
 function findUnbufferedTime(media)
 {
     var max = 0;
-        
+
     for (var i=0; i < media.buffered.length; i++)
     {
         if (media.buffered.end(i) > max)
@@ -193,8 +193,8 @@ function checkPlaybackRate_check()
 
     checkPlaybackRate_callback(
         isApprox(
-            rate, 
-            checkPlaybackRate_playbackRate, 
+            rate,
+            checkPlaybackRate_playbackRate,
             checkPlaybackRate_tolerance
             )
         );

--- a/webapi/tct-svg-html5-tests/common/domtestcase.js
+++ b/webapi/tct-svg-html5-tests/common/domtestcase.js
@@ -9,7 +9,7 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 See W3C License http://www.w3.org/Consortium/Legal/ for more details.
 */
-  
+
 //
 // Log to console wrapper, use this so one doesn't create script errors on
 // user agents that don't support console.log

--- a/webapi/tct-svg-html5-tests/common/media.js
+++ b/webapi/tct-svg-html5-tests/common/media.js
@@ -8,7 +8,7 @@ function isResolvedURI(absolute, relative)
     // contains the current host, and ends with 'relative'
     var regex = new RegExp('^' + location.protocol + '\/\/' + '.*' +
         location.hostname + '.*' + relative + '$', 'i');
-    
+
     return absolute.match(regex);
 }
 
@@ -68,7 +68,7 @@ function getVideoType(codecs)
     var codecs_param = 'avc1.42E01E, mp4a.40.2';
 
     var videotag = document.createElement("video");
-    
+
     if ( videotag.canPlayType  &&
          videotag.canPlayType('video/ogg; codecs="theora, vorbis"') )
     {
@@ -151,7 +151,7 @@ function setPassTimeout(milliseconds)
 function findUnbufferedTime(media)
 {
     var max = 0;
-        
+
     for (var i=0; i < media.buffered.length; i++)
     {
         if (media.buffered.end(i) > max)
@@ -193,8 +193,8 @@ function checkPlaybackRate_check()
 
     checkPlaybackRate_callback(
         isApprox(
-            rate, 
-            checkPlaybackRate_playbackRate, 
+            rate,
+            checkPlaybackRate_playbackRate,
             checkPlaybackRate_tolerance
             )
         );

--- a/webapi/tct-text-css3-tests/text/reference/pre-wrap-line-test-ref.html
+++ b/webapi/tct-text-css3-tests/text/reference/pre-wrap-line-test-ref.html
@@ -3,6 +3,6 @@
 <title>CSP Reference</title>
 <link rel="author" title="Intel" href="http://www.intel.com"/>
 <body>							
-<table><tr><td><div>Three cheers &nbsp;&nbsp;&nbsp;for OldVet and the letter he wrote to Senator Dodd (see above Comment).&nbsp; We all need to be proactive and contact our senators and representatives to let them know our strong feelings on this subject. &nbsp;I would lose what little faith I have left in our government if they engineered a tax payer bailout. 
+<table><tr><td><div>Three cheers &nbsp;&nbsp;&nbsp;for OldVet and the letter he wrote to Senator Dodd (see above Comment).&nbsp; We all need to be proactive and contact our senators and representatives to let them know our strong feelings on this subject. &nbsp;I would lose what little faith I have left in our government if they engineered a tax payer bailout.
 </div></td></tr></table>
 </body>

--- a/webapi/tct-video-html5-tests/common/domtestcase.js
+++ b/webapi/tct-video-html5-tests/common/domtestcase.js
@@ -9,7 +9,7 @@ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 See W3C License http://www.w3.org/Consortium/Legal/ for more details.
 */
-  
+
 //
 // Log to console wrapper, use this so one doesn't create script errors on
 // user agents that don't support console.log

--- a/webapi/tct-video-html5-tests/common/media.js
+++ b/webapi/tct-video-html5-tests/common/media.js
@@ -8,7 +8,7 @@ function isResolvedURI(absolute, relative)
     // contains the current host, and ends with 'relative'
     var regex = new RegExp('^' + location.protocol + '\/\/' + '.*' +
         location.hostname + '.*' + relative + '$', 'i');
-    
+
     return absolute.match(regex);
 }
 
@@ -68,7 +68,7 @@ function getVideoType(codecs)
     var codecs_param = 'avc1.42E01E, mp4a.40.2';
 
     var videotag = document.createElement("video");
-    
+
     if ( videotag.canPlayType  &&
          videotag.canPlayType('video/ogg; codecs="theora, vorbis"') )
     {
@@ -151,7 +151,7 @@ function setPassTimeout(milliseconds)
 function findUnbufferedTime(media)
 {
     var max = 0;
-        
+
     for (var i=0; i < media.buffered.length; i++)
     {
         if (media.buffered.end(i) > max)
@@ -193,8 +193,8 @@ function checkPlaybackRate_check()
 
     checkPlaybackRate_callback(
         isApprox(
-            rate, 
-            checkPlaybackRate_playbackRate, 
+            rate,
+            checkPlaybackRate_playbackRate,
             checkPlaybackRate_tolerance
             )
         );

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_getRealPath.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_getRealPath.html
@@ -51,7 +51,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       var excepted = xwalk.experimental.native_file_system.getRealPath("DOWNLOADS");
       assert_equals(realPath, excepted);
     }, "Insensitive to virtual root character that Downloads has same full path with DOWNLOADS");
-    
+
     test(function() {
       var realPath = xwalk.experimental.native_file_system.getRealPath("MUSIC");
       assert_regexp_match(realPath, /^(\/storage)(\/\w+)+(\/Music)$/);

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_root_base.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_root_base.html
@@ -38,7 +38,7 @@ Authors:
 <script src="../resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-    
+
 var t = async_test("Check if NativeFileSystem.root is the root directory of the file system", {timeout: 2000});
 setup({timeout:500});
 


### PR DESCRIPTION
Clean tail space in js with following cmd:
find ./ -type f -name "*.js"|xargs -I% grep -l ' $' % |grep -v -E 'tizen|w3c|csswg|webkit' |xargs -I% sed -i 's/ *$//g' %