### PR TITLE
[apptools-android] Add case to test the app icon for apptools android

### DIFF
--- a/apptools/apptools-android-tests/apptools/Using_Better_Fitting_Size_Icon.html
+++ b/apptools/apptools-android-tests/apptools/Using_Better_Fitting_Size_Icon.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Yun, Liu<yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>Check_App_Icon</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<body>
+  <p>
+    <strong>Test steps:</strong>
+  </p>
+  <ol>
+    <li>If org.xwalk.test exists in apptools-android-tests/tools/ directory, remove it <br/>
+        Then run below commands under apptools-android-tests/tools/ directory: <br/>
+        On Android: <br/>
+        &nbsp; &nbsp; Shared Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
+        &nbsp; &nbsp; Embedded Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; $ cd org.xwalk.test <br/>
+        &nbsp; &nbsp; Add '{"src": "../../../icon/icon.jpg","sizes": "32x32"}' to "icons" field in app/manifest.json file <br/>
+        &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
+        On Windows: <br/>
+        &nbsp; &nbsp; Shared Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
+        &nbsp; &nbsp; Embedded Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; $ cd org.xwalk.test <br/>
+        &nbsp; &nbsp; Add '{"src": "../../../icon/icon.jpg","sizes": "32x32"}' to "icons" field in app/manifest.json file <br/>
+        &nbsp; &nbsp; $ node  ..\crosswalk-app-tools\src\crosswalk-app build <br/>
+        Shared Mode: <br/>
+        &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
+        &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
+        Embedded Mode: <br/>
+        &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
+        &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
+        Check if 'app/icon.png' isn't same with '../../icon/icon.jpg', and 'app/icon.png' is used as the icon of web app on android device
+    </li>
+  </ol>
+  <p>
+    <strong>Expected Results:</strong>
+  </p>
+  <ol>
+    <li>The 'app/icon.png' isn't same with '../../icon/icon.jpg', and 'app/icon.png' is used as the icon of web app on android device</li>
+  </ol>
+</body>
+

--- a/apptools/apptools-android-tests/tests.full.xml
+++ b/apptools/apptools-android-tests/tests.full.xml
@@ -257,6 +257,11 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/Remote_Debugging.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Using_Better_Fitting_Size_Icon" priority="P1" purpose="Android - Validate if the better fitting size icon is used to the icon of web app" status="approved" type="Functional">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/apptools/Using_Better_Fitting_Size_Icon.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/apptools/apptools-android-tests/tests.xml
+++ b/apptools/apptools-android-tests/tests.xml
@@ -257,6 +257,11 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/Remote_Debugging.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Using_Better_Fitting_Size_Icon" purpose="Android - Validate if the better fitting size icon is used to the icon of web app">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/apptools/Using_Better_Fitting_Size_Icon.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
The better fitting size icon is used as app icon

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-5079
https://crosswalk-project.org/jira/browse/XWALK-5082