### PR TITLE
[webapi] Add webaudio.createAnalyser return value test

### DIFF
--- a/webapi/tct-webaudio-w3c-tests/tests.full.xml
+++ b/webapi/tct-webaudio-w3c-tests/tests.full.xml
@@ -3,6 +3,18 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="tct-webaudio-w3c-tests">
     <set name="WebAudio1" type="js">
+      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="analysernode_default_value" priority="P2" purpose="Check that the default values of AnalyserNode's members as specified" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/analysernode_default_value.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="Tizen W3C API Specifications" element_name="fftSize" element_type="attribute" interface="AnalyserNode" section="Media" specification="Web Audio API" />
+            <spec_url>http://webaudio.github.io/web-audio-api/#idl-def-AnalyserNode</spec_url>
+            <spec_statement />
+          </spec>
+        </specs>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="analysernode_fftSize_exists" priority="P1" purpose="Check if AnalyserNode.fftSize attribute exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/analysernode_fftSize_exists.html</test_script_entry>
@@ -3977,7 +3989,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="audiocontext_createAnalyser_return_value" priority="P2" purpose="Check if AudioContext.createAnalyser() returns zero" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="audiocontext_createAnalyser_return_value" priority="P2" purpose="Check that AudioContext.createAnalyser() returns an instance of AnalyserNode" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/audiocontext_createAnalyser_return_value.html</test_script_entry>
         </description>

--- a/webapi/tct-webaudio-w3c-tests/tests.full.xml
+++ b/webapi/tct-webaudio-w3c-tests/tests.full.xml
@@ -3977,6 +3977,18 @@
           </spec>
         </specs>
       </testcase>
+      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="audiocontext_createAnalyser_return_value" priority="P2" purpose="Check if AudioContext.createAnalyser() returns zero" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/audiocontext_createAnalyser_return_value.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="Tizen W3C API Specifications" element_name="createAnalyser" element_type="method" interface="AudioContext" section="Media" specification="Web Audio API" />
+            <spec_url>http://webaudio.github.io/web-audio-api/#widl-AudioContext-createAnalyser-AnalyserNode</spec_url>
+            <spec_statement />
+          </spec>
+        </specs>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="audiocontext_createBiquadFilter_base" priority="P2" purpose="Check if AudioContext.createBiquadFilter method return value type of is BiquadFilterNode" status="approved" type="compliance">
         <description>
           <steps>

--- a/webapi/tct-webaudio-w3c-tests/tests.xml
+++ b/webapi/tct-webaudio-w3c-tests/tests.xml
@@ -3,6 +3,11 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="tct-webaudio-w3c-tests">
     <set name="WebAudio1" type="js">
+      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="analysernode_default_value" purpose="Check that the default values of AnalyserNode's members as specified">
+        <description>
+          <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/analysernode_default_value.html</test_script_entry>
+        </description>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="analysernode_fftSize_exists" purpose="Check if AnalyserNode.fftSize attribute exists">
         <description>
           <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/analysernode_fftSize_exists.html</test_script_entry>
@@ -1481,7 +1486,7 @@
           <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/audiocontext_createAnalyser_base.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="audiocontext_createAnalyser_return_value" purpose="Check if AudioContext.createAnalyser() returns zero">
+      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="audiocontext_createAnalyser_return_value" purpose="Check that AudioContext.createAnalyser() returns an instance of AnalyserNode">
         <description>
           <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/audiocontext_createAnalyser_return_value.html</test_script_entry>
         </description>

--- a/webapi/tct-webaudio-w3c-tests/tests.xml
+++ b/webapi/tct-webaudio-w3c-tests/tests.xml
@@ -1481,6 +1481,11 @@
           <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/audiocontext_createAnalyser_base.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="audiocontext_createAnalyser_return_value" purpose="Check if AudioContext.createAnalyser() returns zero">
+        <description>
+          <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/audiocontext_createAnalyser_return_value.html</test_script_entry>
+        </description>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="audiocontext_createBiquadFilter_base" purpose="Check if AudioContext.createBiquadFilter method return value type of is BiquadFilterNode">
         <description>
           <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/audiocontext_createBiquadFilter_base.html</test_script_entry>

--- a/webapi/tct-webaudio-w3c-tests/webaudio/analysernode_default_value.html
+++ b/webapi/tct-webaudio-w3c-tests/webaudio/analysernode_default_value.html
@@ -27,10 +27,10 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
 <meta charset="utf-8">
-<title>WebAudio Test: AudioContext createAnalyser return value</title>
+<title>WebAudio Test: default value of AnalyserNode's members</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Chunyan Wang" href="mailto:chunyanx.wang@intel.com">
-<link rel="help" href="http://webaudio.github.io/web-audio-api/#widl-AudioContext-createAnalyser-AnalyserNode">
+<link rel="help" href="http://webaudio.github.io/web-audio-api/#idl-def-AnalyserNode">
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
 <div id="log"></div>
@@ -40,8 +40,19 @@ test(function() {
   var context = new AudioContext();
   var analyser = context.createAnalyser();
 
-  assert_true(analyser instanceof AnalyserNode);
+  assert_equals(analyser.numberOfInputs, 1, "analyser.numberOfInputs");
+  assert_equals(analyser.numberOfOutputs, 1, "analyser.numberOfOutputs");
+  assert_equals(analyser.channelCount, 1, "analyser.channelCount");
+  assert_equals(analyser.channelCountMode, "max", "analyser.channelCountMode");
+  assert_equals(analyser.channelInterpretation, "speakers", "analyser.channelInterpretation");
 
-}, "Check that AudioContext.createAnalyser() returns an instance of AnalyserNode.");
+  assert_equals(analyser.fftSize, 2048, "fftSize default value");
+  analyser.frequencyBinCount = 64;
+  assert_equals(analyser.frequencyBinCount, 1024, "frequencyBinCount is readonly, and the value is half of fftSize");
+  assert_equals(analyser.maxDecibels, -30, "maxDecibels's default value");
+  assert_equals(analyser.minDecibels, -100, "minDecibels's default value");
+  assert_equals(analyser.smoothingTimeConstant, 0.8, "smoothingTimeConstant's default value");
+
+}, "Check that the default values of AnalyserNode's members as specified.");
 </script>
 

--- a/webapi/tct-webaudio-w3c-tests/webaudio/audiocontext_createAnalyser_return_value.html
+++ b/webapi/tct-webaudio-w3c-tests/webaudio/audiocontext_createAnalyser_return_value.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<meta charset="utf-8">
+<title>WebAudio Test: audiocontext createAnalyser return value</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Chunyan Wang" href="mailto:chunyanx.wang@intel.com">
+<link rel="help" href="http://webaudio.github.io/web-audio-api/#widl-AudioContext-createAnalyser-AnalyserNode">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/webaudio.js"></script>
+<div id="log"></div>
+<script>
+
+test(function() {
+  var context = new AudioContext();
+  var analyser = context.createAnalyser();
+  analyser.fftSize = 256;
+  assert_true(analyser instanceof AnalyserNode);
+  assert_not_equals(analyser, 0);
+}, "Check if AudioContext.createAnalyser() returns zero.");
+
+</script>
+


### PR DESCRIPTION
The value of channelCount get 2 not  except 1 on Crosswalk and Chrome browser desktop,
but it gets 1 on Firefox browser desktop.

Impacted TCs num(approved): New 2, Update 0, Delete 0
Unit test Platform: Crosswalk Project for Android 16.45.410.0
Unit test result summary: Pass 1, Fail 1, Blocked 0