### PR TITLE
[EmbeddingApi] Add autocase to implement XWalkView.getUserAgentString

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -944,7 +944,16 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
 	            mXWalkView.setUserAgentString(userAgent);
 	        }
 	    });
-	}    
+	}
+	
+	protected String getUserAgent() throws Exception {
+	    return runTestOnUiThreadAndGetResult(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return mXWalkView.getUserAgentString();
+            }
+        });
+    }	    
 	
     protected void setCookie(final String name, final String value) throws Exception {
         String jsCommand = "javascript:void((function(){" +

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewTest.java
@@ -7,9 +7,12 @@ package org.xwalk.embedding.test.v5;
 import java.util.concurrent.Callable;
 
 import android.graphics.Color;
+import org.apache.http.Header;
+import org.apache.http.HttpRequest;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 import android.annotation.SuppressLint;
 import android.test.suitebuilder.annotation.SmallTest;
+import android.test.suitebuilder.annotation.MediumTest;
 
 @SuppressLint("NewApi")
 public class XWalkViewTest extends XWalkViewTestBase {
@@ -31,6 +34,49 @@ public class XWalkViewTest extends XWalkViewTestBase {
             assertTrue(false);
         }
     }
+    
+    
+    @SmallTest
+    public void testUserAgent() throws Throwable {
+        final String USER_AGENT = "Chrome/44.0.2403.81 Crosswalk/15.44.376.0 Mobile Safari/537.36";
+        final String defaultUserAgentString = getUserAgent();
+
+        // Check that an attempt to set the default UA string to null or "" has no effect.
+        setUserAgent(null);
+        assertEquals(defaultUserAgentString, getUserAgent());
+        setUserAgent("");
+        assertEquals(defaultUserAgentString, getUserAgent());
+
+        // Set a custom UA string, verify that it can be reset back to default.
+        setUserAgent(USER_AGENT);
+        assertEquals(USER_AGENT, getUserAgent());
+        setUserAgent(null);
+        assertEquals(defaultUserAgentString, getUserAgent());
+    }
+    
+    @MediumTest
+    public void testUserAgentWithTestServer() throws Throwable {
+        final String customUserAgentString = "testUserAgentWithTestServerUserAgent";
+
+        String fileName = null;
+        try {
+            final String httpPath = "/testUserAgentWithTestServer.html";
+            final String url = mWebServer.setResponse(httpPath, "foo", null);
+
+            setUserAgent(customUserAgentString);
+            loadUrlSync(url);
+
+            assertEquals(1, mWebServer.getRequestCount(httpPath));
+            HttpRequest request = mWebServer.getLastRequest(httpPath);
+            Header[] matchingHeaders  = request.getHeaders("User-Agent");
+            assertEquals(1, matchingHeaders.length);
+
+            Header header = matchingHeaders[0];
+            assertEquals(customUserAgentString, header.getValue());
+            assertEquals(customUserAgentString, getUserAgent());
+        } finally {
+        }
+    }    
 
     @SmallTest
     public void testSetZOrderOnTop_True() {

--- a/embeddingapi/embedding-api-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-api-android-tests/tests.full.xml
@@ -83,7 +83,7 @@
           <test_script_entry>org.xwalk.embedding.test.v4.XWalkResourceClientTest</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="11">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="13">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-api-android-tests/tests_v5.xml
+++ b/embeddingapi/embedding-api-android-tests/tests_v5.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite name="webapi-embeddingapi-xwalk-tests" category="Android embedding APIs">
     <set name="EmbeddingApiTest" type="androidunit" location="device">
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="11">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTest" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="13">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -915,6 +915,15 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
 	    });
 	}    
 	
+	protected String getUserAgent() throws Exception {
+	    return runTestOnUiThreadAndGetResult(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return mXWalkView.getUserAgentString();
+            }
+        });
+    }	    
+	
     protected void setCookie(final String name, final String value) throws Exception {
         String jsCommand = "javascript:void((function(){" +
                 "var expirationDate = new Date();" +

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewTestAsync.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkViewTestAsync.java
@@ -7,9 +7,12 @@ package org.xwalk.embedding.test.v5;
 import java.util.concurrent.Callable;
 
 import android.graphics.Color;
+import org.apache.http.Header;
+import org.apache.http.HttpRequest;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 import android.annotation.SuppressLint;
 import android.test.suitebuilder.annotation.SmallTest;
+import android.test.suitebuilder.annotation.MediumTest;
 
 @SuppressLint("NewApi")
 public class XWalkViewTestAsync extends XWalkViewTestBase {
@@ -29,6 +32,49 @@ public class XWalkViewTestAsync extends XWalkViewTestBase {
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);
+        }
+    }
+    
+    
+    @SmallTest
+    public void testUserAgent() throws Throwable {
+        final String USER_AGENT = "Chrome/44.0.2403.81 Crosswalk/15.44.376.0 Mobile Safari/537.36";
+        final String defaultUserAgentString = getUserAgent();
+
+        // Check that an attempt to set the default UA string to null or "" has no effect.
+        setUserAgent(null);
+        assertEquals(defaultUserAgentString, getUserAgent());
+        setUserAgent("");
+        assertEquals(defaultUserAgentString, getUserAgent());
+
+        // Set a custom UA string, verify that it can be reset back to default.
+        setUserAgent(USER_AGENT);
+        assertEquals(USER_AGENT, getUserAgent());
+        setUserAgent(null);
+        assertEquals(defaultUserAgentString, getUserAgent());
+    }
+    
+    @MediumTest
+    public void testUserAgentWithTestServer() throws Throwable {
+        final String customUserAgentString = "testUserAgentWithTestServerUserAgent";
+
+        String fileName = null;
+        try {
+            final String httpPath = "/testUserAgentWithTestServer.html";
+            final String url = mWebServer.setResponse(httpPath, "foo", null);
+
+            setUserAgent(customUserAgentString);
+            loadUrlSync(url);
+
+            assertEquals(1, mWebServer.getRequestCount(httpPath));
+            HttpRequest request = mWebServer.getLastRequest(httpPath);
+            Header[] matchingHeaders  = request.getHeaders("User-Agent");
+            assertEquals(1, matchingHeaders.length);
+
+            Header header = matchingHeaders[0];
+            assertEquals(customUserAgentString, header.getValue());
+            assertEquals(customUserAgentString, getUserAgent());
+        } finally {
         }
     }
 

--- a/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
@@ -83,7 +83,7 @@
           <test_script_entry>org.xwalk.embedding.test.v4.XWalkResourceClientTestAsync</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTestAsync" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="11">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTestAsync" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="13">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewTestAsync</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/tests_v5.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests_v5.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite name="Embedding-asyncapi-android-tests" category="Android embedding APIs">
     <set name="EmbeddingApiAsyncTest" type="androidunit" location="device">
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTestAsync" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="11">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v5.XWalkViewTestAsync" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="13">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v5.XWalkViewTestAsync</test_script_entry>
         </description>


### PR DESCRIPTION
-Add autocase to implement XWalkView.getUserAgentString
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 4, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 4, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4825