### PR TITLE
Complete the webapi test suite path in pack.sh

### DIFF
--- a/misc/webapi-noneservice-tests/pack.sh
+++ b/misc/webapi-noneservice-tests/pack.sh
@@ -62,7 +62,7 @@ rm -rf $SRC_ROOT/*.zip
 cp -arf $SRC_ROOT/* $BUILD_ROOT/
 
 for list in $LIST;do
-    cp -ar $list $BUILD_ROOT/
+    cp -ar ./../../webapi/$list $BUILD_ROOT/
 done
 
 ## creat testlist.json ##


### PR DESCRIPTION
For XWALK-4898, now use the while list for the test suites.
In the pack.sh script, we need the complete the path for the test
suites by adding the webapi parent directory.

Related to: https://crosswalk-project.org/jira/browse/XWALK-4898
Signed-off-by: Zhong Qiu <zhongx.qiu@intel.com>