### PR TITLE
[atip] Update startswith and endswith to use innerHTML

### DIFF
--- a/tools/atip/atip/web/web.py
+++ b/tools/atip/atip/web/web.py
@@ -513,7 +513,7 @@ class WebAPP(common.APP):
     def should_see_text_startswith(self, text=None, key=None):
         try:
             js_script = 'var text=document.getElementById(\"' + \
-                key + '\").innerText; return text'
+                key + '\").innerHTML; return text'
             content = self.driver.execute_script(js_script)
             if content.strip().startswith(text):
                 return True
@@ -526,7 +526,7 @@ class WebAPP(common.APP):
     def should_see_text_endswith(self, text=None, key=None):
         try:
             js_script = 'var text=document.getElementById(\"' + \
-                key + '\").innerText; return text'
+                key + '\").innerHTML; return text'
             content = self.driver.execute_script(js_script)
             if content.strip().endswith(text):
                 return True


### PR DESCRIPTION
For textarea element, innerText will be empty string when set its content,
it's better to use innerHTML for most elements.

Impacted tests(approved): new 0, update 2, delete 0
Unit test platform: Crosswalk Project for Android 16.45.410.0
Unit test result summary: pass 2, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4877