### PR TITLE
[webapi] Capitalize first letter of type name in SIMD

### DIFF
--- a/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/ecmascript_simd.js
+++ b/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/ecmascript_simd.js
@@ -97,13 +97,13 @@ _SIMD_PRIVATE.frombool = function(x) {
 // Save/Restore utilities for implementing bitwise conversions.
 
 _SIMD_PRIVATE.saveFloat64x2 = function(x) {
-  x = SIMD.float64x2.check(x);
+  x = SIMD.Float64x2.check(x);
   _SIMD_PRIVATE._f64x2[0] = x.x;
   _SIMD_PRIVATE._f64x2[1] = x.y;
 }
 
 _SIMD_PRIVATE.saveFloat32x4 = function(x) {
-  x = SIMD.float32x4.check(x);
+  x = SIMD.Float32x4.check(x);
   _SIMD_PRIVATE._f32x4[0] = x.x;
   _SIMD_PRIVATE._f32x4[1] = x.y;
   _SIMD_PRIVATE._f32x4[2] = x.z;
@@ -111,7 +111,7 @@ _SIMD_PRIVATE.saveFloat32x4 = function(x) {
 }
 
 _SIMD_PRIVATE.saveInt32x4 = function(x) {
-  x = SIMD.int32x4.check(x);
+  x = SIMD.Int32x4.check(x);
   _SIMD_PRIVATE._i32x4[0] = x.x;
   _SIMD_PRIVATE._i32x4[1] = x.y;
   _SIMD_PRIVATE._i32x4[2] = x.z;
@@ -152,17 +152,17 @@ _SIMD_PRIVATE.saveInt8x16 = function(x) {
 
 _SIMD_PRIVATE.restoreFloat64x2 = function() {
   var alias = _SIMD_PRIVATE._f64x2;
-  return SIMD.float64x2(alias[0], alias[1]);
+  return SIMD.Float64x2(alias[0], alias[1]);
 }
 
 _SIMD_PRIVATE.restoreFloat32x4 = function() {
   var alias = _SIMD_PRIVATE._f32x4;
-  return SIMD.float32x4(alias[0], alias[1], alias[2], alias[3]);
+  return SIMD.Float32x4(alias[0], alias[1], alias[2], alias[3]);
 }
 
 _SIMD_PRIVATE.restoreInt32x4 = function() {
   var alias = _SIMD_PRIVATE._i32x4;
-  return SIMD.int32x4(alias[0], alias[1], alias[2], alias[3]);
+  return SIMD.Int32x4(alias[0], alias[1], alias[2], alias[3]);
 }
 
 _SIMD_PRIVATE.restoreInt16x8 = function() {
@@ -179,18 +179,18 @@ _SIMD_PRIVATE.restoreInt8x16 = function() {
                       alias[12], alias[13], alias[14], alias[15]);
 }
 
-if (typeof SIMD.float32x4 === "undefined") {
+if (typeof SIMD.Float32x4 === "undefined") {
   /**
-    * Construct a new instance of float32x4 number.
+    * Construct a new instance of Float32x4 number.
     * @param {double} value used for x lane.
     * @param {double} value used for y lane.
     * @param {double} value used for z lane.
     * @param {double} value used for w lane.
     * @constructor
     */
-  SIMD.float32x4 = function(x, y, z, w) {
-    if (!(this instanceof SIMD.float32x4)) {
-      return new SIMD.float32x4(x, y, z, w);
+  SIMD.Float32x4 = function(x, y, z, w) {
+    if (!(this instanceof SIMD.Float32x4)) {
+      return new SIMD.Float32x4(x, y, z, w);
     }
 
     this.x_ = _SIMD_PRIVATE.truncatef32(x);
@@ -199,26 +199,26 @@ if (typeof SIMD.float32x4 === "undefined") {
     this.w_ = _SIMD_PRIVATE.truncatef32(w);
   }
 
-  Object.defineProperty(SIMD.float32x4.prototype, 'x', {
+  Object.defineProperty(SIMD.Float32x4.prototype, 'x', {
     get: function() { return this.x_; }
   });
 
-  Object.defineProperty(SIMD.float32x4.prototype, 'y', {
+  Object.defineProperty(SIMD.Float32x4.prototype, 'y', {
     get: function() { return this.y_; }
   });
 
-  Object.defineProperty(SIMD.float32x4.prototype, 'z', {
+  Object.defineProperty(SIMD.Float32x4.prototype, 'z', {
     get: function() { return this.z_; }
   });
 
-  Object.defineProperty(SIMD.float32x4.prototype, 'w', {
+  Object.defineProperty(SIMD.Float32x4.prototype, 'w', {
     get: function() { return this.w_; }
   });
 
   /**
     * Extract the sign bit from each lane return them in the first 4 bits.
     */
-  Object.defineProperty(SIMD.float32x4.prototype, 'signMask', {
+  Object.defineProperty(SIMD.Float32x4.prototype, 'signMask', {
     get: function() {
       var mx = (this.x < 0.0 || 1/this.x === -Infinity);
       var my = (this.y < 0.0 || 1/this.y === -Infinity);
@@ -229,108 +229,108 @@ if (typeof SIMD.float32x4 === "undefined") {
   });
 }
 
-if (typeof SIMD.float32x4.check === "undefined") {
+if (typeof SIMD.Float32x4.check === "undefined") {
   /**
-    * Check whether the argument is a float32x4.
-    * @param {float32x4} v An instance of float32x4.
-    * @return {float32x4} The float32x4 instance.
+    * Check whether the argument is a Float32x4.
+    * @param {Float32x4} v An instance of Float32x4.
+    * @return {Float32x4} The Float32x4 instance.
     */
-  SIMD.float32x4.check = function(v) {
-    if (!(v instanceof SIMD.float32x4)) {
-      throw new TypeError("argument is not a float32x4.");
+  SIMD.Float32x4.check = function(v) {
+    if (!(v instanceof SIMD.Float32x4)) {
+      throw new TypeError("argument is not a Float32x4.");
     }
     return v;
   }
 }
 
-if (typeof SIMD.float32x4.splat === "undefined") {
+if (typeof SIMD.Float32x4.splat === "undefined") {
   /**
-    * Construct a new instance of float32x4 number with the same value
+    * Construct a new instance of Float32x4 number with the same value
     * in all lanes.
     * @param {double} value used for all lanes.
     * @constructor
     */
-  SIMD.float32x4.splat = function(s) {
-    return SIMD.float32x4(s, s, s, s);
+  SIMD.Float32x4.splat = function(s) {
+    return SIMD.Float32x4(s, s, s, s);
   }
 }
 
-if (typeof SIMD.float32x4.fromFloat64x2 === "undefined") {
+if (typeof SIMD.Float32x4.fromFloat64x2 === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @return {float32x4} A float32x4 with .x and .y from t
+    * @param {Float64x2} t An instance of Float64x2.
+    * @return {Float32x4} A Float32x4 with .x and .y from t
     */
-  SIMD.float32x4.fromFloat64x2 = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.float32x4(t.x, t.y, 0, 0);
+  SIMD.Float32x4.fromFloat64x2 = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Float32x4(t.x, t.y, 0, 0);
   }
 }
 
-if (typeof SIMD.float32x4.fromInt32x4 === "undefined") {
+if (typeof SIMD.Float32x4.fromInt32x4 === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @return {float32x4} An integer to float conversion copy of t.
+    * @param {Int32x4} t An instance of Int32x4.
+    * @return {Float32x4} An integer to float conversion copy of t.
     */
-  SIMD.float32x4.fromInt32x4 = function(t) {
-    t = SIMD.int32x4.check(t);
-    return SIMD.float32x4(t.x, t.y, t.z, t.w);
+  SIMD.Float32x4.fromInt32x4 = function(t) {
+    t = SIMD.Int32x4.check(t);
+    return SIMD.Float32x4(t.x, t.y, t.z, t.w);
   }
 }
 
-if (typeof SIMD.float32x4.fromFloat64x2Bits === "undefined") {
+if (typeof SIMD.Float32x4.fromFloat64x2Bits === "undefined") {
   /**
-   * @param {float64x2} t An instance of float64x2.
-   * @return {float32x4} a bit-wise copy of t as a float32x4.
+   * @param {Float64x2} t An instance of Float64x2.
+   * @return {Float32x4} a bit-wise copy of t as a Float32x4.
    */
-  SIMD.float32x4.fromFloat64x2Bits = function(t) {
+  SIMD.Float32x4.fromFloat64x2Bits = function(t) {
     _SIMD_PRIVATE.saveFloat64x2(t);
     return _SIMD_PRIVATE.restoreFloat32x4();
   }
 }
 
-if (typeof SIMD.float32x4.fromInt32x4Bits === "undefined") {
+if (typeof SIMD.Float32x4.fromInt32x4Bits === "undefined") {
   /**
-   * @param {int32x4} t An instance of int32x4.
-   * @return {float32x4} a bit-wise copy of t as a float32x4.
+   * @param {Int32x4} t An instance of Int32x4.
+   * @return {Float32x4} a bit-wise copy of t as a Float32x4.
    */
-  SIMD.float32x4.fromInt32x4Bits = function(t) {
+  SIMD.Float32x4.fromInt32x4Bits = function(t) {
     _SIMD_PRIVATE.saveInt32x4(t);
     return _SIMD_PRIVATE.restoreFloat32x4();
   }
 }
 
-if (typeof SIMD.float32x4.fromInt16x8Bits === "undefined") {
+if (typeof SIMD.Float32x4.fromInt16x8Bits === "undefined") {
   /**
    * @param {int16x8} t An instance of int16x8.
-   * @return {float32x4} a bit-wise copy of t as a float32x4.
+   * @return {Float32x4} a bit-wise copy of t as a Float32x4.
    */
-  SIMD.float32x4.fromInt16x8Bits = function(t) {
+  SIMD.Float32x4.fromInt16x8Bits = function(t) {
     _SIMD_PRIVATE.saveInt16x8(t);
     return _SIMD_PRIVATE.restoreFloat32x4();
   }
 }
 
-if (typeof SIMD.float32x4.fromInt8x16Bits === "undefined") {
+if (typeof SIMD.Float32x4.fromInt8x16Bits === "undefined") {
   /**
    * @param {int8x16} t An instance of int8x16.
-   * @return {float32x4} a bit-wise copy of t as a float32x4.
+   * @return {Float32x4} a bit-wise copy of t as a Float32x4.
    */
-  SIMD.float32x4.fromInt8x16Bits = function(t) {
+  SIMD.Float32x4.fromInt8x16Bits = function(t) {
     _SIMD_PRIVATE.saveInt8x16(t);
     return _SIMD_PRIVATE.restoreFloat32x4();
   }
 }
 
-if (typeof SIMD.float64x2 === "undefined") {
+if (typeof SIMD.Float64x2 === "undefined") {
   /**
-    * Construct a new instance of float64x2 number.
+    * Construct a new instance of Float64x2 number.
     * @param {double} value used for x lane.
     * @param {double} value used for y lane.
     * @constructor
     */
-  SIMD.float64x2 = function(x, y) {
-    if (!(this instanceof SIMD.float64x2)) {
-      return new SIMD.float64x2(x, y);
+  SIMD.Float64x2 = function(x, y) {
+    if (!(this instanceof SIMD.Float64x2)) {
+      return new SIMD.Float64x2(x, y);
     }
 
     // Use unary + to force coercion to Number.
@@ -338,18 +338,18 @@ if (typeof SIMD.float64x2 === "undefined") {
     this.y_ = +y;
   }
 
-  Object.defineProperty(SIMD.float64x2.prototype, 'x', {
+  Object.defineProperty(SIMD.Float64x2.prototype, 'x', {
     get: function() { return this.x_; }
   });
 
-  Object.defineProperty(SIMD.float64x2.prototype, 'y', {
+  Object.defineProperty(SIMD.Float64x2.prototype, 'y', {
     get: function() { return this.y_; }
   });
 
   /**
     * Extract the sign bit from each lane return them in the first 2 bits.
     */
-  Object.defineProperty(SIMD.float64x2.prototype, 'signMask', {
+  Object.defineProperty(SIMD.Float64x2.prototype, 'signMask', {
     get: function() {
       var mx = (this.x < 0.0 || 1/this.x === -Infinity);
       var my = (this.y < 0.0 || 1/this.y === -Infinity);
@@ -358,110 +358,110 @@ if (typeof SIMD.float64x2 === "undefined") {
   });
 }
 
-if (typeof SIMD.float64x2.check === "undefined") {
+if (typeof SIMD.Float64x2.check === "undefined") {
   /**
-    * Check whether the argument is a float64x2.
-    * @param {float64x2} v An instance of float64x2.
-    * @return {float64x2} The float64x2 instance.
+    * Check whether the argument is a Float64x2.
+    * @param {Float64x2} v An instance of Float64x2.
+    * @return {Float64x2} The Float64x2 instance.
     */
-  SIMD.float64x2.check = function(v) {
-    if (!(v instanceof SIMD.float64x2)) {
-      throw new TypeError("argument is not a float64x2.");
+  SIMD.Float64x2.check = function(v) {
+    if (!(v instanceof SIMD.Float64x2)) {
+      throw new TypeError("argument is not a Float64x2.");
     }
     return v;
   }
 }
 
-if (typeof SIMD.float64x2.splat === "undefined") {
+if (typeof SIMD.Float64x2.splat === "undefined") {
   /**
-    * Construct a new instance of float64x2 number with the same value
+    * Construct a new instance of Float64x2 number with the same value
     * in all lanes.
     * @param {double} value used for all lanes.
     * @constructor
     */
-  SIMD.float64x2.splat = function(s) {
-    return SIMD.float64x2(s, s);
+  SIMD.Float64x2.splat = function(s) {
+    return SIMD.Float64x2(s, s);
   }
 }
 
-if (typeof SIMD.float64x2.fromFloat32x4 === "undefined") {
+if (typeof SIMD.Float64x2.fromFloat32x4 === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {float64x2} A float64x2 with .x and .y from t
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Float64x2} A Float64x2 with .x and .y from t
     */
-  SIMD.float64x2.fromFloat32x4 = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.float64x2(t.x, t.y);
+  SIMD.Float64x2.fromFloat32x4 = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Float64x2(t.x, t.y);
   }
 }
 
-if (typeof SIMD.float64x2.fromInt32x4 === "undefined") {
+if (typeof SIMD.Float64x2.fromInt32x4 === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @return {float64x2} A float64x2 with .x and .y from t
+    * @param {Int32x4} t An instance of Int32x4.
+    * @return {Float64x2} A Float64x2 with .x and .y from t
     */
-  SIMD.float64x2.fromInt32x4 = function(t) {
-    t = SIMD.int32x4.check(t);
-    return SIMD.float64x2(t.x, t.y);
+  SIMD.Float64x2.fromInt32x4 = function(t) {
+    t = SIMD.Int32x4.check(t);
+    return SIMD.Float64x2(t.x, t.y);
   }
 }
 
-if (typeof SIMD.float64x2.fromFloat32x4Bits === "undefined") {
+if (typeof SIMD.Float64x2.fromFloat32x4Bits === "undefined") {
   /**
-   * @param {float32x4} t An instance of float32x4.
-   * @return {float64x2} a bit-wise copy of t as a float64x2.
+   * @param {Float32x4} t An instance of Float32x4.
+   * @return {Float64x2} a bit-wise copy of t as a Float64x2.
    */
-  SIMD.float64x2.fromFloat32x4Bits = function(t) {
+  SIMD.Float64x2.fromFloat32x4Bits = function(t) {
     _SIMD_PRIVATE.saveFloat32x4(t);
     return _SIMD_PRIVATE.restoreFloat64x2();
   }
 }
 
-if (typeof SIMD.float64x2.fromInt32x4Bits === "undefined") {
+if (typeof SIMD.Float64x2.fromInt32x4Bits === "undefined") {
   /**
-   * @param {int32x4} t An instance of int32x4.
-   * @return {float64x2} a bit-wise copy of t as a float64x2.
+   * @param {Int32x4} t An instance of Int32x4.
+   * @return {Float64x2} a bit-wise copy of t as a Float64x2.
    */
-  SIMD.float64x2.fromInt32x4Bits = function(t) {
+  SIMD.Float64x2.fromInt32x4Bits = function(t) {
     _SIMD_PRIVATE.saveInt32x4(t);
     return _SIMD_PRIVATE.restoreFloat64x2();
   }
 }
 
-if (typeof SIMD.float64x2.fromInt16x8Bits === "undefined") {
+if (typeof SIMD.Float64x2.fromInt16x8Bits === "undefined") {
   /**
    * @param {int16x8} t An instance of int16x8.
-   * @return {float64x2} a bit-wise copy of t as a float64x2.
+   * @return {Float64x2} a bit-wise copy of t as a Float64x2.
    */
-  SIMD.float64x2.fromInt16x8Bits = function(t) {
+  SIMD.Float64x2.fromInt16x8Bits = function(t) {
     _SIMD_PRIVATE.saveInt16x8(t);
     return _SIMD_PRIVATE.restoreFloat64x2();
   }
 }
 
-if (typeof SIMD.float64x2.fromInt8x16Bits === "undefined") {
+if (typeof SIMD.Float64x2.fromInt8x16Bits === "undefined") {
   /**
    * @param {int8x16} t An instance of int8x16.
-   * @return {float64x2} a bit-wise copy of t as a float64x2.
+   * @return {Float64x2} a bit-wise copy of t as a Float64x2.
    */
-  SIMD.float64x2.fromInt8x16Bits = function(t) {
+  SIMD.Float64x2.fromInt8x16Bits = function(t) {
     _SIMD_PRIVATE.saveInt8x16(t);
     return _SIMD_PRIVATE.restoreFloat64x2();
   }
 }
 
-if (typeof SIMD.int32x4 === "undefined") {
+if (typeof SIMD.Int32x4 === "undefined") {
   /**
-    * Construct a new instance of int32x4 number.
+    * Construct a new instance of Int32x4 number.
     * @param {integer} 32-bit value used for x lane.
     * @param {integer} 32-bit value used for y lane.
     * @param {integer} 32-bit value used for z lane.
     * @param {integer} 32-bit value used for w lane.
     * @constructor
     */
-  SIMD.int32x4 = function(x, y, z, w) {
-    if (!(this instanceof SIMD.int32x4)) {
-      return new SIMD.int32x4(x, y, z, w);
+  SIMD.Int32x4 = function(x, y, z, w) {
+    if (!(this instanceof SIMD.Int32x4)) {
+      return new SIMD.Int32x4(x, y, z, w);
     }
 
     this.x_ = x|0;
@@ -470,42 +470,42 @@ if (typeof SIMD.int32x4 === "undefined") {
     this.w_ = w|0;
   }
 
-  Object.defineProperty(SIMD.int32x4.prototype, 'x', {
+  Object.defineProperty(SIMD.Int32x4.prototype, 'x', {
     get: function() { return this.x_; }
   });
 
-  Object.defineProperty(SIMD.int32x4.prototype, 'y', {
+  Object.defineProperty(SIMD.Int32x4.prototype, 'y', {
     get: function() { return this.y_; }
   });
 
-  Object.defineProperty(SIMD.int32x4.prototype, 'z', {
+  Object.defineProperty(SIMD.Int32x4.prototype, 'z', {
     get: function() { return this.z_; }
   });
 
-  Object.defineProperty(SIMD.int32x4.prototype, 'w', {
+  Object.defineProperty(SIMD.Int32x4.prototype, 'w', {
     get: function() { return this.w_; }
   });
 
-  Object.defineProperty(SIMD.int32x4.prototype, 'flagX', {
+  Object.defineProperty(SIMD.Int32x4.prototype, 'flagX', {
     get: function() { return _SIMD_PRIVATE.tobool(this.x); }
   });
 
-  Object.defineProperty(SIMD.int32x4.prototype, 'flagY', {
+  Object.defineProperty(SIMD.Int32x4.prototype, 'flagY', {
     get: function() { return _SIMD_PRIVATE.tobool(this.y); }
   });
 
-  Object.defineProperty(SIMD.int32x4.prototype, 'flagZ', {
+  Object.defineProperty(SIMD.Int32x4.prototype, 'flagZ', {
     get: function() { return _SIMD_PRIVATE.tobool(this.z); }
   });
 
-  Object.defineProperty(SIMD.int32x4.prototype, 'flagW', {
+  Object.defineProperty(SIMD.Int32x4.prototype, 'flagW', {
     get: function() { return _SIMD_PRIVATE.tobool(this.w); }
   });
 
   /**
     * Extract the sign bit from each lane return them in the first 4 bits.
     */
-  Object.defineProperty(SIMD.int32x4.prototype, 'signMask', {
+  Object.defineProperty(SIMD.Int32x4.prototype, 'signMask', {
     get: function() {
       var mx = _SIMD_PRIVATE.tobool(this.x);
       var my = _SIMD_PRIVATE.tobool(this.y);
@@ -516,23 +516,23 @@ if (typeof SIMD.int32x4 === "undefined") {
   });
 }
 
-if (typeof SIMD.int32x4.check === "undefined") {
+if (typeof SIMD.Int32x4.check === "undefined") {
   /**
-    * Check whether the argument is a int32x4.
-    * @param {int32x4} v An instance of int32x4.
-    * @return {int32x4} The int32x4 instance.
+    * Check whether the argument is a Int32x4.
+    * @param {Int32x4} v An instance of Int32x4.
+    * @return {Int32x4} The Int32x4 instance.
     */
-  SIMD.int32x4.check = function(v) {
-    if (!(v instanceof SIMD.int32x4)) {
-      throw new TypeError("argument is not a int32x4.");
+  SIMD.Int32x4.check = function(v) {
+    if (!(v instanceof SIMD.Int32x4)) {
+      throw new TypeError("argument is not a Int32x4.");
     }
     return v;
   }
 }
 
-if (typeof SIMD.int32x4.bool === "undefined") {
+if (typeof SIMD.Int32x4.bool === "undefined") {
   /**
-    * Construct a new instance of int32x4 number with either true or false in each
+    * Construct a new instance of Int32x4 number with either true or false in each
     * lane, depending on the truth values in x, y, z, and w.
     * @param {boolean} flag used for x lane.
     * @param {boolean} flag used for y lane.
@@ -540,87 +540,87 @@ if (typeof SIMD.int32x4.bool === "undefined") {
     * @param {boolean} flag used for w lane.
     * @constructor
     */
-  SIMD.int32x4.bool = function(x, y, z, w) {
-    return SIMD.int32x4(_SIMD_PRIVATE.frombool(x),
+  SIMD.Int32x4.bool = function(x, y, z, w) {
+    return SIMD.Int32x4(_SIMD_PRIVATE.frombool(x),
                         _SIMD_PRIVATE.frombool(y),
                         _SIMD_PRIVATE.frombool(z),
                         _SIMD_PRIVATE.frombool(w));
   }
 }
 
-if (typeof SIMD.int32x4.splat === "undefined") {
+if (typeof SIMD.Int32x4.splat === "undefined") {
   /**
-    * Construct a new instance of int32x4 number with the same value
+    * Construct a new instance of Int32x4 number with the same value
     * in all lanes.
     * @param {integer} value used for all lanes.
     * @constructor
     */
-  SIMD.int32x4.splat = function(s) {
-    return SIMD.int32x4(s, s, s, s);
+  SIMD.Int32x4.splat = function(s) {
+    return SIMD.Int32x4(s, s, s, s);
   }
 }
 
-if (typeof SIMD.int32x4.fromFloat32x4 === "undefined") {
+if (typeof SIMD.Int32x4.fromFloat32x4 === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {int32x4} with a integer to float conversion of t.
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Int32x4} with a integer to float conversion of t.
     */
-  SIMD.int32x4.fromFloat32x4 = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.int32x4(t.x, t.y, t.z, t.w);
+  SIMD.Int32x4.fromFloat32x4 = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Int32x4(t.x, t.y, t.z, t.w);
   }
 }
 
-if (typeof SIMD.int32x4.fromFloat64x2 === "undefined") {
+if (typeof SIMD.Int32x4.fromFloat64x2 === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @return {int32x4}  An int32x4 with .x and .y from t
+    * @param {Float64x2} t An instance of Float64x2.
+    * @return {Int32x4}  An Int32x4 with .x and .y from t
     */
-  SIMD.int32x4.fromFloat64x2 = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.int32x4(t.x, t.y, 0, 0);
+  SIMD.Int32x4.fromFloat64x2 = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Int32x4(t.x, t.y, 0, 0);
   }
 }
 
-if (typeof SIMD.int32x4.fromFloat32x4Bits === "undefined") {
+if (typeof SIMD.Int32x4.fromFloat32x4Bits === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {int32x4} a bit-wise copy of t as a int32x4.
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Int32x4} a bit-wise copy of t as a Int32x4.
     */
-  SIMD.int32x4.fromFloat32x4Bits = function(t) {
+  SIMD.Int32x4.fromFloat32x4Bits = function(t) {
     _SIMD_PRIVATE.saveFloat32x4(t);
     return _SIMD_PRIVATE.restoreInt32x4();
   }
 }
 
-if (typeof SIMD.int32x4.fromFloat64x2Bits === "undefined") {
+if (typeof SIMD.Int32x4.fromFloat64x2Bits === "undefined") {
   /**
-   * @param {float64x2} t An instance of float64x2.
-   * @return {int32x4} a bit-wise copy of t as an int32x4.
+   * @param {Float64x2} t An instance of Float64x2.
+   * @return {Int32x4} a bit-wise copy of t as an Int32x4.
    */
-  SIMD.int32x4.fromFloat64x2Bits = function(t) {
+  SIMD.Int32x4.fromFloat64x2Bits = function(t) {
     _SIMD_PRIVATE.saveFloat64x2(t);
     return _SIMD_PRIVATE.restoreInt32x4();
   }
 }
 
-if (typeof SIMD.int32x4.fromInt16x8Bits === "undefined") {
+if (typeof SIMD.Int32x4.fromInt16x8Bits === "undefined") {
   /**
     * @param {int16x8} t An instance of int16x8.
-    * @return {int32x4} a bit-wise copy of t as a int32x4.
+    * @return {Int32x4} a bit-wise copy of t as a Int32x4.
     */
-  SIMD.int32x4.fromInt16x8Bits = function(t) {
+  SIMD.Int32x4.fromInt16x8Bits = function(t) {
     _SIMD_PRIVATE.saveInt16x8(t);
     return _SIMD_PRIVATE.restoreInt32x4();
   }
 }
 
-if (typeof SIMD.int32x4.fromInt8x16Bits === "undefined") {
+if (typeof SIMD.Int32x4.fromInt8x16Bits === "undefined") {
   /**
     * @param {int8x16} t An instance of int8x16.
-    * @return {int32x4} a bit-wise copy of t as a int32x4.
+    * @return {Int32x4} a bit-wise copy of t as a Int32x4.
     */
-  SIMD.int32x4.fromInt8x16Bits = function(t) {
+  SIMD.Int32x4.fromInt8x16Bits = function(t) {
     _SIMD_PRIVATE.saveInt8x16(t);
     return _SIMD_PRIVATE.restoreInt32x4();
   }
@@ -759,7 +759,7 @@ if (typeof SIMD.int16x8.splat === "undefined") {
 
 if (typeof SIMD.int16x8.fromFloat32x4Bits === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
+    * @param {Float32x4} t An instance of Float32x4.
     * @return {int16x8} a bit-wise copy of t as a int16x8.
     */
   SIMD.int16x8.fromFloat32x4Bits = function(t) {
@@ -770,7 +770,7 @@ if (typeof SIMD.int16x8.fromFloat32x4Bits === "undefined") {
 
 if (typeof SIMD.int16x8.fromFloat64x2Bits === "undefined") {
   /**
-   * @param {float64x2} t An instance of float64x2.
+   * @param {Float64x2} t An instance of Float64x2.
    * @return {int16x8} a bit-wise copy of t as an int16x8.
    */
   SIMD.int16x8.fromFloat64x2Bits = function(t) {
@@ -781,7 +781,7 @@ if (typeof SIMD.int16x8.fromFloat64x2Bits === "undefined") {
 
 if (typeof SIMD.int16x8.fromInt32x4Bits === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
+    * @param {Int32x4} t An instance of Int32x4.
     * @return {int16x8} a bit-wise copy of t as a int16x8.
     */
   SIMD.int16x8.fromInt32x4Bits = function(t) {
@@ -1013,7 +1013,7 @@ if (typeof SIMD.int8x16.splat === "undefined") {
 
 if (typeof SIMD.int8x16.fromFloat32x4Bits === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
+    * @param {Float32x4} t An instance of Float32x4.
     * @return {int8x16} a bit-wise copy of t as a int8x16.
     */
   SIMD.int8x16.fromFloat32x4Bits = function(t) {
@@ -1024,7 +1024,7 @@ if (typeof SIMD.int8x16.fromFloat32x4Bits === "undefined") {
 
 if (typeof SIMD.int8x16.fromFloat64x2Bits === "undefined") {
   /**
-   * @param {float64x2} t An instance of float64x2.
+   * @param {Float64x2} t An instance of Float64x2.
    * @return {int8x16} a bit-wise copy of t as an int8x16.
    */
   SIMD.int8x16.fromFloat64x2Bits = function(t) {
@@ -1035,7 +1035,7 @@ if (typeof SIMD.int8x16.fromFloat64x2Bits === "undefined") {
 
 if (typeof SIMD.int8x16.fromInt32x4Bits === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
+    * @param {Int32x4} t An instance of Int32x4.
     * @return {int8x16} a bit-wise copy of t as a int8x16.
     */
   SIMD.int8x16.fromInt32x4Bits = function(t) {
@@ -1055,95 +1055,95 @@ if (typeof SIMD.int8x16.fromInt16x8Bits === "undefined") {
   }
 }
 
-if (typeof SIMD.float32x4.abs === "undefined") {
+if (typeof SIMD.Float32x4.abs === "undefined") {
   /**
-   * @param {float32x4} t An instance of float32x4.
-   * @return {float32x4} New instance of float32x4 with absolute values of
+   * @param {Float32x4} t An instance of Float32x4.
+   * @return {Float32x4} New instance of Float32x4 with absolute values of
    * t.
    */
-  SIMD.float32x4.abs = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.float32x4(Math.abs(t.x), Math.abs(t.y), Math.abs(t.z),
+  SIMD.Float32x4.abs = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Float32x4(Math.abs(t.x), Math.abs(t.y), Math.abs(t.z),
                           Math.abs(t.w));
   }
 }
 
-if (typeof SIMD.float32x4.neg === "undefined") {
+if (typeof SIMD.Float32x4.neg === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with negated values of
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with negated values of
     * t.
     */
-  SIMD.float32x4.neg = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.float32x4(-t.x, -t.y, -t.z, -t.w);
+  SIMD.Float32x4.neg = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Float32x4(-t.x, -t.y, -t.z, -t.w);
   }
 }
 
-if (typeof SIMD.float32x4.add === "undefined") {
+if (typeof SIMD.Float32x4.add === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with a + b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with a + b.
     */
-  SIMD.float32x4.add = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    return SIMD.float32x4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
+  SIMD.Float32x4.add = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    return SIMD.Float32x4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
   }
 }
 
-if (typeof SIMD.float32x4.sub === "undefined") {
+if (typeof SIMD.Float32x4.sub === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with a - b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with a - b.
     */
-  SIMD.float32x4.sub = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    return SIMD.float32x4(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
+  SIMD.Float32x4.sub = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    return SIMD.Float32x4(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
   }
 }
 
-if (typeof SIMD.float32x4.mul === "undefined") {
+if (typeof SIMD.Float32x4.mul === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with a * b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with a * b.
     */
-  SIMD.float32x4.mul = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    return SIMD.float32x4(a.x * b.x, a.y * b.y, a.z * b.z, a.w * b.w);
+  SIMD.Float32x4.mul = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    return SIMD.Float32x4(a.x * b.x, a.y * b.y, a.z * b.z, a.w * b.w);
   }
 }
 
-if (typeof SIMD.float32x4.div === "undefined") {
+if (typeof SIMD.Float32x4.div === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with a / b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with a / b.
     */
-  SIMD.float32x4.div = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    return SIMD.float32x4(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
+  SIMD.Float32x4.div = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    return SIMD.Float32x4(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
   }
 }
 
-if (typeof SIMD.float32x4.clamp === "undefined") {
+if (typeof SIMD.Float32x4.clamp === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} lowerLimit An instance of float32x4.
-    * @param {float32x4} upperLimit An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with t's values clamped
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} lowerLimit An instance of Float32x4.
+    * @param {Float32x4} upperLimit An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with t's values clamped
     * between lowerLimit and upperLimit.
     */
-  SIMD.float32x4.clamp = function(t, lowerLimit, upperLimit) {
-    t = SIMD.float32x4.check(t);
-    lowerLimit = SIMD.float32x4.check(lowerLimit);
-    upperLimit = SIMD.float32x4.check(upperLimit);
+  SIMD.Float32x4.clamp = function(t, lowerLimit, upperLimit) {
+    t = SIMD.Float32x4.check(t);
+    lowerLimit = SIMD.Float32x4.check(lowerLimit);
+    upperLimit = SIMD.Float32x4.check(upperLimit);
     var cx = t.x < lowerLimit.x ? lowerLimit.x : t.x;
     var cy = t.y < lowerLimit.y ? lowerLimit.y : t.y;
     var cz = t.z < lowerLimit.z ? lowerLimit.z : t.z;
@@ -1152,153 +1152,153 @@ if (typeof SIMD.float32x4.clamp === "undefined") {
     cy = cy > upperLimit.y ? upperLimit.y : cy;
     cz = cz > upperLimit.z ? upperLimit.z : cz;
     cw = cw > upperLimit.w ? upperLimit.w : cw;
-    return SIMD.float32x4(cx, cy, cz, cw);
+    return SIMD.Float32x4(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.min === "undefined") {
+if (typeof SIMD.Float32x4.min === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with the minimum value of
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with the minimum value of
     * t and other.
     */
-  SIMD.float32x4.min = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
+  SIMD.Float32x4.min = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
     var cx = Math.min(t.x, other.x);
     var cy = Math.min(t.y, other.y);
     var cz = Math.min(t.z, other.z);
     var cw = Math.min(t.w, other.w);
-    return SIMD.float32x4(cx, cy, cz, cw);
+    return SIMD.Float32x4(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.max === "undefined") {
+if (typeof SIMD.Float32x4.max === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with the maximum value of
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with the maximum value of
     * t and other.
     */
-  SIMD.float32x4.max = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
+  SIMD.Float32x4.max = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
     var cx = Math.max(t.x, other.x);
     var cy = Math.max(t.y, other.y);
     var cz = Math.max(t.z, other.z);
     var cw = Math.max(t.w, other.w);
-    return SIMD.float32x4(cx, cy, cz, cw);
+    return SIMD.Float32x4(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.minNum === "undefined") {
+if (typeof SIMD.Float32x4.minNum === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with the minimum value of
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with the minimum value of
     * t and other, preferring numbers over NaNs.
     */
-  SIMD.float32x4.minNum = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
+  SIMD.Float32x4.minNum = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
     var cx = _SIMD_PRIVATE.minNum(t.x, other.x);
     var cy = _SIMD_PRIVATE.minNum(t.y, other.y);
     var cz = _SIMD_PRIVATE.minNum(t.z, other.z);
     var cw = _SIMD_PRIVATE.minNum(t.w, other.w);
-    return SIMD.float32x4(cx, cy, cz, cw);
+    return SIMD.Float32x4(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.maxNum === "undefined") {
+if (typeof SIMD.Float32x4.maxNum === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with the maximum value of
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with the maximum value of
     * t and other, preferring numbers over NaNs.
     */
-  SIMD.float32x4.maxNum = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
+  SIMD.Float32x4.maxNum = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
     var cx = _SIMD_PRIVATE.maxNum(t.x, other.x);
     var cy = _SIMD_PRIVATE.maxNum(t.y, other.y);
     var cz = _SIMD_PRIVATE.maxNum(t.z, other.z);
     var cw = _SIMD_PRIVATE.maxNum(t.w, other.w);
-    return SIMD.float32x4(cx, cy, cz, cw);
+    return SIMD.Float32x4(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.reciprocal === "undefined") {
+if (typeof SIMD.Float32x4.reciprocal === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with reciprocal value of
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with reciprocal value of
     * t.
     */
-  SIMD.float32x4.reciprocal = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.float32x4(1.0 / t.x, 1.0 / t.y, 1.0 / t.z, 1.0 / t.w);
+  SIMD.Float32x4.reciprocal = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Float32x4(1.0 / t.x, 1.0 / t.y, 1.0 / t.z, 1.0 / t.w);
   }
 }
 
-if (typeof SIMD.float32x4.reciprocalSqrt === "undefined") {
+if (typeof SIMD.Float32x4.reciprocalSqrt === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with square root of the
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with square root of the
     * reciprocal value of t.
     */
-  SIMD.float32x4.reciprocalSqrt = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.float32x4(Math.sqrt(1.0 / t.x), Math.sqrt(1.0 / t.y),
+  SIMD.Float32x4.reciprocalSqrt = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Float32x4(Math.sqrt(1.0 / t.x), Math.sqrt(1.0 / t.y),
                           Math.sqrt(1.0 / t.z), Math.sqrt(1.0 / t.w));
   }
 }
 
-if (typeof SIMD.float32x4.sqrt === "undefined") {
+if (typeof SIMD.Float32x4.sqrt === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with square root of
+    * @param {Float32x4} t An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with square root of
     * values of t.
     */
-  SIMD.float32x4.sqrt = function(t) {
-    t = SIMD.float32x4.check(t);
-    return SIMD.float32x4(Math.sqrt(t.x), Math.sqrt(t.y),
+  SIMD.Float32x4.sqrt = function(t) {
+    t = SIMD.Float32x4.check(t);
+    return SIMD.Float32x4(Math.sqrt(t.x), Math.sqrt(t.y),
                           Math.sqrt(t.z), Math.sqrt(t.w));
   }
 }
 
-if (typeof SIMD.float32x4.swizzle === "undefined") {
+if (typeof SIMD.Float32x4.swizzle === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4 to be swizzled.
+    * @param {Float32x4} t An instance of Float32x4 to be swizzled.
     * @param {integer} x - Index in t for lane x
     * @param {integer} y - Index in t for lane y
     * @param {integer} z - Index in t for lane z
     * @param {integer} w - Index in t for lane w
-    * @return {float32x4} New instance of float32x4 with lanes swizzled.
+    * @return {Float32x4} New instance of Float32x4 with lanes swizzled.
     */
-  SIMD.float32x4.swizzle = function(t, x, y, z, w) {
-    t = SIMD.float32x4.check(t);
+  SIMD.Float32x4.swizzle = function(t, x, y, z, w) {
+    t = SIMD.Float32x4.check(t);
     _SIMD_PRIVATE._f32x4[0] = t.x;
     _SIMD_PRIVATE._f32x4[1] = t.y;
     _SIMD_PRIVATE._f32x4[2] = t.z;
     _SIMD_PRIVATE._f32x4[3] = t.w;
     var storage = _SIMD_PRIVATE._f32x4;
-    return SIMD.float32x4(storage[x], storage[y], storage[z], storage[w]);
+    return SIMD.Float32x4(storage[x], storage[y], storage[z], storage[w]);
   }
 }
 
-if (typeof SIMD.float32x4.shuffle === "undefined") {
+if (typeof SIMD.Float32x4.shuffle === "undefined") {
   /**
-    * @param {float32x4} t1 An instance of float32x4 to be shuffled.
-    * @param {float32x4} t2 An instance of float32x4 to be shuffled.
+    * @param {Float32x4} t1 An instance of Float32x4 to be shuffled.
+    * @param {Float32x4} t2 An instance of Float32x4 to be shuffled.
     * @param {integer} x - Index in concatenation of t1 and t2 for lane x
     * @param {integer} y - Index in concatenation of t1 and t2 for lane y
     * @param {integer} z - Index in concatenation of t1 and t2 for lane z
     * @param {integer} w - Index in concatenation of t1 and t2 for lane w
-    * @return {float32x4} New instance of float32x4 with lanes shuffled.
+    * @return {Float32x4} New instance of Float32x4 with lanes shuffled.
     */
-  SIMD.float32x4.shuffle = function(t1, t2, x, y, z, w) {
-    t1 = SIMD.float32x4.check(t1);
-    t2 = SIMD.float32x4.check(t2);
+  SIMD.Float32x4.shuffle = function(t1, t2, x, y, z, w) {
+    t1 = SIMD.Float32x4.check(t1);
+    t2 = SIMD.Float32x4.check(t2);
     var storage = _SIMD_PRIVATE._f32x8;
     storage[0] = t1.x;
     storage[1] = t1.y;
@@ -1308,277 +1308,277 @@ if (typeof SIMD.float32x4.shuffle === "undefined") {
     storage[5] = t2.y;
     storage[6] = t2.z;
     storage[7] = t2.w;
-    return SIMD.float32x4(storage[x], storage[y], storage[z], storage[w]);
+    return SIMD.Float32x4(storage[x], storage[y], storage[z], storage[w]);
   }
 }
 
-if (typeof SIMD.float32x4.withX === "undefined") {
+if (typeof SIMD.Float32x4.withX === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
+    * @param {Float32x4} t An instance of Float32x4.
     * @param {double} value used for x lane.
-    * @return {float32x4} New instance of float32x4 with the values in t and
+    * @return {Float32x4} New instance of Float32x4 with the values in t and
     * x replaced with {x}.
     */
-  SIMD.float32x4.withX = function(t, x) {
-    t = SIMD.float32x4(t);
-    return SIMD.float32x4(x, t.y, t.z, t.w);
+  SIMD.Float32x4.withX = function(t, x) {
+    t = SIMD.Float32x4(t);
+    return SIMD.Float32x4(x, t.y, t.z, t.w);
   }
 }
 
-if (typeof SIMD.float32x4.withY === "undefined") {
+if (typeof SIMD.Float32x4.withY === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
+    * @param {Float32x4} t An instance of Float32x4.
     * @param {double} value used for y lane.
-    * @return {float32x4} New instance of float32x4 with the values in t and
+    * @return {Float32x4} New instance of Float32x4 with the values in t and
     * y replaced with {y}.
     */
-  SIMD.float32x4.withY = function(t, y) {
-    t = SIMD.float32x4(t);
-    return SIMD.float32x4(t.x, y, t.z, t.w);
+  SIMD.Float32x4.withY = function(t, y) {
+    t = SIMD.Float32x4(t);
+    return SIMD.Float32x4(t.x, y, t.z, t.w);
   }
 }
 
-if (typeof SIMD.float32x4.withZ === "undefined") {
+if (typeof SIMD.Float32x4.withZ === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
+    * @param {Float32x4} t An instance of Float32x4.
     * @param {double} value used for z lane.
-    * @return {float32x4} New instance of float32x4 with the values in t and
+    * @return {Float32x4} New instance of Float32x4 with the values in t and
     * z replaced with {z}.
     */
-  SIMD.float32x4.withZ = function(t, z) {
-    t = SIMD.float32x4(t);
-    return SIMD.float32x4(t.x, t.y, z, t.w);
+  SIMD.Float32x4.withZ = function(t, z) {
+    t = SIMD.Float32x4(t);
+    return SIMD.Float32x4(t.x, t.y, z, t.w);
   }
 }
 
-if (typeof SIMD.float32x4.withW === "undefined") {
+if (typeof SIMD.Float32x4.withW === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
+    * @param {Float32x4} t An instance of Float32x4.
     * @param {double} value used for w lane.
-    * @return {float32x4} New instance of float32x4 with the values in t and
+    * @return {Float32x4} New instance of Float32x4 with the values in t and
     * w replaced with {w}.
     */
-  SIMD.float32x4.withW = function(t, w) {
-    t = SIMD.float32x4(t);
-    return SIMD.float32x4(t.x, t.y, t.z, w);
+  SIMD.Float32x4.withW = function(t, w) {
+    t = SIMD.Float32x4(t);
+    return SIMD.Float32x4(t.x, t.y, t.z, w);
   }
 }
 
-if (typeof SIMD.float32x4.lessThan === "undefined") {
+if (typeof SIMD.Float32x4.lessThan === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t < other.
     */
-  SIMD.float32x4.lessThan = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
+  SIMD.Float32x4.lessThan = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
     var cx = t.x < other.x;
     var cy = t.y < other.y;
     var cz = t.z < other.z;
     var cw = t.w < other.w;
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.lessThanOrEqual === "undefined") {
+if (typeof SIMD.Float32x4.lessThanOrEqual === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t <= other.
     */
-  SIMD.float32x4.lessThanOrEqual = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
+  SIMD.Float32x4.lessThanOrEqual = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
     var cx = t.x <= other.x;
     var cy = t.y <= other.y;
     var cz = t.z <= other.z;
     var cw = t.w <= other.w;
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.equal === "undefined") {
+if (typeof SIMD.Float32x4.equal === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t == other.
     */
-  SIMD.float32x4.equal = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
+  SIMD.Float32x4.equal = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
     var cx = t.x == other.x;
     var cy = t.y == other.y;
     var cz = t.z == other.z;
     var cw = t.w == other.w;
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.notEqual === "undefined") {
+if (typeof SIMD.Float32x4.notEqual === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t != other.
     */
-  SIMD.float32x4.notEqual = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
+  SIMD.Float32x4.notEqual = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
     var cx = t.x != other.x;
     var cy = t.y != other.y;
     var cz = t.z != other.z;
     var cw = t.w != other.w;
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.greaterThanOrEqual === "undefined") {
+if (typeof SIMD.Float32x4.greaterThanOrEqual === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t >= other.
     */
-  SIMD.float32x4.greaterThanOrEqual = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
+  SIMD.Float32x4.greaterThanOrEqual = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
     var cx = t.x >= other.x;
     var cy = t.y >= other.y;
     var cz = t.z >= other.z;
     var cw = t.w >= other.w;
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.greaterThan === "undefined") {
+if (typeof SIMD.Float32x4.greaterThan === "undefined") {
   /**
-    * @param {float32x4} t An instance of float32x4.
-    * @param {float32x4} other An instance of float32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float32x4} t An instance of Float32x4.
+    * @param {Float32x4} other An instance of Float32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t > other.
     */
-  SIMD.float32x4.greaterThan = function(t, other) {
-    t = SIMD.float32x4.check(t);
-    other = SIMD.float32x4.check(other);
+  SIMD.Float32x4.greaterThan = function(t, other) {
+    t = SIMD.Float32x4.check(t);
+    other = SIMD.Float32x4.check(other);
     var cx = t.x > other.x;
     var cy = t.y > other.y;
     var cz = t.z > other.z;
     var cw = t.w > other.w;
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.float32x4.select === "undefined") {
+if (typeof SIMD.Float32x4.select === "undefined") {
   /**
-    * @param {int32x4} t Selector mask. An instance of int32x4
-    * @param {float32x4} trueValue Pick lane from here if corresponding
+    * @param {Int32x4} t Selector mask. An instance of Int32x4
+    * @param {Float32x4} trueValue Pick lane from here if corresponding
     * selector lane is true
-    * @param {float32x4} falseValue Pick lane from here if corresponding
+    * @param {Float32x4} falseValue Pick lane from here if corresponding
     * selector lane is false
-    * @return {float32x4} Mix of lanes from trueValue or falseValue as
+    * @return {Float32x4} Mix of lanes from trueValue or falseValue as
     * indicated
     */
-  SIMD.float32x4.select = function(t, trueValue, falseValue) {
-    t = SIMD.int32x4.check(t);
-    trueValue = SIMD.float32x4.check(trueValue);
-    falseValue = SIMD.float32x4.check(falseValue);
-    return SIMD.float32x4(_SIMD_PRIVATE.tobool(t.x) ? trueValue.x : falseValue.x,
+  SIMD.Float32x4.select = function(t, trueValue, falseValue) {
+    t = SIMD.Int32x4.check(t);
+    trueValue = SIMD.Float32x4.check(trueValue);
+    falseValue = SIMD.Float32x4.check(falseValue);
+    return SIMD.Float32x4(_SIMD_PRIVATE.tobool(t.x) ? trueValue.x : falseValue.x,
                           _SIMD_PRIVATE.tobool(t.y) ? trueValue.y : falseValue.y,
                           _SIMD_PRIVATE.tobool(t.z) ? trueValue.z : falseValue.z,
                           _SIMD_PRIVATE.tobool(t.w) ? trueValue.w : falseValue.w);
   }
 }
 
-if (typeof SIMD.float32x4.bitselect === "undefined") {
+if (typeof SIMD.Float32x4.bitselect === "undefined") {
   /**
-    * @param {int32x4} t Selector mask. An instance of int32x4
-    * @param {float32x4} trueValue Pick bit from here if corresponding
+    * @param {Int32x4} t Selector mask. An instance of Int32x4
+    * @param {Float32x4} trueValue Pick bit from here if corresponding
     * selector bit is 1
-    * @param {float32x4} falseValue Pick bit from here if corresponding
+    * @param {Float32x4} falseValue Pick bit from here if corresponding
     * selector bit is 0
-    * @return {float32x4} Mix of bits from trueValue or falseValue as
+    * @return {Float32x4} Mix of bits from trueValue or falseValue as
     * indicated
     */
-  SIMD.float32x4.bitselect = function(t, trueValue, falseValue) {
-    t = SIMD.int32x4.check(t);
-    trueValue = SIMD.float32x4.check(trueValue);
-    falseValue = SIMD.float32x4.check(falseValue);
-    var tv = SIMD.int32x4.fromFloat32x4Bits(trueValue);
-    var fv = SIMD.int32x4.fromFloat32x4Bits(falseValue);
-    var tr = SIMD.int32x4.and(t, tv);
-    var fr = SIMD.int32x4.and(SIMD.int32x4.not(t), fv);
-    return SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.or(tr, fr));
+  SIMD.Float32x4.bitselect = function(t, trueValue, falseValue) {
+    t = SIMD.Int32x4.check(t);
+    trueValue = SIMD.Float32x4.check(trueValue);
+    falseValue = SIMD.Float32x4.check(falseValue);
+    var tv = SIMD.Int32x4.fromFloat32x4Bits(trueValue);
+    var fv = SIMD.Int32x4.fromFloat32x4Bits(falseValue);
+    var tr = SIMD.Int32x4.and(t, tv);
+    var fr = SIMD.Int32x4.and(SIMD.Int32x4.not(t), fv);
+    return SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.or(tr, fr));
   }
 }
 
-if (typeof SIMD.float32x4.and === "undefined") {
+if (typeof SIMD.Float32x4.and === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with values of a & b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with values of a & b.
     */
-  SIMD.float32x4.and = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    var aInt = SIMD.int32x4.fromFloat32x4Bits(a);
-    var bInt = SIMD.int32x4.fromFloat32x4Bits(b);
-    return SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.and(aInt, bInt));
+  SIMD.Float32x4.and = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    var aInt = SIMD.Int32x4.fromFloat32x4Bits(a);
+    var bInt = SIMD.Int32x4.fromFloat32x4Bits(b);
+    return SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.and(aInt, bInt));
   }
 }
 
-if (typeof SIMD.float32x4.or === "undefined") {
+if (typeof SIMD.Float32x4.or === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with values of a | b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with values of a | b.
     */
-  SIMD.float32x4.or = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    var aInt = SIMD.int32x4.fromFloat32x4Bits(a);
-    var bInt = SIMD.int32x4.fromFloat32x4Bits(b);
-    return SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.or(aInt, bInt));
+  SIMD.Float32x4.or = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    var aInt = SIMD.Int32x4.fromFloat32x4Bits(a);
+    var bInt = SIMD.Int32x4.fromFloat32x4Bits(b);
+    return SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.or(aInt, bInt));
   }
 }
 
-if (typeof SIMD.float32x4.xor === "undefined") {
+if (typeof SIMD.Float32x4.xor === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @param {float32x4} b An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with values of a ^ b.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @param {Float32x4} b An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with values of a ^ b.
     */
-  SIMD.float32x4.xor = function(a, b) {
-    a = SIMD.float32x4.check(a);
-    b = SIMD.float32x4.check(b);
-    var aInt = SIMD.int32x4.fromFloat32x4Bits(a);
-    var bInt = SIMD.int32x4.fromFloat32x4Bits(b);
-    return SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.xor(aInt, bInt));
+  SIMD.Float32x4.xor = function(a, b) {
+    a = SIMD.Float32x4.check(a);
+    b = SIMD.Float32x4.check(b);
+    var aInt = SIMD.Int32x4.fromFloat32x4Bits(a);
+    var bInt = SIMD.Int32x4.fromFloat32x4Bits(b);
+    return SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.xor(aInt, bInt));
   }
 }
 
-if (typeof SIMD.float32x4.not === "undefined") {
+if (typeof SIMD.Float32x4.not === "undefined") {
   /**
-    * @param {float32x4} a An instance of float32x4.
-    * @return {float32x4} New instance of float32x4 with values of ~a.
+    * @param {Float32x4} a An instance of Float32x4.
+    * @return {Float32x4} New instance of Float32x4 with values of ~a.
     */
-  SIMD.float32x4.not = function(a) {
-    a = SIMD.float32x4.check(a);
-    var aInt = SIMD.int32x4.fromFloat32x4Bits(a);
-    return SIMD.float32x4.fromInt32x4Bits(SIMD.int32x4.not(aInt));
+  SIMD.Float32x4.not = function(a) {
+    a = SIMD.Float32x4.check(a);
+    var aInt = SIMD.Int32x4.fromFloat32x4Bits(a);
+    return SIMD.Float32x4.fromInt32x4Bits(SIMD.Int32x4.not(aInt));
   }
 }
 
-if (typeof SIMD.float32x4.load === "undefined") {
+if (typeof SIMD.Float32x4.load === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {float32x4} New instance of float32x4.
+    * @return {Float32x4} New instance of Float32x4.
     */
-  SIMD.float32x4.load = function(tarray, index) {
+  SIMD.Float32x4.load = function(tarray, index) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -1594,17 +1594,17 @@ if (typeof SIMD.float32x4.load === "undefined") {
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
     var f32temp = _SIMD_PRIVATE._f32x4;
-    return SIMD.float32x4(f32temp[0], f32temp[1], f32temp[2], f32temp[3]);
+    return SIMD.Float32x4(f32temp[0], f32temp[1], f32temp[2], f32temp[3]);
   }
 }
 
-if (typeof SIMD.float32x4.loadX === "undefined") {
+if (typeof SIMD.Float32x4.loadX === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {float32x4} New instance of float32x4.
+    * @return {Float32x4} New instance of Float32x4.
     */
-  SIMD.float32x4.loadX = function(tarray, index) {
+  SIMD.Float32x4.loadX = function(tarray, index) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -1620,17 +1620,17 @@ if (typeof SIMD.float32x4.loadX === "undefined") {
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
     var f32temp = _SIMD_PRIVATE._f32x4;
-    return SIMD.float32x4(f32temp[0], 0.0, 0.0, 0.0);
+    return SIMD.Float32x4(f32temp[0], 0.0, 0.0, 0.0);
   }
 }
 
-if (typeof SIMD.float32x4.loadXY === "undefined") {
+if (typeof SIMD.Float32x4.loadXY === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {float32x4} New instance of float32x4.
+    * @return {Float32x4} New instance of Float32x4.
     */
-  SIMD.float32x4.loadXY = function(tarray, index) {
+  SIMD.Float32x4.loadXY = function(tarray, index) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -1646,17 +1646,17 @@ if (typeof SIMD.float32x4.loadXY === "undefined") {
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
     var f32temp = _SIMD_PRIVATE._f32x4;
-    return SIMD.float32x4(f32temp[0], f32temp[1], 0.0, 0.0);
+    return SIMD.Float32x4(f32temp[0], f32temp[1], 0.0, 0.0);
   }
 }
 
-if (typeof SIMD.float32x4.loadXYZ === "undefined") {
+if (typeof SIMD.Float32x4.loadXYZ === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {float32x4} New instance of float32x4.
+    * @return {Float32x4} New instance of Float32x4.
     */
-  SIMD.float32x4.loadXYZ = function(tarray, index) {
+  SIMD.Float32x4.loadXYZ = function(tarray, index) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -1672,18 +1672,18 @@ if (typeof SIMD.float32x4.loadXYZ === "undefined") {
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
     var f32temp = _SIMD_PRIVATE._f32x4;
-    return SIMD.float32x4(f32temp[0], f32temp[1], f32temp[2], 0.0);
+    return SIMD.Float32x4(f32temp[0], f32temp[1], f32temp[2], 0.0);
   }
 }
 
-if (typeof SIMD.float32x4.store === "undefined") {
+if (typeof SIMD.Float32x4.store === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {float32x4} value An instance of float32x4.
+    * @param {Float32x4} value An instance of Float32x4.
     * @return {void}
     */
-  SIMD.float32x4.store = function(tarray, index, value) {
+  SIMD.Float32x4.store = function(tarray, index, value) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -1691,7 +1691,7 @@ if (typeof SIMD.float32x4.store === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 16) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.float32x4.check(value);
+    value = SIMD.Float32x4.check(value);
     _SIMD_PRIVATE._f32x4[0] = value.x;
     _SIMD_PRIVATE._f32x4[1] = value.y;
     _SIMD_PRIVATE._f32x4[2] = value.z;
@@ -1706,14 +1706,14 @@ if (typeof SIMD.float32x4.store === "undefined") {
   }
 }
 
-if (typeof SIMD.float32x4.storeX === "undefined") {
+if (typeof SIMD.Float32x4.storeX === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {float32x4} value An instance of float32x4.
+    * @param {Float32x4} value An instance of Float32x4.
     * @return {void}
     */
-  SIMD.float32x4.storeX = function(tarray, index, value) {
+  SIMD.Float32x4.storeX = function(tarray, index, value) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -1721,7 +1721,7 @@ if (typeof SIMD.float32x4.storeX === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 4) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.float32x4.check(value);
+    value = SIMD.Float32x4.check(value);
     if (bpe == 8) {
       // tarray's elements are too wide. Just create a new view; this is rare.
       var view = new Float32Array(tarray.buffer, tarray.byteOffset + index * 8, 1);
@@ -1738,14 +1738,14 @@ if (typeof SIMD.float32x4.storeX === "undefined") {
   }
 }
 
-if (typeof SIMD.float32x4.storeXY === "undefined") {
+if (typeof SIMD.Float32x4.storeXY === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {float32x4} value An instance of float32x4.
+    * @param {Float32x4} value An instance of Float32x4.
     * @return {void}
     */
-  SIMD.float32x4.storeXY = function(tarray, index, value) {
+  SIMD.Float32x4.storeXY = function(tarray, index, value) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -1753,7 +1753,7 @@ if (typeof SIMD.float32x4.storeXY === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 8) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.float32x4.check(value);
+    value = SIMD.Float32x4.check(value);
     _SIMD_PRIVATE._f32x4[0] = value.x;
     _SIMD_PRIVATE._f32x4[1] = value.y;
     var array = bpe == 1 ? _SIMD_PRIVATE._i8x16 :
@@ -1766,14 +1766,14 @@ if (typeof SIMD.float32x4.storeXY === "undefined") {
   }
 }
 
-if (typeof SIMD.float32x4.storeXYZ === "undefined") {
+if (typeof SIMD.Float32x4.storeXYZ === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {float32x4} value An instance of float32x4.
+    * @param {Float32x4} value An instance of Float32x4.
     * @return {void}
     */
-  SIMD.float32x4.storeXYZ = function(tarray, index, value) {
+  SIMD.Float32x4.storeXYZ = function(tarray, index, value) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -1781,7 +1781,7 @@ if (typeof SIMD.float32x4.storeXYZ === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 12) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.float32x4.check(value);
+    value = SIMD.Float32x4.check(value);
     if (bpe == 8) {
       // tarray's elements are too wide. Just create a new view; this is rare.
       var view = new Float32Array(tarray.buffer, tarray.byteOffset + index * 8, 3);
@@ -1802,408 +1802,408 @@ if (typeof SIMD.float32x4.storeXYZ === "undefined") {
   }
 }
 
-if (typeof SIMD.float64x2.abs === "undefined") {
+if (typeof SIMD.Float64x2.abs === "undefined") {
   /**
-   * @param {float64x2} t An instance of float64x2.
-   * @return {float64x2} New instance of float64x2 with absolute values of
+   * @param {Float64x2} t An instance of Float64x2.
+   * @return {Float64x2} New instance of Float64x2 with absolute values of
    * t.
    */
-  SIMD.float64x2.abs = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.float64x2(Math.abs(t.x), Math.abs(t.y));
+  SIMD.Float64x2.abs = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Float64x2(Math.abs(t.x), Math.abs(t.y));
   }
 }
 
-if (typeof SIMD.float64x2.neg === "undefined") {
+if (typeof SIMD.Float64x2.neg === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with negated values of
+    * @param {Float64x2} t An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with negated values of
     * t.
     */
-  SIMD.float64x2.neg = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.float64x2(-t.x, -t.y);
+  SIMD.Float64x2.neg = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Float64x2(-t.x, -t.y);
   }
 }
 
-if (typeof SIMD.float64x2.add === "undefined") {
+if (typeof SIMD.Float64x2.add === "undefined") {
   /**
-    * @param {float64x2} a An instance of float64x2.
-    * @param {float64x2} b An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with a + b.
+    * @param {Float64x2} a An instance of Float64x2.
+    * @param {Float64x2} b An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with a + b.
     */
-  SIMD.float64x2.add = function(a, b) {
-    a = SIMD.float64x2.check(a);
-    b = SIMD.float64x2.check(b);
-    return SIMD.float64x2(a.x + b.x, a.y + b.y);
+  SIMD.Float64x2.add = function(a, b) {
+    a = SIMD.Float64x2.check(a);
+    b = SIMD.Float64x2.check(b);
+    return SIMD.Float64x2(a.x + b.x, a.y + b.y);
   }
 }
 
-if (typeof SIMD.float64x2.sub === "undefined") {
+if (typeof SIMD.Float64x2.sub === "undefined") {
   /**
-    * @param {float64x2} a An instance of float64x2.
-    * @param {float64x2} b An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with a - b.
+    * @param {Float64x2} a An instance of Float64x2.
+    * @param {Float64x2} b An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with a - b.
     */
-  SIMD.float64x2.sub = function(a, b) {
-    a = SIMD.float64x2.check(a);
-    b = SIMD.float64x2.check(b);
-    return SIMD.float64x2(a.x - b.x, a.y - b.y);
+  SIMD.Float64x2.sub = function(a, b) {
+    a = SIMD.Float64x2.check(a);
+    b = SIMD.Float64x2.check(b);
+    return SIMD.Float64x2(a.x - b.x, a.y - b.y);
   }
 }
 
-if (typeof SIMD.float64x2.mul === "undefined") {
+if (typeof SIMD.Float64x2.mul === "undefined") {
   /**
-    * @param {float64x2} a An instance of float64x2.
-    * @param {float64x2} b An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with a * b.
+    * @param {Float64x2} a An instance of Float64x2.
+    * @param {Float64x2} b An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with a * b.
     */
-  SIMD.float64x2.mul = function(a, b) {
-    a = SIMD.float64x2.check(a);
-    b = SIMD.float64x2.check(b);
-    return SIMD.float64x2(a.x * b.x, a.y * b.y);
+  SIMD.Float64x2.mul = function(a, b) {
+    a = SIMD.Float64x2.check(a);
+    b = SIMD.Float64x2.check(b);
+    return SIMD.Float64x2(a.x * b.x, a.y * b.y);
   }
 }
 
-if (typeof SIMD.float64x2.div === "undefined") {
+if (typeof SIMD.Float64x2.div === "undefined") {
   /**
-    * @param {float64x2} a An instance of float64x2.
-    * @param {float64x2} b An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with a / b.
+    * @param {Float64x2} a An instance of Float64x2.
+    * @param {Float64x2} b An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with a / b.
     */
-  SIMD.float64x2.div = function(a, b) {
-    a = SIMD.float64x2.check(a);
-    b = SIMD.float64x2.check(b);
-    return SIMD.float64x2(a.x / b.x, a.y / b.y);
+  SIMD.Float64x2.div = function(a, b) {
+    a = SIMD.Float64x2.check(a);
+    b = SIMD.Float64x2.check(b);
+    return SIMD.Float64x2(a.x / b.x, a.y / b.y);
   }
 }
 
-if (typeof SIMD.float64x2.clamp === "undefined") {
+if (typeof SIMD.Float64x2.clamp === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} lowerLimit An instance of float64x2.
-    * @param {float64x2} upperLimit An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with t's values clamped
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} lowerLimit An instance of Float64x2.
+    * @param {Float64x2} upperLimit An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with t's values clamped
     * between lowerLimit and upperLimit.
     */
-  SIMD.float64x2.clamp = function(t, lowerLimit, upperLimit) {
-    t = SIMD.float64x2.check(t);
-    lowerLimit = SIMD.float64x2.check(lowerLimit);
-    upperLimit = SIMD.float64x2.check(upperLimit);
+  SIMD.Float64x2.clamp = function(t, lowerLimit, upperLimit) {
+    t = SIMD.Float64x2.check(t);
+    lowerLimit = SIMD.Float64x2.check(lowerLimit);
+    upperLimit = SIMD.Float64x2.check(upperLimit);
     var cx = t.x < lowerLimit.x ? lowerLimit.x : t.x;
     var cy = t.y < lowerLimit.y ? lowerLimit.y : t.y;
     cx = cx > upperLimit.x ? upperLimit.x : cx;
     cy = cy > upperLimit.y ? upperLimit.y : cy;
-    return SIMD.float64x2(cx, cy);
+    return SIMD.Float64x2(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.min === "undefined") {
+if (typeof SIMD.Float64x2.min === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with the minimum value of
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with the minimum value of
     * t and other.
     */
-  SIMD.float64x2.min = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
+  SIMD.Float64x2.min = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
     var cx = Math.min(t.x, other.x);
     var cy = Math.min(t.y, other.y);
-    return SIMD.float64x2(cx, cy);
+    return SIMD.Float64x2(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.max === "undefined") {
+if (typeof SIMD.Float64x2.max === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with the maximum value of
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with the maximum value of
     * t and other.
     */
-  SIMD.float64x2.max = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
+  SIMD.Float64x2.max = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
     var cx = Math.max(t.x, other.x);
     var cy = Math.max(t.y, other.y);
-    return SIMD.float64x2(cx, cy);
+    return SIMD.Float64x2(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.minNum === "undefined") {
+if (typeof SIMD.Float64x2.minNum === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with the minimum value of
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with the minimum value of
     * t and other, preferring numbers over NaNs.
     */
-  SIMD.float64x2.minNum = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
+  SIMD.Float64x2.minNum = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
     var cx = _SIMD_PRIVATE.minNum(t.x, other.x);
     var cy = _SIMD_PRIVATE.minNum(t.y, other.y);
-    return SIMD.float64x2(cx, cy);
+    return SIMD.Float64x2(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.maxNum === "undefined") {
+if (typeof SIMD.Float64x2.maxNum === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with the maximum value of
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with the maximum value of
     * t and other, preferring numbers over NaNs.
     */
-  SIMD.float64x2.maxNum = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
+  SIMD.Float64x2.maxNum = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
     var cx = _SIMD_PRIVATE.maxNum(t.x, other.x);
     var cy = _SIMD_PRIVATE.maxNum(t.y, other.y);
-    return SIMD.float64x2(cx, cy);
+    return SIMD.Float64x2(cx, cy);
   }
 }
 
-if (typeof SIMD.float64x2.reciprocal === "undefined") {
+if (typeof SIMD.Float64x2.reciprocal === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with reciprocal value of
+    * @param {Float64x2} t An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with reciprocal value of
     * t.
     */
-  SIMD.float64x2.reciprocal = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.float64x2(1.0 / t.x, 1.0 / t.y);
+  SIMD.Float64x2.reciprocal = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Float64x2(1.0 / t.x, 1.0 / t.y);
   }
 }
 
-if (typeof SIMD.float64x2.reciprocalSqrt === "undefined") {
+if (typeof SIMD.Float64x2.reciprocalSqrt === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with square root of the
+    * @param {Float64x2} t An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with square root of the
     * reciprocal value of t.
     */
-  SIMD.float64x2.reciprocalSqrt = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.float64x2(Math.sqrt(1.0 / t.x), Math.sqrt(1.0 / t.y));
+  SIMD.Float64x2.reciprocalSqrt = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Float64x2(Math.sqrt(1.0 / t.x), Math.sqrt(1.0 / t.y));
   }
 }
 
-if (typeof SIMD.float64x2.sqrt === "undefined") {
+if (typeof SIMD.Float64x2.sqrt === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @return {float64x2} New instance of float64x2 with square root of
+    * @param {Float64x2} t An instance of Float64x2.
+    * @return {Float64x2} New instance of Float64x2 with square root of
     * values of t.
     */
-  SIMD.float64x2.sqrt = function(t) {
-    t = SIMD.float64x2.check(t);
-    return SIMD.float64x2(Math.sqrt(t.x), Math.sqrt(t.y));
+  SIMD.Float64x2.sqrt = function(t) {
+    t = SIMD.Float64x2.check(t);
+    return SIMD.Float64x2(Math.sqrt(t.x), Math.sqrt(t.y));
   }
 }
 
-if (typeof SIMD.float64x2.swizzle === "undefined") {
+if (typeof SIMD.Float64x2.swizzle === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2 to be swizzled.
+    * @param {Float64x2} t An instance of Float64x2 to be swizzled.
     * @param {integer} x - Index in t for lane x
     * @param {integer} y - Index in t for lane y
-    * @return {float64x2} New instance of float64x2 with lanes swizzled.
+    * @return {Float64x2} New instance of Float64x2 with lanes swizzled.
     */
-  SIMD.float64x2.swizzle = function(t, x, y) {
-    t = SIMD.float64x2.check(t);
+  SIMD.Float64x2.swizzle = function(t, x, y) {
+    t = SIMD.Float64x2.check(t);
     var storage = _SIMD_PRIVATE._f64x2;
     storage[0] = t.x;
     storage[1] = t.y;
-    return SIMD.float64x2(storage[x], storage[y]);
+    return SIMD.Float64x2(storage[x], storage[y]);
   }
 }
 
-if (typeof SIMD.float64x2.shuffle === "undefined") {
+if (typeof SIMD.Float64x2.shuffle === "undefined") {
   /**
-    * @param {float64x2} t1 An instance of float64x2 to be shuffled.
-    * @param {float64x2} t2 An instance of float64x2 to be shuffled.
+    * @param {Float64x2} t1 An instance of Float64x2 to be shuffled.
+    * @param {Float64x2} t2 An instance of Float64x2 to be shuffled.
     * @param {integer} x - Index in concatenation of t1 and t2 for lane x
     * @param {integer} y - Index in concatenation of t1 and t2 for lane y
-    * @return {float64x2} New instance of float64x2 with lanes shuffled.
+    * @return {Float64x2} New instance of Float64x2 with lanes shuffled.
     */
-  SIMD.float64x2.shuffle = function(t1, t2, x, y) {
-    t1 = SIMD.float64x2.check(t1);
-    t2 = SIMD.float64x2.check(t2);
+  SIMD.Float64x2.shuffle = function(t1, t2, x, y) {
+    t1 = SIMD.Float64x2.check(t1);
+    t2 = SIMD.Float64x2.check(t2);
     var storage = _SIMD_PRIVATE._f64x4;
     storage[0] = t1.x;
     storage[1] = t1.y;
     storage[2] = t2.x;
     storage[3] = t2.y;
-    return SIMD.float64x2(storage[x], storage[y]);
+    return SIMD.Float64x2(storage[x], storage[y]);
   }
 }
 
-if (typeof SIMD.float64x2.withX === "undefined") {
+if (typeof SIMD.Float64x2.withX === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
+    * @param {Float64x2} t An instance of Float64x2.
     * @param {double} value used for x lane.
-    * @return {float64x2} New instance of float64x2 with the values in t and
+    * @return {Float64x2} New instance of Float64x2 with the values in t and
     * x replaced with {x}.
     */
-  SIMD.float64x2.withX = function(t, x) {
-    t = SIMD.float64x2(t);
-    return SIMD.float64x2(x, t.y);
+  SIMD.Float64x2.withX = function(t, x) {
+    t = SIMD.Float64x2(t);
+    return SIMD.Float64x2(x, t.y);
   }
 }
 
-if (typeof SIMD.float64x2.withY === "undefined") {
+if (typeof SIMD.Float64x2.withY === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
+    * @param {Float64x2} t An instance of Float64x2.
     * @param {double} value used for y lane.
-    * @return {float64x2} New instance of float64x2 with the values in t and
+    * @return {Float64x2} New instance of Float64x2 with the values in t and
     * y replaced with {y}.
     */
-  SIMD.float64x2.withY = function(t, y) {
-    t = SIMD.float64x2(t);
-    return SIMD.float64x2(t.x, y);
+  SIMD.Float64x2.withY = function(t, y) {
+    t = SIMD.Float64x2(t);
+    return SIMD.Float64x2(t.x, y);
   }
 }
 
-if (typeof SIMD.float64x2.lessThan === "undefined") {
+if (typeof SIMD.Float64x2.lessThan === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t < other.
     */
-  SIMD.float64x2.lessThan = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
+  SIMD.Float64x2.lessThan = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
     var cx = t.x < other.x;
     var cy = t.y < other.y;
-    return SIMD.int32x4.bool(cx, cx, cy, cy);
+    return SIMD.Int32x4.bool(cx, cx, cy, cy);
   }
 }
 
-if (typeof SIMD.float64x2.lessThanOrEqual === "undefined") {
+if (typeof SIMD.Float64x2.lessThanOrEqual === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t <= other.
     */
-  SIMD.float64x2.lessThanOrEqual = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
+  SIMD.Float64x2.lessThanOrEqual = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
     var cx = t.x <= other.x;
     var cy = t.y <= other.y;
-    return SIMD.int32x4.bool(cx, cx, cy, cy);
+    return SIMD.Int32x4.bool(cx, cx, cy, cy);
   }
 }
 
-if (typeof SIMD.float64x2.equal === "undefined") {
+if (typeof SIMD.Float64x2.equal === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t == other.
     */
-  SIMD.float64x2.equal = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
+  SIMD.Float64x2.equal = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
     var cx = t.x == other.x;
     var cy = t.y == other.y;
-    return SIMD.int32x4.bool(cx, cx, cy, cy);
+    return SIMD.Int32x4.bool(cx, cx, cy, cy);
   }
 }
 
-if (typeof SIMD.float64x2.notEqual === "undefined") {
+if (typeof SIMD.Float64x2.notEqual === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t != other.
     */
-  SIMD.float64x2.notEqual = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
+  SIMD.Float64x2.notEqual = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
     var cx = t.x != other.x;
     var cy = t.y != other.y;
-    return SIMD.int32x4.bool(cx, cx, cy, cy);
+    return SIMD.Int32x4.bool(cx, cx, cy, cy);
   }
 }
 
-if (typeof SIMD.float64x2.greaterThanOrEqual === "undefined") {
+if (typeof SIMD.Float64x2.greaterThanOrEqual === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t >= other.
     */
-  SIMD.float64x2.greaterThanOrEqual = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
+  SIMD.Float64x2.greaterThanOrEqual = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
     var cx = t.x >= other.x;
     var cy = t.y >= other.y;
-    return SIMD.int32x4.bool(cx, cx, cy, cy);
+    return SIMD.Int32x4.bool(cx, cx, cy, cy);
   }
 }
 
-if (typeof SIMD.float64x2.greaterThan === "undefined") {
+if (typeof SIMD.Float64x2.greaterThan === "undefined") {
   /**
-    * @param {float64x2} t An instance of float64x2.
-    * @param {float64x2} other An instance of float64x2.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Float64x2} t An instance of Float64x2.
+    * @param {Float64x2} other An instance of Float64x2.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t > other.
     */
-  SIMD.float64x2.greaterThan = function(t, other) {
-    t = SIMD.float64x2.check(t);
-    other = SIMD.float64x2.check(other);
+  SIMD.Float64x2.greaterThan = function(t, other) {
+    t = SIMD.Float64x2.check(t);
+    other = SIMD.Float64x2.check(other);
     var cx = t.x > other.x;
     var cy = t.y > other.y;
-    return SIMD.int32x4.bool(cx, cx, cy, cy);
+    return SIMD.Int32x4.bool(cx, cx, cy, cy);
   }
 }
 
-if (typeof SIMD.float64x2.select === "undefined") {
+if (typeof SIMD.Float64x2.select === "undefined") {
   /**
-    * @param {int32x4} t Selector mask. An instance of int32x4
-    * @param {float64x2} trueValue Pick lane from here if corresponding
+    * @param {Int32x4} t Selector mask. An instance of Int32x4
+    * @param {Float64x2} trueValue Pick lane from here if corresponding
     * selector lane is true
-    * @param {float64x2} falseValue Pick lane from here if corresponding
+    * @param {Float64x2} falseValue Pick lane from here if corresponding
     * selector lane is false
-    * @return {float64x2} Mix of lanes from trueValue or falseValue as
+    * @return {Float64x2} Mix of lanes from trueValue or falseValue as
     * indicated
     */
-  SIMD.float64x2.select = function(t, trueValue, falseValue) {
-    t = SIMD.int32x4.check(t);
-    trueValue = SIMD.float64x2.check(trueValue);
-    falseValue = SIMD.float64x2.check(falseValue);
-    return SIMD.float64x2(_SIMD_PRIVATE.tobool(t.x) ? trueValue.x : falseValue.x,
+  SIMD.Float64x2.select = function(t, trueValue, falseValue) {
+    t = SIMD.Int32x4.check(t);
+    trueValue = SIMD.Float64x2.check(trueValue);
+    falseValue = SIMD.Float64x2.check(falseValue);
+    return SIMD.Float64x2(_SIMD_PRIVATE.tobool(t.x) ? trueValue.x : falseValue.x,
                           _SIMD_PRIVATE.tobool(t.y) ? trueValue.y : falseValue.y);
   }
 }
 
-if (typeof SIMD.float64x2.bitselect === "undefined") {
+if (typeof SIMD.Float64x2.bitselect === "undefined") {
   /**
-    * @param {int32x4} t Selector mask. An instance of int32x4
-    * @param {float64x2} trueValue Pick bit from here if corresponding
+    * @param {Int32x4} t Selector mask. An instance of Int32x4
+    * @param {Float64x2} trueValue Pick bit from here if corresponding
     * selector bit is 1
-    * @param {float64x2} falseValue Pick bit from here if corresponding
+    * @param {Float64x2} falseValue Pick bit from here if corresponding
     * selector bit is 0
-    * @return {float64x2} Mix of bits from trueValue or falseValue as
+    * @return {Float64x2} Mix of bits from trueValue or falseValue as
     * indicated
     */
-  SIMD.float64x2.bitselect = function(t, trueValue, falseValue) {
-    t = SIMD.int32x4.check(t);
-    trueValue = SIMD.float64x2.check(trueValue);
-    falseValue = SIMD.float64x2.check(falseValue);
-    var tv = SIMD.int32x4.fromFloat64x2Bits(trueValue);
-    var fv = SIMD.int32x4.fromFloat64x2Bits(falseValue);
-    var tr = SIMD.int32x4.and(t, tv);
-    var fr = SIMD.int32x4.and(SIMD.int32x4.not(t), fv);
-    return SIMD.float64x2.fromInt32x4Bits(SIMD.int32x4.or(tr, fr));
+  SIMD.Float64x2.bitselect = function(t, trueValue, falseValue) {
+    t = SIMD.Int32x4.check(t);
+    trueValue = SIMD.Float64x2.check(trueValue);
+    falseValue = SIMD.Float64x2.check(falseValue);
+    var tv = SIMD.Int32x4.fromFloat64x2Bits(trueValue);
+    var fv = SIMD.Int32x4.fromFloat64x2Bits(falseValue);
+    var tr = SIMD.Int32x4.and(t, tv);
+    var fr = SIMD.Int32x4.and(SIMD.Int32x4.not(t), fv);
+    return SIMD.Float64x2.fromInt32x4Bits(SIMD.Int32x4.or(tr, fr));
   }
 }
 
-if (typeof SIMD.float64x2.load === "undefined") {
+if (typeof SIMD.Float64x2.load === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {float64x2} New instance of float64x2.
+    * @return {Float64x2} New instance of Float64x2.
     */
-  SIMD.float64x2.load = function(tarray, index) {
+  SIMD.Float64x2.load = function(tarray, index) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -2219,17 +2219,17 @@ if (typeof SIMD.float64x2.load === "undefined") {
     var n = 16 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.float64x2(f64temp[0], f64temp[1]);
+    return SIMD.Float64x2(f64temp[0], f64temp[1]);
   }
 }
 
-if (typeof SIMD.float64x2.loadX === "undefined") {
+if (typeof SIMD.Float64x2.loadX === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {float64x2} New instance of float64x2.
+    * @return {Float64x2} New instance of Float64x2.
     */
-  SIMD.float64x2.loadX = function(tarray, index) {
+  SIMD.Float64x2.loadX = function(tarray, index) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -2245,18 +2245,18 @@ if (typeof SIMD.float64x2.loadX === "undefined") {
     var n = 8 / bpe;
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
-    return SIMD.float64x2(f64temp[0], 0.0);
+    return SIMD.Float64x2(f64temp[0], 0.0);
   }
 }
 
-if (typeof SIMD.float64x2.store === "undefined") {
+if (typeof SIMD.Float64x2.store === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {float64x2} value An instance of float64x2.
+    * @param {Float64x2} value An instance of Float64x2.
     * @return {void}
     */
-  SIMD.float64x2.store = function(tarray, index, value) {
+  SIMD.Float64x2.store = function(tarray, index, value) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -2264,7 +2264,7 @@ if (typeof SIMD.float64x2.store === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 16) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.float64x2.check(value);
+    value = SIMD.Float64x2.check(value);
     _SIMD_PRIVATE._f64x2[0] = value.x;
     _SIMD_PRIVATE._f64x2[1] = value.y;
     var array = bpe == 1 ? _SIMD_PRIVATE._i8x16 :
@@ -2277,14 +2277,14 @@ if (typeof SIMD.float64x2.store === "undefined") {
   }
 }
 
-if (typeof SIMD.float64x2.storeX === "undefined") {
+if (typeof SIMD.Float64x2.storeX === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {float64x2} value An instance of float64x2.
+    * @param {Float64x2} value An instance of Float64x2.
     * @return {void}
     */
-  SIMD.float64x2.storeX = function(tarray, index, value) {
+  SIMD.Float64x2.storeX = function(tarray, index, value) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -2292,7 +2292,7 @@ if (typeof SIMD.float64x2.storeX === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 8) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.float64x2.check(value);
+    value = SIMD.Float64x2.check(value);
     _SIMD_PRIVATE._f64x2[0] = value.x;
     var array = bpe == 1 ? _SIMD_PRIVATE._i8x16 :
                 bpe == 2 ? _SIMD_PRIVATE._i16x8 :
@@ -2304,140 +2304,140 @@ if (typeof SIMD.float64x2.storeX === "undefined") {
   }
 }
 
-if (typeof SIMD.int32x4.and === "undefined") {
+if (typeof SIMD.Int32x4.and === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
-    * @param {int32x4} b An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of a & b.
+    * @param {Int32x4} a An instance of Int32x4.
+    * @param {Int32x4} b An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of a & b.
     */
-  SIMD.int32x4.and = function(a, b) {
-    a = SIMD.int32x4.check(a);
-    b = SIMD.int32x4.check(b);
-    return SIMD.int32x4(a.x & b.x, a.y & b.y, a.z & b.z, a.w & b.w);
+  SIMD.Int32x4.and = function(a, b) {
+    a = SIMD.Int32x4.check(a);
+    b = SIMD.Int32x4.check(b);
+    return SIMD.Int32x4(a.x & b.x, a.y & b.y, a.z & b.z, a.w & b.w);
   }
 }
 
-if (typeof SIMD.int32x4.or === "undefined") {
+if (typeof SIMD.Int32x4.or === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
-    * @param {int32x4} b An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of a | b.
+    * @param {Int32x4} a An instance of Int32x4.
+    * @param {Int32x4} b An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of a | b.
     */
-  SIMD.int32x4.or = function(a, b) {
-    a = SIMD.int32x4.check(a);
-    b = SIMD.int32x4.check(b);
-    return SIMD.int32x4(a.x | b.x, a.y | b.y, a.z | b.z, a.w | b.w);
+  SIMD.Int32x4.or = function(a, b) {
+    a = SIMD.Int32x4.check(a);
+    b = SIMD.Int32x4.check(b);
+    return SIMD.Int32x4(a.x | b.x, a.y | b.y, a.z | b.z, a.w | b.w);
   }
 }
 
-if (typeof SIMD.int32x4.xor === "undefined") {
+if (typeof SIMD.Int32x4.xor === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
-    * @param {int32x4} b An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of a ^ b.
+    * @param {Int32x4} a An instance of Int32x4.
+    * @param {Int32x4} b An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of a ^ b.
     */
-  SIMD.int32x4.xor = function(a, b) {
-    a = SIMD.int32x4.check(a);
-    b = SIMD.int32x4.check(b);
-    return SIMD.int32x4(a.x ^ b.x, a.y ^ b.y, a.z ^ b.z, a.w ^ b.w);
+  SIMD.Int32x4.xor = function(a, b) {
+    a = SIMD.Int32x4.check(a);
+    b = SIMD.Int32x4.check(b);
+    return SIMD.Int32x4(a.x ^ b.x, a.y ^ b.y, a.z ^ b.z, a.w ^ b.w);
   }
 }
 
-if (typeof SIMD.int32x4.not === "undefined") {
+if (typeof SIMD.Int32x4.not === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of ~t
+    * @param {Int32x4} t An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of ~t
     */
-  SIMD.int32x4.not = function(t) {
-    t = SIMD.int32x4.check(t);
-    return SIMD.int32x4(~t.x, ~t.y, ~t.z, ~t.w);
+  SIMD.Int32x4.not = function(t) {
+    t = SIMD.Int32x4.check(t);
+    return SIMD.Int32x4(~t.x, ~t.y, ~t.z, ~t.w);
   }
 }
 
-if (typeof SIMD.int32x4.neg === "undefined") {
+if (typeof SIMD.Int32x4.neg === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of -t
+    * @param {Int32x4} t An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of -t
     */
-  SIMD.int32x4.neg = function(t) {
-    t = SIMD.int32x4.check(t);
-    return SIMD.int32x4(-t.x, -t.y, -t.z, -t.w);
+  SIMD.Int32x4.neg = function(t) {
+    t = SIMD.Int32x4.check(t);
+    return SIMD.Int32x4(-t.x, -t.y, -t.z, -t.w);
   }
 }
 
-if (typeof SIMD.int32x4.add === "undefined") {
+if (typeof SIMD.Int32x4.add === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
-    * @param {int32x4} b An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of a + b.
+    * @param {Int32x4} a An instance of Int32x4.
+    * @param {Int32x4} b An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of a + b.
     */
-  SIMD.int32x4.add = function(a, b) {
-    a = SIMD.int32x4.check(a);
-    b = SIMD.int32x4.check(b);
-    return SIMD.int32x4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
+  SIMD.Int32x4.add = function(a, b) {
+    a = SIMD.Int32x4.check(a);
+    b = SIMD.Int32x4.check(b);
+    return SIMD.Int32x4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
   }
 }
 
-if (typeof SIMD.int32x4.sub === "undefined") {
+if (typeof SIMD.Int32x4.sub === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
-    * @param {int32x4} b An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of a - b.
+    * @param {Int32x4} a An instance of Int32x4.
+    * @param {Int32x4} b An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of a - b.
     */
-  SIMD.int32x4.sub = function(a, b) {
-    a = SIMD.int32x4.check(a);
-    b = SIMD.int32x4.check(b);
-    return SIMD.int32x4(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
+  SIMD.Int32x4.sub = function(a, b) {
+    a = SIMD.Int32x4.check(a);
+    b = SIMD.Int32x4.check(b);
+    return SIMD.Int32x4(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
   }
 }
 
-if (typeof SIMD.int32x4.mul === "undefined") {
+if (typeof SIMD.Int32x4.mul === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
-    * @param {int32x4} b An instance of int32x4.
-    * @return {int32x4} New instance of int32x4 with values of a * b.
+    * @param {Int32x4} a An instance of Int32x4.
+    * @param {Int32x4} b An instance of Int32x4.
+    * @return {Int32x4} New instance of Int32x4 with values of a * b.
     */
-  SIMD.int32x4.mul = function(a, b) {
-    a = SIMD.int32x4.check(a);
-    b = SIMD.int32x4.check(b);
-    return SIMD.int32x4(Math.imul(a.x, b.x), Math.imul(a.y, b.y),
+  SIMD.Int32x4.mul = function(a, b) {
+    a = SIMD.Int32x4.check(a);
+    b = SIMD.Int32x4.check(b);
+    return SIMD.Int32x4(Math.imul(a.x, b.x), Math.imul(a.y, b.y),
                         Math.imul(a.z, b.z), Math.imul(a.w, b.w));
   }
 }
 
-if (typeof SIMD.int32x4.swizzle === "undefined") {
+if (typeof SIMD.Int32x4.swizzle === "undefined") {
   /**
-    * @param {int32x4} t An instance of float32x4 to be swizzled.
+    * @param {Int32x4} t An instance of Float32x4 to be swizzled.
     * @param {integer} x - Index in t for lane x
     * @param {integer} y - Index in t for lane y
     * @param {integer} z - Index in t for lane z
     * @param {integer} w - Index in t for lane w
-    * @return {int32x4} New instance of float32x4 with lanes swizzled.
+    * @return {Int32x4} New instance of Float32x4 with lanes swizzled.
     */
-  SIMD.int32x4.swizzle = function(t, x, y, z, w) {
-    t = SIMD.int32x4.check(t);
+  SIMD.Int32x4.swizzle = function(t, x, y, z, w) {
+    t = SIMD.Int32x4.check(t);
     var storage = _SIMD_PRIVATE._i32x4;
     storage[0] = t.x;
     storage[1] = t.y;
     storage[2] = t.z;
     storage[3] = t.w;
-    return SIMD.int32x4(storage[x], storage[y], storage[z], storage[w]);
+    return SIMD.Int32x4(storage[x], storage[y], storage[z], storage[w]);
   }
 }
 
-if (typeof SIMD.int32x4.shuffle === "undefined") {
+if (typeof SIMD.Int32x4.shuffle === "undefined") {
   /**
-    * @param {int32x4} t1 An instance of float32x4 to be shuffled.
-    * @param {int32x4} t2 An instance of float32x4 to be shuffled.
+    * @param {Int32x4} t1 An instance of Float32x4 to be shuffled.
+    * @param {Int32x4} t2 An instance of Float32x4 to be shuffled.
     * @param {integer} x - Index in concatenation of t1 and t2 for lane x
     * @param {integer} y - Index in concatenation of t1 and t2 for lane y
     * @param {integer} z - Index in concatenation of t1 and t2 for lane z
     * @param {integer} w - Index in concatenation of t1 and t2 for lane w
-    * @return {int32x4} New instance of float32x4 with lanes shuffled.
+    * @return {Int32x4} New instance of Float32x4 with lanes shuffled.
     */
-  SIMD.int32x4.shuffle = function(t1, t2, x, y, z, w) {
-    t1 = SIMD.int32x4.check(t1);
-    t2 = SIMD.int32x4.check(t2);
+  SIMD.Int32x4.shuffle = function(t1, t2, x, y, z, w) {
+    t1 = SIMD.Int32x4.check(t1);
+    t2 = SIMD.Int32x4.check(t2);
     var storage = _SIMD_PRIVATE._i32x8;
     storage[0] = t1.x;
     storage[1] = t1.y;
@@ -2447,266 +2447,266 @@ if (typeof SIMD.int32x4.shuffle === "undefined") {
     storage[5] = t2.y;
     storage[6] = t2.z;
     storage[7] = t2.w;
-    return SIMD.float32x4(storage[x], storage[y], storage[z], storage[w]);
+    return SIMD.Float32x4(storage[x], storage[y], storage[z], storage[w]);
   }
 }
 
-if (typeof SIMD.int32x4.select === "undefined") {
+if (typeof SIMD.Int32x4.select === "undefined") {
   /**
-    * @param {int32x4} t Selector mask. An instance of int32x4
-    * @param {int32x4} trueValue Pick lane from here if corresponding
+    * @param {Int32x4} t Selector mask. An instance of Int32x4
+    * @param {Int32x4} trueValue Pick lane from here if corresponding
     * selector lane is true
-    * @param {int32x4} falseValue Pick lane from here if corresponding
+    * @param {Int32x4} falseValue Pick lane from here if corresponding
     * selector lane is false
-    * @return {int32x4} Mix of lanes from trueValue or falseValue as
+    * @return {Int32x4} Mix of lanes from trueValue or falseValue as
     * indicated
     */
-  SIMD.int32x4.select = function(t, trueValue, falseValue) {
-    t = SIMD.int32x4.check(t);
-    trueValue = SIMD.int32x4.check(trueValue);
-    falseValue = SIMD.int32x4.check(falseValue);
-    return SIMD.int32x4(_SIMD_PRIVATE.tobool(t.x) ? trueValue.x : falseValue.x,
+  SIMD.Int32x4.select = function(t, trueValue, falseValue) {
+    t = SIMD.Int32x4.check(t);
+    trueValue = SIMD.Int32x4.check(trueValue);
+    falseValue = SIMD.Int32x4.check(falseValue);
+    return SIMD.Int32x4(_SIMD_PRIVATE.tobool(t.x) ? trueValue.x : falseValue.x,
                         _SIMD_PRIVATE.tobool(t.y) ? trueValue.y : falseValue.y,
                         _SIMD_PRIVATE.tobool(t.z) ? trueValue.z : falseValue.z,
                         _SIMD_PRIVATE.tobool(t.w) ? trueValue.w : falseValue.w);
   }
 }
 
-if (typeof SIMD.int32x4.bitselect === "undefined") {
+if (typeof SIMD.Int32x4.bitselect === "undefined") {
   /**
-    * @param {int32x4} t Selector mask. An instance of int32x4
-    * @param {int32x4} trueValue Pick bit from here if corresponding
+    * @param {Int32x4} t Selector mask. An instance of Int32x4
+    * @param {Int32x4} trueValue Pick bit from here if corresponding
     * selector bit is 1
-    * @param {int32x4} falseValue Pick bit from here if corresponding
+    * @param {Int32x4} falseValue Pick bit from here if corresponding
     * selector bit is 0
-    * @return {int32x4} Mix of bits from trueValue or falseValue as
+    * @return {Int32x4} Mix of bits from trueValue or falseValue as
     * indicated
     */
-  SIMD.int32x4.bitselect = function(t, trueValue, falseValue) {
-    t = SIMD.int32x4.check(t);
-    trueValue = SIMD.int32x4.check(trueValue);
-    falseValue = SIMD.int32x4.check(falseValue);
-    var tr = SIMD.int32x4.and(t, trueValue);
-    var fr = SIMD.int32x4.and(SIMD.int32x4.not(t), falseValue);
-    return SIMD.int32x4.or(tr, fr);
+  SIMD.Int32x4.bitselect = function(t, trueValue, falseValue) {
+    t = SIMD.Int32x4.check(t);
+    trueValue = SIMD.Int32x4.check(trueValue);
+    falseValue = SIMD.Int32x4.check(falseValue);
+    var tr = SIMD.Int32x4.and(t, trueValue);
+    var fr = SIMD.Int32x4.and(SIMD.Int32x4.not(t), falseValue);
+    return SIMD.Int32x4.or(tr, fr);
   }
 }
 
-if (typeof SIMD.int32x4.withX === "undefined") {
+if (typeof SIMD.Int32x4.withX === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
+    * @param {Int32x4} t An instance of Int32x4.
     * @param {integer} 32-bit value used for x lane.
-    * @return {int32x4} New instance of int32x4 with the values in t and
+    * @return {Int32x4} New instance of Int32x4 with the values in t and
     * x lane replaced with {x}.
     */
-  SIMD.int32x4.withX = function(t, x) {
-    t = SIMD.int32x4(t);
-    return SIMD.int32x4(x, t.y, t.z, t.w);
+  SIMD.Int32x4.withX = function(t, x) {
+    t = SIMD.Int32x4(t);
+    return SIMD.Int32x4(x, t.y, t.z, t.w);
   }
 }
 
-if (typeof SIMD.int32x4.withY === "undefined") {
+if (typeof SIMD.Int32x4.withY === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
+    * @param {Int32x4} t An instance of Int32x4.
     * @param {integer} 32-bit value used for y lane.
-    * @return {int32x4} New instance of int32x4 with the values in t and
+    * @return {Int32x4} New instance of Int32x4 with the values in t and
     * y lane replaced with {y}.
     */
-  SIMD.int32x4.withY = function(t, y) {
-    t = SIMD.int32x4(t);
-    return SIMD.int32x4(t.x, y, t.z, t.w);
+  SIMD.Int32x4.withY = function(t, y) {
+    t = SIMD.Int32x4(t);
+    return SIMD.Int32x4(t.x, y, t.z, t.w);
   }
 }
 
-if (typeof SIMD.int32x4.withZ === "undefined") {
+if (typeof SIMD.Int32x4.withZ === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
+    * @param {Int32x4} t An instance of Int32x4.
     * @param {integer} 32-bit value used for z lane.
-    * @return {int32x4} New instance of int32x4 with the values in t and
+    * @return {Int32x4} New instance of Int32x4 with the values in t and
     * z lane replaced with {z}.
     */
-  SIMD.int32x4.withZ = function(t, z) {
-    t = SIMD.int32x4(t);
-    return SIMD.int32x4(t.x, t.y, z, t.w);
+  SIMD.Int32x4.withZ = function(t, z) {
+    t = SIMD.Int32x4(t);
+    return SIMD.Int32x4(t.x, t.y, z, t.w);
   }
 }
 
-if (typeof SIMD.int32x4.withW === "undefined") {
+if (typeof SIMD.Int32x4.withW === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
+    * @param {Int32x4} t An instance of Int32x4.
     * @param {integer} 32-bit value used for w lane.
-    * @return {int32x4} New instance of int32x4 with the values in t and
+    * @return {Int32x4} New instance of Int32x4 with the values in t and
     * w lane replaced with {w}.
     */
-  SIMD.int32x4.withW = function(t, w) {
-    t = SIMD.int32x4(t);
-    return SIMD.int32x4(t.x, t.y, t.z, w);
+  SIMD.Int32x4.withW = function(t, w) {
+    t = SIMD.Int32x4(t);
+    return SIMD.Int32x4(t.x, t.y, t.z, w);
   }
 }
 
-if (typeof SIMD.int32x4.equal === "undefined") {
+if (typeof SIMD.Int32x4.equal === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @param {int32x4} other An instance of int32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Int32x4} t An instance of Int32x4.
+    * @param {Int32x4} other An instance of Int32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t == other.
     */
-  SIMD.int32x4.equal = function(t, other) {
-    t = SIMD.int32x4.check(t);
-    other = SIMD.int32x4.check(other);
+  SIMD.Int32x4.equal = function(t, other) {
+    t = SIMD.Int32x4.check(t);
+    other = SIMD.Int32x4.check(other);
     var cx = t.x == other.x;
     var cy = t.y == other.y;
     var cz = t.z == other.z;
     var cw = t.w == other.w;
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.int32x4.notEqual === "undefined") {
+if (typeof SIMD.Int32x4.notEqual === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @param {int32x4} other An instance of int32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Int32x4} t An instance of Int32x4.
+    * @param {Int32x4} other An instance of Int32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t != other.
     */
-  SIMD.int32x4.notEqual = function(t, other) {
-    t = SIMD.int32x4.check(t);
-    other = SIMD.int32x4.check(other);
+  SIMD.Int32x4.notEqual = function(t, other) {
+    t = SIMD.Int32x4.check(t);
+    other = SIMD.Int32x4.check(other);
     var cx = t.x != other.x;
     var cy = t.y != other.y;
     var cz = t.z != other.z;
     var cw = t.w != other.w;
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.int32x4.greaterThan === "undefined") {
+if (typeof SIMD.Int32x4.greaterThan === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @param {int32x4} other An instance of int32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Int32x4} t An instance of Int32x4.
+    * @param {Int32x4} other An instance of Int32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t > other.
     */
-  SIMD.int32x4.greaterThan = function(t, other) {
-    t = SIMD.int32x4.check(t);
-    other = SIMD.int32x4.check(other);
+  SIMD.Int32x4.greaterThan = function(t, other) {
+    t = SIMD.Int32x4.check(t);
+    other = SIMD.Int32x4.check(other);
     var cx = t.x > other.x;
     var cy = t.y > other.y;
     var cz = t.z > other.z;
     var cw = t.w > other.w;
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.int32x4.greaterThanOrEqual === "undefined") {
+if (typeof SIMD.Int32x4.greaterThanOrEqual === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @param {int32x4} other An instance of int32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Int32x4} t An instance of Int32x4.
+    * @param {Int32x4} other An instance of Int32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t >= other.
     */
-  SIMD.int32x4.greaterThanOrEqual = function(t, other) {
-    t = SIMD.int32x4.check(t);
-    other = SIMD.int32x4.check(other);
+  SIMD.Int32x4.greaterThanOrEqual = function(t, other) {
+    t = SIMD.Int32x4.check(t);
+    other = SIMD.Int32x4.check(other);
     var cx = t.x >= other.x;
     var cy = t.y >= other.y;
     var cz = t.z >= other.z;
     var cw = t.w >= other.w;
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.int32x4.lessThan === "undefined") {
+if (typeof SIMD.Int32x4.lessThan === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @param {int32x4} other An instance of int32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Int32x4} t An instance of Int32x4.
+    * @param {Int32x4} other An instance of Int32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t < other.
     */
-  SIMD.int32x4.lessThan = function(t, other) {
-    t = SIMD.int32x4.check(t);
-    other = SIMD.int32x4.check(other);
+  SIMD.Int32x4.lessThan = function(t, other) {
+    t = SIMD.Int32x4.check(t);
+    other = SIMD.Int32x4.check(other);
     var cx = t.x < other.x;
     var cy = t.y < other.y;
     var cz = t.z < other.z;
     var cw = t.w < other.w;
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.int32x4.lessThanOrEqual === "undefined") {
+if (typeof SIMD.Int32x4.lessThanOrEqual === "undefined") {
   /**
-    * @param {int32x4} t An instance of int32x4.
-    * @param {int32x4} other An instance of int32x4.
-    * @return {int32x4} true or false in each lane depending on
+    * @param {Int32x4} t An instance of Int32x4.
+    * @param {Int32x4} other An instance of Int32x4.
+    * @return {Int32x4} true or false in each lane depending on
     * the result of t <= other.
     */
-  SIMD.int32x4.lessThanOrEqual = function(t, other) {
-    t = SIMD.int32x4.check(t);
-    other = SIMD.int32x4.check(other);
+  SIMD.Int32x4.lessThanOrEqual = function(t, other) {
+    t = SIMD.Int32x4.check(t);
+    other = SIMD.Int32x4.check(other);
     var cx = t.x <= other.x;
     var cy = t.y <= other.y;
     var cz = t.z <= other.z;
     var cw = t.w <= other.w;
-    return SIMD.int32x4.bool(cx, cy, cz, cw);
+    return SIMD.Int32x4.bool(cx, cy, cz, cw);
   }
 }
 
-if (typeof SIMD.int32x4.shiftLeftByScalar === "undefined") {
+if (typeof SIMD.Int32x4.shiftLeftByScalar === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
+    * @param {Int32x4} a An instance of Int32x4.
     * @param {integer} bits Bit count to shift by.
-    * @return {int32x4} lanes in a shifted by bits.
+    * @return {Int32x4} lanes in a shifted by bits.
     */
-  SIMD.int32x4.shiftLeftByScalar = function(a, bits) {
-    a = SIMD.int32x4.check(a);
+  SIMD.Int32x4.shiftLeftByScalar = function(a, bits) {
+    a = SIMD.Int32x4.check(a);
     var x = a.x << bits;
     var y = a.y << bits;
     var z = a.z << bits;
     var w = a.w << bits;
-    return SIMD.int32x4(x, y, z, w);
+    return SIMD.Int32x4(x, y, z, w);
   }
 }
 
-if (typeof SIMD.int32x4.shiftRightLogicalByScalar === "undefined") {
+if (typeof SIMD.Int32x4.shiftRightLogicalByScalar === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
+    * @param {Int32x4} a An instance of Int32x4.
     * @param {integer} bits Bit count to shift by.
-    * @return {int32x4} lanes in a shifted by bits.
+    * @return {Int32x4} lanes in a shifted by bits.
     */
-  SIMD.int32x4.shiftRightLogicalByScalar = function(a, bits) {
-    a = SIMD.int32x4.check(a);
+  SIMD.Int32x4.shiftRightLogicalByScalar = function(a, bits) {
+    a = SIMD.Int32x4.check(a);
     var x = a.x >>> bits;
     var y = a.y >>> bits;
     var z = a.z >>> bits;
     var w = a.w >>> bits;
-    return SIMD.int32x4(x, y, z, w);
+    return SIMD.Int32x4(x, y, z, w);
   }
 }
 
-if (typeof SIMD.int32x4.shiftRightArithmeticByScalar === "undefined") {
+if (typeof SIMD.Int32x4.shiftRightArithmeticByScalar === "undefined") {
   /**
-    * @param {int32x4} a An instance of int32x4.
+    * @param {Int32x4} a An instance of Int32x4.
     * @param {integer} bits Bit count to shift by.
-    * @return {int32x4} lanes in a shifted by bits.
+    * @return {Int32x4} lanes in a shifted by bits.
     */
-  SIMD.int32x4.shiftRightArithmeticByScalar = function(a, bits) {
-    a = SIMD.int32x4.check(a);
+  SIMD.Int32x4.shiftRightArithmeticByScalar = function(a, bits) {
+    a = SIMD.Int32x4.check(a);
     var x = a.x >> bits;
     var y = a.y >> bits;
     var z = a.z >> bits;
     var w = a.w >> bits;
-    return SIMD.int32x4(x, y, z, w);
+    return SIMD.Int32x4(x, y, z, w);
   }
 }
 
-if (typeof SIMD.int32x4.load === "undefined") {
+if (typeof SIMD.Int32x4.load === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {int32x4} New instance of int32x4.
+    * @return {Int32x4} New instance of Int32x4.
     */
-  SIMD.int32x4.load = function(tarray, index) {
+  SIMD.Int32x4.load = function(tarray, index) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -2722,17 +2722,17 @@ if (typeof SIMD.int32x4.load === "undefined") {
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
     var i32temp = _SIMD_PRIVATE._i32x4;
-    return SIMD.int32x4(i32temp[0], i32temp[1], i32temp[2], i32temp[3]);
+    return SIMD.Int32x4(i32temp[0], i32temp[1], i32temp[2], i32temp[3]);
   }
 }
 
-if (typeof SIMD.int32x4.loadX === "undefined") {
+if (typeof SIMD.Int32x4.loadX === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {int32x4} New instance of int32x4.
+    * @return {Int32x4} New instance of Int32x4.
     */
-  SIMD.int32x4.loadX = function(tarray, index) {
+  SIMD.Int32x4.loadX = function(tarray, index) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -2748,17 +2748,17 @@ if (typeof SIMD.int32x4.loadX === "undefined") {
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
     var i32temp = _SIMD_PRIVATE._i32x4;
-    return SIMD.int32x4(i32temp[0], 0, 0, 0);
+    return SIMD.Int32x4(i32temp[0], 0, 0, 0);
   }
 }
 
-if (typeof SIMD.int32x4.loadXY === "undefined") {
+if (typeof SIMD.Int32x4.loadXY === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {int32x4} New instance of int32x4.
+    * @return {Int32x4} New instance of Int32x4.
     */
-  SIMD.int32x4.loadXY = function(tarray, index) {
+  SIMD.Int32x4.loadXY = function(tarray, index) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -2774,17 +2774,17 @@ if (typeof SIMD.int32x4.loadXY === "undefined") {
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
     var i32temp = _SIMD_PRIVATE._i32x4;
-    return SIMD.int32x4(i32temp[0], i32temp[1], 0, 0);
+    return SIMD.Int32x4(i32temp[0], i32temp[1], 0, 0);
   }
 }
 
-if (typeof SIMD.int32x4.loadXYZ === "undefined") {
+if (typeof SIMD.Int32x4.loadXYZ === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @return {int32x4} New instance of int32x4.
+    * @return {Int32x4} New instance of Int32x4.
     */
-  SIMD.int32x4.loadXYZ = function(tarray, index) {
+  SIMD.Int32x4.loadXYZ = function(tarray, index) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -2800,18 +2800,18 @@ if (typeof SIMD.int32x4.loadXYZ === "undefined") {
     for (var i = 0; i < n; ++i)
       array[i] = tarray[index + i];
     var i32temp = _SIMD_PRIVATE._i32x4;
-    return SIMD.int32x4(i32temp[0], i32temp[1], i32temp[2], 0);
+    return SIMD.Int32x4(i32temp[0], i32temp[1], i32temp[2], 0);
   }
 }
 
-if (typeof SIMD.int32x4.store === "undefined") {
+if (typeof SIMD.Int32x4.store === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {int32x4} value An instance of int32x4.
+    * @param {Int32x4} value An instance of Int32x4.
     * @return {void}
     */
-  SIMD.int32x4.store = function(tarray, index, value) {
+  SIMD.Int32x4.store = function(tarray, index, value) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -2819,7 +2819,7 @@ if (typeof SIMD.int32x4.store === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 16) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.int32x4.check(value);
+    value = SIMD.Int32x4.check(value);
     _SIMD_PRIVATE._i32x4[0] = value.x;
     _SIMD_PRIVATE._i32x4[1] = value.y;
     _SIMD_PRIVATE._i32x4[2] = value.z;
@@ -2834,14 +2834,14 @@ if (typeof SIMD.int32x4.store === "undefined") {
   }
 }
 
-if (typeof SIMD.int32x4.storeX === "undefined") {
+if (typeof SIMD.Int32x4.storeX === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {int32x4} value An instance of int32x4.
+    * @param {Int32x4} value An instance of Int32x4.
     * @return {void}
     */
-  SIMD.int32x4.storeX = function(tarray, index, value) {
+  SIMD.Int32x4.storeX = function(tarray, index, value) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -2849,7 +2849,7 @@ if (typeof SIMD.int32x4.storeX === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 4) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.int32x4.check(value);
+    value = SIMD.Int32x4.check(value);
     if (bpe == 8) {
       // tarray's elements are too wide. Just create a new view; this is rare.
       var view = new Int32Array(tarray.buffer, tarray.byteOffset + index * 8, 1);
@@ -2866,14 +2866,14 @@ if (typeof SIMD.int32x4.storeX === "undefined") {
   }
 }
 
-if (typeof SIMD.int32x4.storeXY === "undefined") {
+if (typeof SIMD.Int32x4.storeXY === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {int32x4} value An instance of int32x4.
+    * @param {Int32x4} value An instance of Int32x4.
     * @return {void}
     */
-  SIMD.int32x4.storeXY = function(tarray, index, value) {
+  SIMD.Int32x4.storeXY = function(tarray, index, value) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -2881,7 +2881,7 @@ if (typeof SIMD.int32x4.storeXY === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 8) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.int32x4.check(value);
+    value = SIMD.Int32x4.check(value);
     _SIMD_PRIVATE._i32x4[0] = value.x;
     _SIMD_PRIVATE._i32x4[1] = value.y;
     var array = bpe == 1 ? _SIMD_PRIVATE._i8x16 :
@@ -2894,14 +2894,14 @@ if (typeof SIMD.int32x4.storeXY === "undefined") {
   }
 }
 
-if (typeof SIMD.int32x4.storeXYZ === "undefined") {
+if (typeof SIMD.Int32x4.storeXYZ === "undefined") {
   /**
     * @param {Typed array} tarray An instance of a typed array.
     * @param {Number} index An instance of Number.
-    * @param {int32x4} value An instance of int32x4.
+    * @param {Int32x4} value An instance of Int32x4.
     * @return {void}
     */
-  SIMD.int32x4.storeXYZ = function(tarray, index, value) {
+  SIMD.Int32x4.storeXYZ = function(tarray, index, value) {
     if (!_SIMD_PRIVATE.isTypedArray(tarray))
       throw new TypeError("The 1st argument must be a typed array.");
     if (!_SIMD_PRIVATE.isNumber(index))
@@ -2909,7 +2909,7 @@ if (typeof SIMD.int32x4.storeXYZ === "undefined") {
     var bpe = tarray.BYTES_PER_ELEMENT;
     if (index < 0 || (index * bpe + 12) > tarray.byteLength)
       throw new RangeError("The value of index is invalid.");
-    value = SIMD.int32x4.check(value);
+    value = SIMD.Int32x4.check(value);
     if (bpe == 8) {
       // tarray's elements are too wide. Just create a new view; this is rare.
       var view = new Int32Array(tarray.buffer, tarray.byteOffset + index * 8, 3);
@@ -3718,7 +3718,7 @@ if (typeof Float32x4Array === "undefined") {
     var y = this.storage_[i*4+1];
     var z = this.storage_[i*4+2];
     var w = this.storage_[i*4+3];
-    return SIMD.float32x4(x, y, z, w);
+    return SIMD.Float32x4(x, y, z, w);
   }
 
   Float32x4Array.prototype.setAt = function(i, v) {
@@ -3728,8 +3728,8 @@ if (typeof Float32x4Array === "undefined") {
     if (i >= this.length) {
       throw "Index out of bounds.";
     }
-    if (!(v instanceof SIMD.float32x4)) {
-      throw "Value is not a float32x4.";
+    if (!(v instanceof SIMD.Float32x4)) {
+      throw "Value is not a Float32x4.";
     }
     this.storage_[i*4+0] = v.x;
     this.storage_[i*4+1] = v.y;
@@ -3810,7 +3810,7 @@ if (typeof Int32x4Array === "undefined") {
     var y = this.storage_[i*4+1];
     var z = this.storage_[i*4+2];
     var w = this.storage_[i*4+3];
-    return SIMD.int32x4(x, y, z, w);
+    return SIMD.Int32x4(x, y, z, w);
   }
 
   Int32x4Array.prototype.setAt = function(i, v) {
@@ -3820,8 +3820,8 @@ if (typeof Int32x4Array === "undefined") {
     if (i >= this.length) {
       throw "Index out of bounds.";
     }
-    if (!(v instanceof SIMD.int32x4)) {
-      throw "Value is not a int32x4.";
+    if (!(v instanceof SIMD.Int32x4)) {
+      throw "Value is not a Int32x4.";
     }
     this.storage_[i*4+0] = v.x;
     this.storage_[i*4+1] = v.y;
@@ -3840,7 +3840,7 @@ if (typeof Int32x4Array === "undefined") {
       throw new RangeError("The value of byteOffset is invalid.");
     if (typeof littleEndian === 'undefined')
       littleEndian = false;
-    return SIMD.float32x4(this.getFloat32(byteOffset, littleEndian),
+    return SIMD.Float32x4(this.getFloat32(byteOffset, littleEndian),
                           this.getFloat32(byteOffset + 4, littleEndian),
                           this.getFloat32(byteOffset + 8, littleEndian),
                           this.getFloat32(byteOffset + 12, littleEndian));
@@ -3853,7 +3853,7 @@ if (typeof Int32x4Array === "undefined") {
       throw new RangeError("The value of byteOffset is invalid.");
     if (typeof littleEndian === 'undefined')
       littleEndian = false;
-    return SIMD.float64x2(this.getFloat64(byteOffset, littleEndian),
+    return SIMD.Float64x2(this.getFloat64(byteOffset, littleEndian),
                           this.getFloat64(byteOffset + 8, littleEndian));
   }
 
@@ -3864,7 +3864,7 @@ if (typeof Int32x4Array === "undefined") {
       throw new RangeError("The value of byteOffset is invalid.");
     if (typeof littleEndian === 'undefined')
       littleEndian = false;
-    return SIMD.int32x4(this.getInt32(byteOffset, littleEndian),
+    return SIMD.Int32x4(this.getInt32(byteOffset, littleEndian),
                         this.getInt32(byteOffset + 4, littleEndian),
                         this.getInt32(byteOffset + 8, littleEndian),
                         this.getInt32(byteOffset + 12, littleEndian));
@@ -3917,7 +3917,7 @@ if (typeof Int32x4Array === "undefined") {
       throw new TypeError("This is not a DataView.");
     if (byteOffset < 0 || (byteOffset + 16) > this.buffer.byteLength)
       throw new RangeError("The value of byteOffset is invalid.");
-    value = SIMD.float32x4.check(value);
+    value = SIMD.Float32x4.check(value);
     if (typeof littleEndian === 'undefined')
       littleEndian = false;
     this.setFloat32(byteOffset, value.x, littleEndian);
@@ -3931,7 +3931,7 @@ if (typeof Int32x4Array === "undefined") {
       throw new TypeError("This is not a DataView.");
     if (byteOffset < 0 || (byteOffset + 16) > this.buffer.byteLength)
       throw new RangeError("The value of byteOffset is invalid.");
-    value = SIMD.float64x2.check(value);
+    value = SIMD.Float64x2.check(value);
     if (typeof littleEndian === 'undefined')
       littleEndian = false;
     this.setFloat64(byteOffset, value.x, littleEndian);
@@ -3943,7 +3943,7 @@ if (typeof Int32x4Array === "undefined") {
       throw new TypeError("This is not a DataView.");
     if (byteOffset < 0 || (byteOffset + 16) > this.buffer.byteLength)
       throw new RangeError("The value of byteOffset is invalid.");
-    value = SIMD.int32x4.check(value);
+    value = SIMD.Int32x4.check(value);
     if (typeof littleEndian === 'undefined')
       littleEndian = false;
     this.setInt32(byteOffset, value.x, littleEndian);

--- a/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/ecmascript_simd_tests.js
+++ b/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/ecmascript_simd_tests.js
@@ -26,41 +26,41 @@ almostEqual = function(a, b) {
   ok(false);
 }
 
-test('float32x4 constructor', function() {
-  notEqual(undefined, SIMD.float32x4);  // Type.
-  notEqual(undefined, SIMD.float32x4(1.0, 2.0, 3.0, 4.0));  // New object.
-  var f1 = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  var f2 = SIMD.float32x4.check(f1);
+test('Float32x4 constructor', function() {
+  notEqual(undefined, SIMD.Float32x4);  // Type.
+  notEqual(undefined, SIMD.Float32x4(1.0, 2.0, 3.0, 4.0));  // New object.
+  var f1 = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  var f2 = SIMD.Float32x4.check(f1);
   equal(f1.x, f2.x, "the value of x should equal");
   equal(f1.y, f2.y, "the value of y should equal");
   equal(f1.z, f2.z, "the value of z should equal");
   equal(f1.w, f2.w, "the value of w should equal");
 });
 
-test('float32x4 scalar getters', function() {
-  var a = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
+test('Float32x4 scalar getters', function() {
+  var a = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
   equal(1.0, a.x);
   equal(2.0, a.y);
   equal(3.0, a.z);
   equal(4.0, a.w);
 });
 
-test('float32x4 signMask getter', function() {
-  var a = SIMD.float32x4(-1.0, -2.0, -3.0, -4.0);
+test('Float32x4 signMask getter', function() {
+  var a = SIMD.Float32x4(-1.0, -2.0, -3.0, -4.0);
   equal(0xf, a.signMask);
-  var b = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
+  var b = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
   equal(0x0, b.signMask);
-  var c = SIMD.float32x4(1.0, -2.0, -3.0, 4.0);
+  var c = SIMD.Float32x4(1.0, -2.0, -3.0, 4.0);
   equal(0x6, c.signMask);
 });
 
-test('float32x4 vector getters', function() {
-  var a = SIMD.float32x4(4.0, 3.0, 2.0, 1.0);
-  var xxxx = SIMD.float32x4.swizzle(a, 0, 0, 0, 0);
-  var yyyy = SIMD.float32x4.swizzle(a, 1, 1, 1, 1);
-  var zzzz = SIMD.float32x4.swizzle(a, 2, 2, 2, 2);
-  var wwww = SIMD.float32x4.swizzle(a, 3, 3, 3, 3);
-  var wzyx = SIMD.float32x4.swizzle(a, 3, 2, 1, 0);
+test('Float32x4 vector getters', function() {
+  var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
+  var xxxx = SIMD.Float32x4.swizzle(a, 0, 0, 0, 0);
+  var yyyy = SIMD.Float32x4.swizzle(a, 1, 1, 1, 1);
+  var zzzz = SIMD.Float32x4.swizzle(a, 2, 2, 2, 2);
+  var wwww = SIMD.Float32x4.swizzle(a, 3, 3, 3, 3);
+  var wzyx = SIMD.Float32x4.swizzle(a, 3, 2, 1, 0);
   equal(4.0, xxxx.x);
   equal(4.0, xxxx.y);
   equal(4.0, xxxx.z);
@@ -83,28 +83,28 @@ test('float32x4 vector getters', function() {
   equal(4.0, wzyx.w);
 });
 
-test('float32x4 abs', function() {
-  var a = SIMD.float32x4(-4.0, -3.0, -2.0, -1.0);
-  var c = SIMD.float32x4.abs(a);
+test('Float32x4 abs', function() {
+  var a = SIMD.Float32x4(-4.0, -3.0, -2.0, -1.0);
+  var c = SIMD.Float32x4.abs(a);
   equal(4.0, c.x);
   equal(3.0, c.y);
   equal(2.0, c.z);
   equal(1.0, c.w);
-  c = SIMD.float32x4.abs(SIMD.float32x4(4.0, 3.0, 2.0, 1.0));
+  c = SIMD.Float32x4.abs(SIMD.Float32x4(4.0, 3.0, 2.0, 1.0));
   equal(4.0, c.x);
   equal(3.0, c.y);
   equal(2.0, c.z);
   equal(1.0, c.w);
 });
 
-test('float32x4 neg', function() {
-  var a = SIMD.float32x4(-4.0, -3.0, -2.0, -1.0);
-  var c = SIMD.float32x4.neg(a);
+test('Float32x4 neg', function() {
+  var a = SIMD.Float32x4(-4.0, -3.0, -2.0, -1.0);
+  var c = SIMD.Float32x4.neg(a);
   equal(4.0, c.x);
   equal(3.0, c.y);
   equal(2.0, c.z);
   equal(1.0, c.w);
-  c = SIMD.float32x4.neg(SIMD.float32x4(4.0, 3.0, 2.0, 1.0));
+  c = SIMD.Float32x4.neg(SIMD.Float32x4(4.0, 3.0, 2.0, 1.0));
   equal(-4.0, c.x);
   equal(-3.0, c.y);
   equal(-2.0, c.z);
@@ -112,119 +112,119 @@ test('float32x4 neg', function() {
 });
 
 
-test('float32x4 add', function() {
-  var a = SIMD.float32x4(4.0, 3.0, 2.0, 1.0);
-  var b = SIMD.float32x4(10.0, 20.0, 30.0, 40.0);
-  var c = SIMD.float32x4.add(a, b);
+test('Float32x4 add', function() {
+  var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
+  var b = SIMD.Float32x4(10.0, 20.0, 30.0, 40.0);
+  var c = SIMD.Float32x4.add(a, b);
   equal(14.0, c.x);
   equal(23.0, c.y);
   equal(32.0, c.z);
   equal(41.0, c.w);
 });
 
-test('float32x4 sub', function() {
-  var a = SIMD.float32x4(4.0, 3.0, 2.0, 1.0);
-  var b = SIMD.float32x4(10.0, 20.0, 30.0, 40.0);
-  var c = SIMD.float32x4.sub(a, b);
+test('Float32x4 sub', function() {
+  var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
+  var b = SIMD.Float32x4(10.0, 20.0, 30.0, 40.0);
+  var c = SIMD.Float32x4.sub(a, b);
   equal(-6.0, c.x);
   equal(-17.0, c.y);
   equal(-28.0, c.z);
   equal(-39.0, c.w);
 });
 
-test('float32x4 mul', function() {
-  var a = SIMD.float32x4(4.0, 3.0, 2.0, 1.0);
-  var b = SIMD.float32x4(10.0, 20.0, 30.0, 40.0);
-  var c = SIMD.float32x4.mul(a, b);
+test('Float32x4 mul', function() {
+  var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
+  var b = SIMD.Float32x4(10.0, 20.0, 30.0, 40.0);
+  var c = SIMD.Float32x4.mul(a, b);
   equal(40.0, c.x);
   equal(60.0, c.y);
   equal(60.0, c.z);
   equal(40.0, c.w);
 });
 
-test('float32x4 div', function() {
-  var a = SIMD.float32x4(4.0, 9.0, 8.0, 1.0);
-  var b = SIMD.float32x4(2.0, 3.0, 1.0, 0.5);
-  var c = SIMD.float32x4.div(a, b);
+test('Float32x4 div', function() {
+  var a = SIMD.Float32x4(4.0, 9.0, 8.0, 1.0);
+  var b = SIMD.Float32x4(2.0, 3.0, 1.0, 0.5);
+  var c = SIMD.Float32x4.div(a, b);
   equal(2.0, c.x);
   equal(3.0, c.y);
   equal(8.0, c.z);
   equal(2.0, c.w);
 });
 
-test('float32x4 clamp', function() {
-  var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
-  var lower = SIMD.float32x4(2.0, 1.0, 50.0, 0.0);
-  var upper = SIMD.float32x4(2.5, 5.0, 55.0, 1.0);
-  var c = SIMD.float32x4.clamp(a, lower, upper);
+test('Float32x4 clamp', function() {
+  var a = SIMD.Float32x4(-20.0, 10.0, 30.0, 0.5);
+  var lower = SIMD.Float32x4(2.0, 1.0, 50.0, 0.0);
+  var upper = SIMD.Float32x4(2.5, 5.0, 55.0, 1.0);
+  var c = SIMD.Float32x4.clamp(a, lower, upper);
   equal(2.0, c.x);
   equal(5.0, c.y);
   equal(50.0, c.z);
   equal(0.5, c.w);
 });
 
-test('float32x4 min', function() {
-  var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
-  var lower = SIMD.float32x4(2.0, 1.0, 50.0, 0.0);
-  var c = SIMD.float32x4.min(a, lower);
+test('Float32x4 min', function() {
+  var a = SIMD.Float32x4(-20.0, 10.0, 30.0, 0.5);
+  var lower = SIMD.Float32x4(2.0, 1.0, 50.0, 0.0);
+  var c = SIMD.Float32x4.min(a, lower);
   equal(-20.0, c.x);
   equal(1.0, c.y);
   equal(30.0, c.z);
   equal(0.0, c.w);
 });
 
-test('float32x4 max', function() {
-  var a = SIMD.float32x4(-20.0, 10.0, 30.0, 0.5);
-  var upper = SIMD.float32x4(2.5, 5.0, 55.0, 1.0);
-  var c = SIMD.float32x4.max(a, upper);
+test('Float32x4 max', function() {
+  var a = SIMD.Float32x4(-20.0, 10.0, 30.0, 0.5);
+  var upper = SIMD.Float32x4(2.5, 5.0, 55.0, 1.0);
+  var c = SIMD.Float32x4.max(a, upper);
   equal(2.5, c.x);
   equal(10.0, c.y);
   equal(55.0, c.z);
   equal(1.0, c.w);
 });
 
-test('float32x4 reciprocal', function() {
-  var a = SIMD.float32x4(8.0, 4.0, 2.0, -2.0);
-  var c = SIMD.float32x4.reciprocal(a);
+test('Float32x4 reciprocal', function() {
+  var a = SIMD.Float32x4(8.0, 4.0, 2.0, -2.0);
+  var c = SIMD.Float32x4.reciprocal(a);
   equal(0.125, c.x);
   equal(0.250, c.y);
   equal(0.5, c.z);
   equal(-0.5, c.w);
 });
 
-test('float32x4 reciprocal sqrt', function() {
-  var a = SIMD.float32x4(1.0, 0.25, 0.111111, 0.0625);
-  var c = SIMD.float32x4.reciprocalSqrt(a);
+test('Float32x4 reciprocal sqrt', function() {
+  var a = SIMD.Float32x4(1.0, 0.25, 0.111111, 0.0625);
+  var c = SIMD.Float32x4.reciprocalSqrt(a);
   almostEqual(1.0, c.x);
   almostEqual(2.0, c.y);
   almostEqual(3.0, c.z);
   almostEqual(4.0, c.w);
 });
 
-test('float32x4 scale', function() {
-  var a = SIMD.float32x4(8.0, 4.0, 2.0, -2.0);
-  var c = SIMD.float32x4.scale(a, 0.5);
+test('Float32x4 scale', function() {
+  var a = SIMD.Float32x4(8.0, 4.0, 2.0, -2.0);
+  var c = SIMD.Float32x4.scale(a, 0.5);
   equal(4.0, c.x);
   equal(2.0, c.y);
   equal(1.0, c.z);
   equal(-1.0, c.w);
 });
 
-test('float32x4 sqrt', function() {
-  var a = SIMD.float32x4(16.0, 9.0, 4.0, 1.0);
-  var c = SIMD.float32x4.sqrt(a);
+test('Float32x4 sqrt', function() {
+  var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
+  var c = SIMD.Float32x4.sqrt(a);
   equal(4.0, c.x);
   equal(3.0, c.y);
   equal(2.0, c.z);
   equal(1.0, c.w);
 });
 
-test('float32x4 shuffleMix', function() {
-  var a    = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  var b    = SIMD.float32x4(5.0, 6.0, 7.0, 8.0);
-  var xyxy = SIMD.float32x4.shuffleMix(a, b, SIMD.XYXY);
-  var zwzw = SIMD.float32x4.shuffleMix(a, b, SIMD.ZWZW);
-  var xxxx = SIMD.float32x4.shuffleMix(a, b, SIMD.XXXX);
+test('Float32x4 shuffleMix', function() {
+  var a    = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  var b    = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
+  var xyxy = SIMD.Float32x4.shuffleMix(a, b, SIMD.XYXY);
+  var zwzw = SIMD.Float32x4.shuffleMix(a, b, SIMD.ZWZW);
+  var xxxx = SIMD.Float32x4.shuffleMix(a, b, SIMD.XXXX);
   equal(1.0, xyxy.x);
   equal(2.0, xyxy.y);
   equal(5.0, xyxy.z);
@@ -239,177 +239,177 @@ test('float32x4 shuffleMix', function() {
   equal(5.0, xxxx.w);
 });
 
-test('float32x4 withX', function() {
-    var a = SIMD.float32x4(16.0, 9.0, 4.0, 1.0);
-    var c = SIMD.float32x4.withX(a, 20.0);
+test('Float32x4 withX', function() {
+    var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
+    var c = SIMD.Float32x4.withX(a, 20.0);
     equal(20.0, c.x);
     equal(9.0, c.y);
     equal(4.0, c.z);
     equal(1.0, c.w);
 });
 
-test('float32x4 withY', function() {
-    var a = SIMD.float32x4(16.0, 9.0, 4.0, 1.0);
-    var c = SIMD.float32x4.withY(a, 20.0);
+test('Float32x4 withY', function() {
+    var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
+    var c = SIMD.Float32x4.withY(a, 20.0);
     equal(16.0, c.x);
     equal(20.0, c.y);
     equal(4.0, c.z);
     equal(1.0, c.w);
 });
 
-test('float32x4 withZ', function() {
-    var a = SIMD.float32x4(16.0, 9.0, 4.0, 1.0);
-    var c = SIMD.float32x4.withZ(a, 20.0);
+test('Float32x4 withZ', function() {
+    var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
+    var c = SIMD.Float32x4.withZ(a, 20.0);
     equal(16.0, c.x);
     equal(9.0, c.y);
     equal(20.0, c.z);
     equal(1.0, c.w);
 });
 
-test('float32x4 withW', function() {
-    var a = SIMD.float32x4(16.0, 9.0, 4.0, 1.0);
-    var c = SIMD.float32x4.withW(a, 20.0);
+test('Float32x4 withW', function() {
+    var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
+    var c = SIMD.Float32x4.withW(a, 20.0);
     equal(16.0, c.x);
     equal(9.0, c.y);
     equal(4.0, c.z);
     equal(20.0, c.w);
 });
 
-test('float32x4 int32x4 conversion', function() {
-  var m = SIMD.int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
-  var n = SIMD.float32x4.fromInt32x4Bits(m);
+test('Float32x4 Int32x4 conversion', function() {
+  var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
+  var n = SIMD.Float32x4.fromInt32x4Bits(m);
   equal(1.0, n.x);
   equal(2.0, n.y);
   equal(3.0, n.z);
   equal(4.0, n.w);
-  n = SIMD.float32x4(5.0, 6.0, 7.0, 8.0);
-  m = SIMD.int32x4.fromFloat32x4Bits(n);
+  n = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
+  m = SIMD.Int32x4.fromFloat32x4Bits(n);
   equal(0x40A00000, m.x);
   equal(0x40C00000, m.y);
   equal(0x40E00000, m.z);
   equal(0x41000000, m.w);
   // Flip sign using bit-wise operators.
-  n = SIMD.float32x4(9.0, 10.0, 11.0, 12.0);
-  m = SIMD.int32x4(0x80000000, 0x80000000, 0x80000000, 0x80000000);
-  var nMask = SIMD.int32x4.fromFloat32x4Bits(n);
-  nMask = SIMD.int32x4.xor(nMask, m); // flip sign.
-  n = SIMD.float32x4.fromInt32x4Bits(nMask);
+  n = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
+  m = SIMD.Int32x4(0x80000000, 0x80000000, 0x80000000, 0x80000000);
+  var nMask = SIMD.Int32x4.fromFloat32x4Bits(n);
+  nMask = SIMD.Int32x4.xor(nMask, m); // flip sign.
+  n = SIMD.Float32x4.fromInt32x4Bits(nMask);
   equal(-9.0, n.x);
   equal(-10.0, n.y);
   equal(-11.0, n.z);
   equal(-12.0, n.w);
-  nMask = SIMD.int32x4.fromFloat32x4Bits(n);
-  nMask = SIMD.int32x4.xor(nMask, m); // flip sign.
-  n = SIMD.float32x4.fromInt32x4Bits(nMask);
+  nMask = SIMD.Int32x4.fromFloat32x4Bits(n);
+  nMask = SIMD.Int32x4.xor(nMask, m); // flip sign.
+  n = SIMD.Float32x4.fromInt32x4Bits(nMask);
   equal(9.0, n.x);
   equal(10.0, n.y);
   equal(11.0, n.z);
   equal(12.0, n.w);
   // Should stay unmodified across bit conversions
-  m = SIMD.int32x4(0xFFFFFFFF, 0xFFFF0000, 0x80000000, 0x0);
-  var m2 = SIMD.int32x4.fromFloat32x4Bits(SIMD.float32x4.fromInt32x4Bits(m));
+  m = SIMD.Int32x4(0xFFFFFFFF, 0xFFFF0000, 0x80000000, 0x0);
+  var m2 = SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.fromInt32x4Bits(m));
   equal(m.x, m2.x);
   equal(m.y, m2.y);
   equal(m.z, m2.z);
   equal(m.w, m2.w);
 });
 
-test('float32x4 comparisons', function() {
-  var m = SIMD.float32x4(1.0, 2.0, 0.1, 0.001);
-  var n = SIMD.float32x4(2.0, 2.0, 0.001, 0.1);
+test('Float32x4 comparisons', function() {
+  var m = SIMD.Float32x4(1.0, 2.0, 0.1, 0.001);
+  var n = SIMD.Float32x4(2.0, 2.0, 0.001, 0.1);
   var cmp;
-  cmp = SIMD.float32x4.lessThan(m, n);
+  cmp = SIMD.Float32x4.lessThan(m, n);
   equal(-1, cmp.x);
   equal(0x0, cmp.y);
   equal(0x0, cmp.z);
   equal(-1, cmp.w);
 
-  cmp = SIMD.float32x4.lessThanOrEqual(m, n);
+  cmp = SIMD.Float32x4.lessThanOrEqual(m, n);
   equal(-1, cmp.x);
   equal(-1, cmp.y);
   equal(0x0, cmp.z);
   equal(-1, cmp.w);
 
-  cmp = SIMD.float32x4.equal(m, n);
+  cmp = SIMD.Float32x4.equal(m, n);
   equal(0x0, cmp.x);
   equal(-1, cmp.y);
   equal(0x0, cmp.z);
   equal(0x0, cmp.w);
 
-  cmp = SIMD.float32x4.notEqual(m, n);
+  cmp = SIMD.Float32x4.notEqual(m, n);
   equal(-1, cmp.x);
   equal(0x0, cmp.y);
   equal(-1, cmp.z);
   equal(-1, cmp.w);
 
-  cmp = SIMD.float32x4.greaterThanOrEqual(m, n);
+  cmp = SIMD.Float32x4.greaterThanOrEqual(m, n);
   equal(0x0, cmp.x);
   equal(-1, cmp.y);
   equal(-1, cmp.z);
   equal(0x0, cmp.w);
 
-  cmp = SIMD.float32x4.greaterThan(m, n);
+  cmp = SIMD.Float32x4.greaterThan(m, n);
   equal(0x0, cmp.x);
   equal(0x0, cmp.y);
   equal(-1, cmp.z);
   equal(0x0, cmp.w);
 });
 
-test('int32x4 select', function() {
-  var m = SIMD.int32x4.bool(true, true, false, false);
-  var t = SIMD.int32x4(1, 2, 3, 4);
-  var f = SIMD.int32x4(5, 6, 7, 8);
-  var s = SIMD.int32x4.select(m, t, f);
+test('Int32x4 select', function() {
+  var m = SIMD.Int32x4.bool(true, true, false, false);
+  var t = SIMD.Int32x4(1, 2, 3, 4);
+  var f = SIMD.Int32x4(5, 6, 7, 8);
+  var s = SIMD.Int32x4.select(m, t, f);
   equal(1, s.x);
   equal(2, s.y);
   equal(7, s.z);
   equal(8, s.w);
 });
 
-test('int32x4 withX', function() {
-    var a = SIMD.int32x4(1, 2, 3, 4);
-    var c = SIMD.int32x4.withX(a, 20);
+test('Int32x4 withX', function() {
+    var a = SIMD.Int32x4(1, 2, 3, 4);
+    var c = SIMD.Int32x4.withX(a, 20);
     equal(20, c.x);
     equal(2, c.y);
     equal(3, c.z);
     equal(4, c.w);
 });
 
-test('int32x4 withY', function() {
-    var a = SIMD.int32x4(1, 2, 3, 4);
-    var c = SIMD.int32x4.withY(a, 20);
+test('Int32x4 withY', function() {
+    var a = SIMD.Int32x4(1, 2, 3, 4);
+    var c = SIMD.Int32x4.withY(a, 20);
     equal(1, c.x);
     equal(20, c.y);
     equal(3, c.z);
     equal(4, c.w);
 });
 
-test('int32x4 withZ', function() {
-    var a = SIMD.int32x4(1, 2, 3, 4);
-    var c = SIMD.int32x4.withZ(a, 20);
+test('Int32x4 withZ', function() {
+    var a = SIMD.Int32x4(1, 2, 3, 4);
+    var c = SIMD.Int32x4.withZ(a, 20);
     equal(1, c.x);
     equal(2, c.y);
     equal(20, c.z);
     equal(4, c.w);
 });
 
-test('int32x4 withW', function() {
-    var a = SIMD.int32x4(1, 2, 3, 4);
-    var c = SIMD.int32x4.withW(a, 20);
+test('Int32x4 withW', function() {
+    var a = SIMD.Int32x4(1, 2, 3, 4);
+    var c = SIMD.Int32x4.withW(a, 20);
     equal(1, c.x);
     equal(2, c.y);
     equal(3, c.z);
     equal(20, c.w);
 });
 
-test('int32x4 withFlagX', function() {
-    var a = SIMD.int32x4.bool(true, false, true, false);
-    var c = SIMD.int32x4.withFlagX(a, true);
+test('Int32x4 withFlagX', function() {
+    var a = SIMD.Int32x4.bool(true, false, true, false);
+    var c = SIMD.Int32x4.withFlagX(a, true);
     equal(true, c.flagX);
     equal(false, c.flagY);
     equal(true, c.flagZ);
     equal(false, c.flagW);
-    c = SIMD.int32x4.withFlagX(a, false);
+    c = SIMD.Int32x4.withFlagX(a, false);
     equal(false, c.flagX);
     equal(false, c.flagY);
     equal(true, c.flagZ);
@@ -420,14 +420,14 @@ test('int32x4 withFlagX', function() {
     equal(0x0, c.w);
 });
 
-test('int32x4 withFlagY', function() {
-    var a = SIMD.int32x4.bool(true, false, true, false);
-    var c = SIMD.int32x4.withFlagY(a, true);
+test('Int32x4 withFlagY', function() {
+    var a = SIMD.Int32x4.bool(true, false, true, false);
+    var c = SIMD.Int32x4.withFlagY(a, true);
     equal(true, c.flagX);
     equal(true, c.flagY);
     equal(true, c.flagZ);
     equal(false, c.flagW);
-    c = SIMD.int32x4.withFlagY(a, false);
+    c = SIMD.Int32x4.withFlagY(a, false);
     equal(true, c.flagX);
     equal(false, c.flagY);
     equal(true, c.flagZ);
@@ -438,15 +438,15 @@ test('int32x4 withFlagY', function() {
     equal(0x0, c.w);
 });
 
-test('int32x4 withFlagZ', function() {
-    var a = SIMD.int32x4.bool(true, false, true, false);
-    var c = SIMD.int32x4.withFlagZ(a, true);
+test('Int32x4 withFlagZ', function() {
+    var a = SIMD.Int32x4.bool(true, false, true, false);
+    var c = SIMD.Int32x4.withFlagZ(a, true);
     equal(-1, c.x);
     equal(true, c.flagX);
     equal(false, c.flagY);
     equal(true, c.flagZ);
     equal(false, c.flagW);
-    c = SIMD.int32x4.withFlagZ(a, false);
+    c = SIMD.Int32x4.withFlagZ(a, false);
     equal(true, c.flagX);
     equal(false, c.flagY);
     equal(false, c.flagZ);
@@ -457,14 +457,14 @@ test('int32x4 withFlagZ', function() {
     equal(0x0, c.w);
 });
 
-test('int32x4 withFlagW', function() {
-    var a = SIMD.int32x4.bool(true, false, true, false);
-    var c = SIMD.int32x4.withFlagW(a, true);
+test('Int32x4 withFlagW', function() {
+    var a = SIMD.Int32x4.bool(true, false, true, false);
+    var c = SIMD.Int32x4.withFlagW(a, true);
     equal(true, c.flagX);
     equal(false, c.flagY);
     equal(true, c.flagZ);
     equal(true, c.flagW);
-    c = SIMD.int32x4.withFlagW(a, false);
+    c = SIMD.Int32x4.withFlagW(a, false);
     equal(true, c.flagX);
     equal(false, c.flagY);
     equal(true, c.flagZ);
@@ -475,9 +475,9 @@ test('int32x4 withFlagW', function() {
     equal(0x0, c.w);
 });
 
-test('int32x4 and', function() {
-  var m = SIMD.int32x4(0xAAAAAAAA, 0xAAAAAAAA, -1431655766, 0xAAAAAAAA);
-  var n = SIMD.int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
+test('Int32x4 and', function() {
+  var m = SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, -1431655766, 0xAAAAAAAA);
+  var n = SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
   equal(-1431655766, m.x);
   equal(-1431655766, m.y);
   equal(-1431655766, m.z);
@@ -490,7 +490,7 @@ test('int32x4 and', function() {
   equal(true, n.flagY);
   equal(true, n.flagZ);
   equal(true, n.flagW);
-  var o = SIMD.int32x4.and(m,n);  // and
+  var o = SIMD.Int32x4.and(m,n);  // and
   equal(0x0, o.x);
   equal(0x0, o.y);
   equal(0x0, o.z);
@@ -501,10 +501,10 @@ test('int32x4 and', function() {
   equal(false, o.flagW);
 });
 
-test('int32x4 or', function() {
-  var m = SIMD.int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA);
-  var n = SIMD.int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
-  var o = SIMD.int32x4.or(m,n);  // or
+test('Int32x4 or', function() {
+  var m = SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA);
+  var n = SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
+  var o = SIMD.Int32x4.or(m,n);  // or
   equal(-1, o.x);
   equal(-1, o.y);
   equal(-1, o.z);
@@ -515,18 +515,18 @@ test('int32x4 or', function() {
   equal(true, o.flagW);
 });
 
-test('int32x4 xor', function() {
-  var m = SIMD.int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA);
-  var n = SIMD.int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
-  n = SIMD.int32x4.withX(n, 0xAAAAAAAA);
-  n = SIMD.int32x4.withY(n, 0xAAAAAAAA);
-  n = SIMD.int32x4.withZ(n, 0xAAAAAAAA);
-  n = SIMD.int32x4.withW(n, 0xAAAAAAAA);
+test('Int32x4 xor', function() {
+  var m = SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA);
+  var n = SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
+  n = SIMD.Int32x4.withX(n, 0xAAAAAAAA);
+  n = SIMD.Int32x4.withY(n, 0xAAAAAAAA);
+  n = SIMD.Int32x4.withZ(n, 0xAAAAAAAA);
+  n = SIMD.Int32x4.withW(n, 0xAAAAAAAA);
   equal(-1431655766, n.x);
   equal(-1431655766, n.y);
   equal(-1431655766, n.z);
   equal(-1431655766, n.w);
-  var o = SIMD.int32x4.xor(m,n);  // xor
+  var o = SIMD.Int32x4.xor(m,n);  // xor
   equal(0x0, o.x);
   equal(0x0, o.y);
   equal(0x0, o.z);
@@ -537,11 +537,11 @@ test('int32x4 xor', function() {
   equal(false, o.flagW);
 });
 
-test('int32x4 neg', function() {
-  var m = SIMD.int32x4(16, 32, 64, 128);
-  var n = SIMD.int32x4(-1, -2, -3, -4);
-  m = SIMD.int32x4.neg(m);
-  n = SIMD.int32x4.neg(n);
+test('Int32x4 neg', function() {
+  var m = SIMD.Int32x4(16, 32, 64, 128);
+  var n = SIMD.Int32x4(-1, -2, -3, -4);
+  m = SIMD.Int32x4.neg(m);
+  n = SIMD.Int32x4.neg(n);
   equal(-16, m.x);
   equal(-32, m.y);
   equal(-64, m.z);
@@ -552,40 +552,40 @@ test('int32x4 neg', function() {
   equal(4, n.w);
 });
 
-test('int32x4 signMask getter', function() {
-  var a = SIMD.int32x4(0x80000000, 0x7000000, 0xFFFFFFFF, 0x0);
+test('Int32x4 signMask getter', function() {
+  var a = SIMD.Int32x4(0x80000000, 0x7000000, 0xFFFFFFFF, 0x0);
   equal(0x5, a.signMask);
-  var b = SIMD.int32x4(0x0, 0x0, 0x0, 0x0);
+  var b = SIMD.Int32x4(0x0, 0x0, 0x0, 0x0);
   equal(0x0, b.signMask);
-  var c = SIMD.int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF);
+  var c = SIMD.Int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF);
   equal(0xf, c.signMask);
 });
 
 
-test('int32x4 add', function() {
-  var a = SIMD.int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x7fffffff, 0x0);
-  var b = SIMD.int32x4(0x1, 0xFFFFFFFF, 0x1, 0xFFFFFFFF);
-  var c = SIMD.int32x4.add(a, b);
+test('Int32x4 add', function() {
+  var a = SIMD.Int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x7fffffff, 0x0);
+  var b = SIMD.Int32x4(0x1, 0xFFFFFFFF, 0x1, 0xFFFFFFFF);
+  var c = SIMD.Int32x4.add(a, b);
   equal(0x0, c.x);
   equal(-2, c.y);
   equal(-0x80000000, c.z);
   equal(-1, c.w);
 });
 
-test('int32x4 sub', function() {
-  var a = SIMD.int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x80000000, 0x0);
-  var b = SIMD.int32x4(0x1, 0xFFFFFFFF, 0x1, 0xFFFFFFFF);
-  var c = SIMD.int32x4.sub(a, b);
+test('Int32x4 sub', function() {
+  var a = SIMD.Int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x80000000, 0x0);
+  var b = SIMD.Int32x4(0x1, 0xFFFFFFFF, 0x1, 0xFFFFFFFF);
+  var c = SIMD.Int32x4.sub(a, b);
   equal(-2, c.x);
   equal(0x0, c.y);
   equal(0x7FFFFFFF, c.z);
   equal(0x1, c.w);
 });
 
-test('int32x4 mul', function() {
-  var a = SIMD.int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x80000000, 0x0);
-  var b = SIMD.int32x4(0x1, 0xFFFFFFFF, 0x80000000, 0xFFFFFFFF);
-  var c = SIMD.int32x4.mul(a, b);
+test('Int32x4 mul', function() {
+  var a = SIMD.Int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x80000000, 0x0);
+  var b = SIMD.Int32x4(0x1, 0xFFFFFFFF, 0x80000000, 0xFFFFFFFF);
+  var c = SIMD.Int32x4.mul(a, b);
   equal(-1, c.x);
   equal(0x1, c.y);
   equal(0x0, c.z);
@@ -611,10 +611,10 @@ test('Float32x4Array simple', function() {
 
 test('Float32x4Array set and get', function() {
   var a = new Float32x4Array(4);
-  a.setAt(0, SIMD.float32x4(1, 2, 3, 4));
-  a.setAt(1, SIMD.float32x4(5, 6, 7, 8));
-  a.setAt(2, SIMD.float32x4(9, 10, 11, 12));
-  a.setAt(3, SIMD.float32x4(13, 14, 15, 16));
+  a.setAt(0, SIMD.Float32x4(1, 2, 3, 4));
+  a.setAt(1, SIMD.Float32x4(5, 6, 7, 8));
+  a.setAt(2, SIMD.Float32x4(9, 10, 11, 12));
+  a.setAt(3, SIMD.Float32x4(13, 14, 15, 16));
   equal(a.getAt(0).x, 1);
   equal(a.getAt(0).y, 2);
   equal(a.getAt(0).z, 3);
@@ -638,10 +638,10 @@ test('Float32x4Array set and get', function() {
 
 test('Float32x4Array swap', function() {
   var a = new Float32x4Array(4);
-  a.setAt(0, SIMD.float32x4(1, 2, 3, 4));
-  a.setAt(1, SIMD.float32x4(5, 6, 7, 8));
-  a.setAt(2, SIMD.float32x4(9, 10, 11, 12));
-  a.setAt(3, SIMD.float32x4(13, 14, 15, 16));
+  a.setAt(0, SIMD.Float32x4(1, 2, 3, 4));
+  a.setAt(1, SIMD.Float32x4(5, 6, 7, 8));
+  a.setAt(2, SIMD.Float32x4(9, 10, 11, 12));
+  a.setAt(3, SIMD.Float32x4(13, 14, 15, 16));
 
   // Swap element 0 and element 3
   var t = a.getAt(0);
@@ -671,10 +671,10 @@ test('Float32x4Array swap', function() {
 
 test('Float32x4Array copy', function() {
   var a = new Float32x4Array(4);
-  a.setAt(0, SIMD.float32x4(1, 2, 3, 4));
-  a.setAt(1, SIMD.float32x4(5, 6, 7, 8));
-  a.setAt(2, SIMD.float32x4(9, 10, 11, 12));
-  a.setAt(3, SIMD.float32x4(13, 14, 15, 16));
+  a.setAt(0, SIMD.Float32x4(1, 2, 3, 4));
+  a.setAt(1, SIMD.Float32x4(5, 6, 7, 8));
+  a.setAt(2, SIMD.Float32x4(9, 10, 11, 12));
+  a.setAt(3, SIMD.Float32x4(13, 14, 15, 16));
   var b = new Float32x4Array(a);
   equal(a.getAt(0).x, b.getAt(0).x);
   equal(a.getAt(0).y, b.getAt(0).y);
@@ -696,7 +696,7 @@ test('Float32x4Array copy', function() {
   equal(a.getAt(3).z, b.getAt(3).z);
   equal(a.getAt(3).w, b.getAt(3).w);
 
-  a.setAt(2, SIMD.float32x4(17, 18, 19, 20));
+  a.setAt(2, SIMD.Float32x4(17, 18, 19, 20));
 
   equal(a.getAt(2).x, 17);
   equal(a.getAt(2).y, 18);
@@ -821,10 +821,10 @@ test('Float32x4Array exceptions', function () {
 
 test('View on Float32x4Array', function() {
   var a = new Float32x4Array(4);
-  a.setAt(0, SIMD.float32x4(1, 2, 3, 4));
-  a.setAt(1, SIMD.float32x4(5, 6, 7, 8));
-  a.setAt(2, SIMD.float32x4(9, 10, 11, 12));
-  a.setAt(3, SIMD.float32x4(13, 14, 15, 16));
+  a.setAt(0, SIMD.Float32x4(1, 2, 3, 4));
+  a.setAt(1, SIMD.Float32x4(5, 6, 7, 8));
+  a.setAt(2, SIMD.Float32x4(9, 10, 11, 12));
+  a.setAt(3, SIMD.Float32x4(13, 14, 15, 16));
   equal(a.getAt(0).x, 1);
   equal(a.getAt(0).y, 2);
   equal(a.getAt(0).z, 3);
@@ -874,87 +874,87 @@ test('View on Float32x4Array', function() {
   equal(a.getAt(3).w, 16);
 });
 
-test('int32x4 shiftLeftByScalar', function() {
-  var a = SIMD.int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
+test('Int32x4 shiftLeftByScalar', function() {
+  var a = SIMD.Int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
   var b;
-  b = SIMD.int32x4.shiftLeftByScalar(a, 1);
+  b = SIMD.Int32x4.shiftLeftByScalar(a, 1);
   equal(b.x, 0xfffffffe|0);
   equal(b.y, 0xfffffffe|0);
   equal(b.z, 0x00000002);
   equal(b.w, 0x00000000);
-  b = SIMD.int32x4.shiftLeftByScalar(a, 2);
+  b = SIMD.Int32x4.shiftLeftByScalar(a, 2);
   equal(b.x, 0xfffffffc|0);
   equal(b.y, 0xfffffffc|0);
   equal(b.z, 0x00000004);
   equal(b.w, 0x00000000);
-  b = SIMD.int32x4.shiftLeftByScalar(a, 30);
+  b = SIMD.Int32x4.shiftLeftByScalar(a, 30);
   equal(b.x, 0xc0000000|0);
   equal(b.y, 0xc0000000|0);
   equal(b.z, 0x40000000);
   equal(b.w, 0x00000000);
-  b = SIMD.int32x4.shiftLeftByScalar(a, 31);
+  b = SIMD.Int32x4.shiftLeftByScalar(a, 31);
   equal(b.x, 0x80000000|0);
   equal(b.y, 0x80000000|0);
   equal(b.z, 0x80000000|0);
   equal(b.w, 0x0);
 });
 
-test('int32x4 shiftRightLogicalByScalar', function() {
-  var a = SIMD.int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
+test('Int32x4 shiftRightLogicalByScalar', function() {
+  var a = SIMD.Int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
   var b;
-  b = SIMD.int32x4.shiftRightLogicalByScalar(a, 1);
+  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 1);
   equal(b.x, 0x7fffffff);
   equal(b.y, 0x3fffffff);
   equal(b.z, 0x00000000);
   equal(b.w, 0x00000000);
-  b = SIMD.int32x4.shiftRightLogicalByScalar(a, 2);
+  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 2);
   equal(b.x, 0x3fffffff);
   equal(b.y, 0x1fffffff);
   equal(b.z, 0x00000000);
   equal(b.w, 0x00000000);
-  b = SIMD.int32x4.shiftRightLogicalByScalar(a, 30);
+  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 30);
   equal(b.x, 0x00000003);
   equal(b.y, 0x00000001);
   equal(b.z, 0x00000000);
   equal(b.w, 0x00000000);
-  b = SIMD.int32x4.shiftRightLogicalByScalar(a, 31);
+  b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 31);
   equal(b.x, 0x00000001);
   equal(b.y, 0x00000000);
   equal(b.z, 0x00000000);
   equal(b.w, 0x00000000);
 });
 
-test('int32x4 shiftRightArithmeticByScalar', function() {
-  var a = SIMD.int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
+test('Int32x4 shiftRightArithmeticByScalar', function() {
+  var a = SIMD.Int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
   var b;
-  b = SIMD.int32x4.shiftRightArithmeticByScalar(a, 1);
+  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 1);
   equal(b.x, 0xffffffff|0);
   equal(b.y, 0x3fffffff);
   equal(b.z, 0x00000000);
   equal(b.w, 0x00000000);
-  b = SIMD.int32x4.shiftRightArithmeticByScalar(a, 2);
+  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 2);
   equal(b.x, 0xffffffff|0);
   equal(b.y, 0x1fffffff);
   equal(b.z, 0x00000000);
   equal(b.w, 0x00000000);
-  b = SIMD.int32x4.shiftRightArithmeticByScalar(a, 30);
+  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 30);
   equal(b.x, 0xffffffff|0);
   equal(b.y, 0x00000001);
   equal(b.z, 0x00000000);
   equal(b.w, 0x00000000);
-  b = SIMD.int32x4.shiftRightArithmeticByScalar(a, 31);
+  b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 31);
   equal(b.x, 0xffffffff|0);
   equal(b.y, 0x00000000);
   equal(b.z, 0x00000000);
   equal(b.w, 0x00000000);
 });
 
-test('float32x4 shuffle', function() {
-  var a = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  var b = SIMD.float32x4(5.0, 6.0, 7.0, 8.0);
-  var xyxy = SIMD.float32x4.shuffle(a, b, 0, 1, 4, 5);
-  var zwzw = SIMD.float32x4.shuffle(a, b, 2, 3, 6, 7);
-  var xxxx = SIMD.float32x4.shuffle(a, b, 0, 0, 4, 4);
+test('Float32x4 shuffle', function() {
+  var a = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  var b = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
+  var xyxy = SIMD.Float32x4.shuffle(a, b, 0, 1, 4, 5);
+  var zwzw = SIMD.Float32x4.shuffle(a, b, 2, 3, 6, 7);
+  var xxxx = SIMD.Float32x4.shuffle(a, b, 0, 0, 4, 4);
   equal(1.0, xyxy.x);
   equal(2.0, xyxy.y);
   equal(5.0, xyxy.z);
@@ -967,9 +967,9 @@ test('float32x4 shuffle', function() {
   equal(1.0, xxxx.y);
   equal(5.0, xxxx.z);
   equal(5.0, xxxx.w);
-  var c = SIMD.float32x4.shuffle(a, b, 0, 4, 5, 1);
-  var d = SIMD.float32x4.shuffle(a, b, 2, 6, 3, 7);
-  var e = SIMD.float32x4.shuffle(a, b, 0, 4, 0, 4);
+  var c = SIMD.Float32x4.shuffle(a, b, 0, 4, 5, 1);
+  var d = SIMD.Float32x4.shuffle(a, b, 2, 6, 3, 7);
+  var e = SIMD.Float32x4.shuffle(a, b, 0, 4, 0, 4);
   equal(1.0, c.x);
   equal(5.0, c.y);
   equal(6.0, c.z);
@@ -984,12 +984,12 @@ test('float32x4 shuffle', function() {
   equal(5.0, e.w);
 });
 
-test('float64x2 swizzle', function() {
-  var a = SIMD.float64x2(1.0, 2.0);
-  var xx = SIMD.float64x2.swizzle(a, 0, 0);
-  var xy = SIMD.float64x2.swizzle(a, 0, 1);
-  var yx = SIMD.float64x2.swizzle(a, 1, 0);
-  var yy = SIMD.float64x2.swizzle(a, 1, 1);
+test('Float64x2 swizzle', function() {
+  var a = SIMD.Float64x2(1.0, 2.0);
+  var xx = SIMD.Float64x2.swizzle(a, 0, 0);
+  var xy = SIMD.Float64x2.swizzle(a, 0, 1);
+  var yx = SIMD.Float64x2.swizzle(a, 1, 0);
+  var yy = SIMD.Float64x2.swizzle(a, 1, 1);
   equal(1.0, xx.x);
   equal(1.0, xx.y);
   equal(1.0, xy.x);
@@ -1000,13 +1000,13 @@ test('float64x2 swizzle', function() {
   equal(2.0, yy.y);
 });
 
-test('float64x2 shuffle', function() {
-  var a = SIMD.float64x2(1.0, 2.0);
-  var b = SIMD.float64x2(3.0, 4.0);
-  var xx = SIMD.float64x2.shuffle(a, b, 0, 2);
-  var xy = SIMD.float64x2.shuffle(a, b, 0, 3);
-  var yx = SIMD.float64x2.shuffle(a, b, 1, 0);
-  var yy = SIMD.float64x2.shuffle(a, b, 1, 3);
+test('Float64x2 shuffle', function() {
+  var a = SIMD.Float64x2(1.0, 2.0);
+  var b = SIMD.Float64x2(3.0, 4.0);
+  var xx = SIMD.Float64x2.shuffle(a, b, 0, 2);
+  var xy = SIMD.Float64x2.shuffle(a, b, 0, 3);
+  var yx = SIMD.Float64x2.shuffle(a, b, 1, 0);
+  var yy = SIMD.Float64x2.shuffle(a, b, 1, 3);
   equal(1.0, xx.x);
   equal(3.0, xx.y);
   equal(1.0, xy.x);
@@ -1015,10 +1015,10 @@ test('float64x2 shuffle', function() {
   equal(1.0, yx.y);
   equal(2.0, yy.x);
   equal(4.0, yy.y);
-  var c = SIMD.float64x2.shuffle(a, b, 1, 0);
-  var d = SIMD.float64x2.shuffle(a, b, 3, 2);
-  var e = SIMD.float64x2.shuffle(a, b, 0, 1);
-  var f = SIMD.float64x2.shuffle(a, b, 0, 2);
+  var c = SIMD.Float64x2.shuffle(a, b, 1, 0);
+  var d = SIMD.Float64x2.shuffle(a, b, 3, 2);
+  var e = SIMD.Float64x2.shuffle(a, b, 0, 1);
+  var f = SIMD.Float64x2.shuffle(a, b, 0, 2);
   equal(2.0, c.x);
   equal(1.0, c.y);
   equal(4.0, d.x);
@@ -1029,12 +1029,12 @@ test('float64x2 shuffle', function() {
   equal(3.0, f.y);
 });
 
-test('int32x4 shuffle', function() {
-  var a = SIMD.int32x4(1, 2, 3, 4);
-  var b = SIMD.int32x4(5, 6, 7, 8);
-  var xyxy = SIMD.int32x4.shuffle(a, b, 0, 1, 4, 5);
-  var zwzw = SIMD.int32x4.shuffle(a, b, 2, 3, 6, 7);
-  var xxxx = SIMD.int32x4.shuffle(a, b, 0, 0, 4, 4);
+test('Int32x4 shuffle', function() {
+  var a = SIMD.Int32x4(1, 2, 3, 4);
+  var b = SIMD.Int32x4(5, 6, 7, 8);
+  var xyxy = SIMD.Int32x4.shuffle(a, b, 0, 1, 4, 5);
+  var zwzw = SIMD.Int32x4.shuffle(a, b, 2, 3, 6, 7);
+  var xxxx = SIMD.Int32x4.shuffle(a, b, 0, 0, 4, 4);
   equal(1, xyxy.x);
   equal(2, xyxy.y);
   equal(5, xyxy.z);
@@ -1047,9 +1047,9 @@ test('int32x4 shuffle', function() {
   equal(1, xxxx.y);
   equal(5, xxxx.z);
   equal(5, xxxx.w);
-  var c = SIMD.int32x4.shuffle(a, b, 0, 4, 5, 1);
-  var d = SIMD.int32x4.shuffle(a, b, 2, 6, 3, 7);
-  var e = SIMD.int32x4.shuffle(a, b, 0, 4, 0, 4);
+  var c = SIMD.Int32x4.shuffle(a, b, 0, 4, 5, 1);
+  var d = SIMD.Int32x4.shuffle(a, b, 2, 6, 3, 7);
+  var e = SIMD.Int32x4.shuffle(a, b, 0, 4, 0, 4);
   equal(1, c.x);
   equal(5, c.y);
   equal(6, c.z);
@@ -1064,13 +1064,13 @@ test('int32x4 shuffle', function() {
   equal(5, e.w);
 });
 
-test('int32x4 vector getters', function() {
-  var a = SIMD.int32x4(4, 3, 2, 1);
-  var xxxx = SIMD.int32x4.swizzle(a, 0, 0, 0, 0);
-  var yyyy = SIMD.int32x4.swizzle(a, 1, 1, 1, 1);
-  var zzzz = SIMD.int32x4.swizzle(a, 2, 2, 2, 2);
-  var wwww = SIMD.int32x4.swizzle(a, 3, 3, 3, 3);
-  var wzyx = SIMD.int32x4.swizzle(a, 3, 2, 1, 0);
+test('Int32x4 vector getters', function() {
+  var a = SIMD.Int32x4(4, 3, 2, 1);
+  var xxxx = SIMD.Int32x4.swizzle(a, 0, 0, 0, 0);
+  var yyyy = SIMD.Int32x4.swizzle(a, 1, 1, 1, 1);
+  var zzzz = SIMD.Int32x4.swizzle(a, 2, 2, 2, 2);
+  var wwww = SIMD.Int32x4.swizzle(a, 3, 3, 3, 3);
+  var wzyx = SIMD.Int32x4.swizzle(a, 3, 2, 1, 0);
   equal(4, xxxx.x);
   equal(4, xxxx.y);
   equal(4, xxxx.z);

--- a/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/float32x4array.js
+++ b/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/float32x4array.js
@@ -113,7 +113,7 @@ Float32x4Array.prototype.getAt = function(i) {
   var y = this.storage_[i*4+1];
   var z = this.storage_[i*4+2];
   var w = this.storage_[i*4+3];
-  return SIMD.float32x4(x, y, z, w);
+  return SIMD.Float32x4(x, y, z, w);
 }
 
 Float32x4Array.prototype.setAt = function(i, v) {
@@ -123,8 +123,8 @@ Float32x4Array.prototype.setAt = function(i, v) {
   if (i >= this.length) {
     throw "Index out of bounds.";
   }
-  if (!(v instanceof SIMD.float32x4)) {
-    throw "Value is not a float32x4.";
+  if (!(v instanceof SIMD.Float32x4)) {
+    throw "Value is not a Float32x4.";
   }
   this.storage_[i*4+0] = v.x;
   this.storage_[i*4+1] = v.y;

--- a/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/int32x4array.js
+++ b/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/int32x4array.js
@@ -115,7 +115,7 @@ Int32x4Array.prototype.getAt = function(i) {
   var y = this.storage_[i*4+1];
   var z = this.storage_[i*4+2];
   var w = this.storage_[i*4+3];
-  return SIMD.int32x4(x, y, z, w);
+  return SIMD.Int32x4(x, y, z, w);
 }
 
 Int32x4Array.prototype.setAt = function(i, v) {
@@ -125,8 +125,8 @@ Int32x4Array.prototype.setAt = function(i, v) {
   if (i >= this.length) {
     throw "Index out of bounds.";
   }
-  if (!(v instanceof SIMD.int32x4)) {
-    throw "Value is not a int32x4.";
+  if (!(v instanceof SIMD.Int32x4)) {
+    throw "Value is not a Int32x4.";
   }
   this.storage_[i*4+0] = v.x;
   this.storage_[i*4+1] = v.y;

--- a/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html
+++ b/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>SIMD Test: float64x2</title>
+<title>SIMD Test: Float64x2</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="help" href="https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md">
 <link rel="stylesheet" href="external/qunit.css">
@@ -40,13 +40,13 @@ Authors:
 <div id="qunit-fixture"></div>
 <script>
 
-test('float32x4 load', function() {
+test('Float32x4 load', function() {
   var a = new Float32Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 3; i++) {
-    var v = SIMD.float32x4.load(a, i);
+    var v = SIMD.Float32x4.load(a, i);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(i+2, v.z);
@@ -54,7 +54,7 @@ test('float32x4 load', function() {
   }
 });
 
-test('float32x4 overaligned load', function() {
+test('Float32x4 overaligned load', function() {
   var b = new ArrayBuffer(40);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -62,7 +62,7 @@ test('float32x4 overaligned load', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 3; i += 2) {
-    var v = SIMD.float32x4.load(af, i / 2);
+    var v = SIMD.Float32x4.load(af, i / 2);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(i+2, v.z);
@@ -71,7 +71,7 @@ test('float32x4 overaligned load', function() {
 });
 
 
-test('float32x4 unaligned load', function() {
+test('Float32x4 unaligned load', function() {
   var a = new Float32Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -84,7 +84,7 @@ test('float32x4 unaligned load', function() {
   }
   // Load the values unaligned.
   for (var i = 0; i < a.length - 3; i++) {
-    var v = SIMD.float32x4.load(b, i * 4 + 1);
+    var v = SIMD.Float32x4.load(b, i * 4 + 1);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(i+2, v.z);
@@ -92,13 +92,13 @@ test('float32x4 unaligned load', function() {
   }
 });
 
-test('float32x4 loadX', function() {
+test('Float32x4 loadX', function() {
   var a = new Float32Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length; i++) {
-    var v = SIMD.float32x4.loadX(a, i);
+    var v = SIMD.Float32x4.loadX(a, i);
     equal(i, v.x);
     equal(0.0, v.y);
     equal(0.0, v.z);
@@ -106,7 +106,7 @@ test('float32x4 loadX', function() {
   }
 });
 
-test('float32x4 overaligned loadX', function() {
+test('Float32x4 overaligned loadX', function() {
   var b = new ArrayBuffer(40);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -114,7 +114,7 @@ test('float32x4 overaligned loadX', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length; i += 2) {
-    var v = SIMD.float32x4.loadX(af, i / 2);
+    var v = SIMD.Float32x4.loadX(af, i / 2);
     equal(i, v.x);
     equal(0.0, v.y);
     equal(0.0, v.z);
@@ -122,7 +122,7 @@ test('float32x4 overaligned loadX', function() {
   }
 });
 
-test('float32x4 unaligned loadX', function() {
+test('Float32x4 unaligned loadX', function() {
   var a = new Float32Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -135,7 +135,7 @@ test('float32x4 unaligned loadX', function() {
   }
   // Load the values unaligned.
   for (var i = 0; i < a.length; i++) {
-    var v = SIMD.float32x4.loadX(b, i * 4 + 1);
+    var v = SIMD.Float32x4.loadX(b, i * 4 + 1);
     equal(i, v.x);
     equal(0.0, v.y);
     equal(0.0, v.z);
@@ -143,13 +143,13 @@ test('float32x4 unaligned loadX', function() {
   }
 });
 
-test('float32x4 loadXY', function() {
+test('Float32x4 loadXY', function() {
   var a = new Float32Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.float32x4.loadXY(a, i);
+    var v = SIMD.Float32x4.loadXY(a, i);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(0.0, v.z);
@@ -157,7 +157,7 @@ test('float32x4 loadXY', function() {
   }
 });
 
-test('float32x4 overaligned loadXY', function() {
+test('Float32x4 overaligned loadXY', function() {
   var b = new ArrayBuffer(40);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -165,7 +165,7 @@ test('float32x4 overaligned loadXY', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 1; i += 2) {
-  var v = SIMD.float32x4.loadXY(af, i / 2);
+  var v = SIMD.Float32x4.loadXY(af, i / 2);
   equal(i, v.x);
   equal(i+1, v.y);
   equal(0.0, v.z);
@@ -173,7 +173,7 @@ test('float32x4 overaligned loadXY', function() {
 }
 });
 
-test('float32x4 unaligned loadXY', function() {
+test('Float32x4 unaligned loadXY', function() {
   var a = new Float32Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -186,7 +186,7 @@ test('float32x4 unaligned loadXY', function() {
   }
   // Load the values unaligned.
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.float32x4.loadXY(b, i * 4 + 1);
+    var v = SIMD.Float32x4.loadXY(b, i * 4 + 1);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(0.0, v.z);
@@ -194,13 +194,13 @@ test('float32x4 unaligned loadXY', function() {
   }
 });
 
-test('float32x4 loadXYZ', function() {
+test('Float32x4 loadXYZ', function() {
   var a = new Float32Array(9);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 2; i++) {
-    var v = SIMD.float32x4.loadXYZ(a, i);
+    var v = SIMD.Float32x4.loadXYZ(a, i);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(i+2, v.z);
@@ -208,7 +208,7 @@ test('float32x4 loadXYZ', function() {
   }
 });
 
-test('float32x4 overaligned loadXYZ', function() {
+test('Float32x4 overaligned loadXYZ', function() {
   var b = new ArrayBuffer(48);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -216,7 +216,7 @@ test('float32x4 overaligned loadXYZ', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 2; i += 2) {
-    var v = SIMD.float32x4.loadXYZ(af, i / 2);
+    var v = SIMD.Float32x4.loadXYZ(af, i / 2);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(i+2, v.z);
@@ -224,7 +224,7 @@ test('float32x4 overaligned loadXYZ', function() {
   }
 });
 
-test('float32x4 unaligned loadXYZ', function() {
+test('Float32x4 unaligned loadXYZ', function() {
   var a = new Float32Array(9);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -237,7 +237,7 @@ test('float32x4 unaligned loadXYZ', function() {
   }
   // Load the values unaligned.
   for (var i = 0; i < a.length - 2; i++) {
-    var v = SIMD.float32x4.loadXYZ(b, i * 4 + 1);
+    var v = SIMD.Float32x4.loadXYZ(b, i * 4 + 1);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(i+2, v.z);
@@ -245,33 +245,33 @@ test('float32x4 unaligned loadXYZ', function() {
   }
 });
 
-test('float32x4 store', function() {
+test('Float32x4 store', function() {
   var a = new Float32Array(12);
-  SIMD.float32x4.store(a, 0, SIMD.float32x4(0, 1, 2, 3));
-  SIMD.float32x4.store(a, 4, SIMD.float32x4(4, 5, 6, 7));
-  SIMD.float32x4.store(a, 8, SIMD.float32x4(8, 9, 10, 11));
+  SIMD.Float32x4.store(a, 0, SIMD.Float32x4(0, 1, 2, 3));
+  SIMD.Float32x4.store(a, 4, SIMD.Float32x4(4, 5, 6, 7));
+  SIMD.Float32x4.store(a, 8, SIMD.Float32x4(8, 9, 10, 11));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('float32x4 overaligned store', function() {
+test('Float32x4 overaligned store', function() {
   var b = new ArrayBuffer(56);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
-  SIMD.float32x4.store(af, 0, SIMD.float32x4(0, 1, 2, 3));
-  SIMD.float32x4.store(af, 2, SIMD.float32x4(4, 5, 6, 7));
-  SIMD.float32x4.store(af, 4, SIMD.float32x4(8, 9, 10, 11));
+  SIMD.Float32x4.store(af, 0, SIMD.Float32x4(0, 1, 2, 3));
+  SIMD.Float32x4.store(af, 2, SIMD.Float32x4(4, 5, 6, 7));
+  SIMD.Float32x4.store(af, 4, SIMD.Float32x4(8, 9, 10, 11));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('float32x4 unaligned store', function() {
+test('Float32x4 unaligned store', function() {
   var c = new Int8Array(48 + 1);
-  SIMD.float32x4.store(c, 0 + 1, SIMD.float32x4(0, 1, 2, 3));
-  SIMD.float32x4.store(c, 16 + 1, SIMD.float32x4(4, 5, 6, 7));
-  SIMD.float32x4.store(c, 32 + 1, SIMD.float32x4(8, 9, 10, 11));
+  SIMD.Float32x4.store(c, 0 + 1, SIMD.Float32x4(0, 1, 2, 3));
+  SIMD.Float32x4.store(c, 16 + 1, SIMD.Float32x4(4, 5, 6, 7));
+  SIMD.Float32x4.store(c, 32 + 1, SIMD.Float32x4(8, 9, 10, 11));
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
   for (var i = 1; i < c.length; i++) {
@@ -283,25 +283,25 @@ test('float32x4 unaligned store', function() {
   }
 });
 
-test('float32x4 storeX', function() {
+test('Float32x4 storeX', function() {
   var a = new Float32Array(4);
-  SIMD.float32x4.storeX(a, 0, SIMD.float32x4(0, -1, -1, -1));
-  SIMD.float32x4.storeX(a, 1, SIMD.float32x4(1, -1, -1, -1));
-  SIMD.float32x4.storeX(a, 2, SIMD.float32x4(2, -1, -1, -1));
-  SIMD.float32x4.storeX(a, 3, SIMD.float32x4(3, -1, -1, -1));
+  SIMD.Float32x4.storeX(a, 0, SIMD.Float32x4(0, -1, -1, -1));
+  SIMD.Float32x4.storeX(a, 1, SIMD.Float32x4(1, -1, -1, -1));
+  SIMD.Float32x4.storeX(a, 2, SIMD.Float32x4(2, -1, -1, -1));
+  SIMD.Float32x4.storeX(a, 3, SIMD.Float32x4(3, -1, -1, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('float32x4 overaligned storeX', function() {
+test('Float32x4 overaligned storeX', function() {
   var b = new ArrayBuffer(24);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
   a[1] = -2;
   a[3] = -2;
-  SIMD.float32x4.storeX(af, 0, SIMD.float32x4(0, -1, -1, -1));
-  SIMD.float32x4.storeX(af, 1, SIMD.float32x4(2, -1, -1, -1));
+  SIMD.Float32x4.storeX(af, 0, SIMD.Float32x4(0, -1, -1, -1));
+  SIMD.Float32x4.storeX(af, 1, SIMD.Float32x4(2, -1, -1, -1));
   for (var i = 0; i < a.length; i++) {
     if (i % 2 == 0) {
       equal(i, a[i]);
@@ -310,12 +310,12 @@ test('float32x4 overaligned storeX', function() {
     }
 }
 });
-test('float32x4 unaligned storeX', function() {
+test('Float32x4 unaligned storeX', function() {
   var c = new Int8Array(16 + 1);
-  SIMD.float32x4.storeX(c, 0 + 1, SIMD.float32x4(0, -1, -1, -1));
-  SIMD.float32x4.storeX(c, 4 + 1, SIMD.float32x4(1, -1, -1, -1));
-  SIMD.float32x4.storeX(c, 8 + 1, SIMD.float32x4(2, -1, -1, -1));
-  SIMD.float32x4.storeX(c, 12 + 1, SIMD.float32x4(3, -1, -1, -1));
+  SIMD.Float32x4.storeX(c, 0 + 1, SIMD.Float32x4(0, -1, -1, -1));
+  SIMD.Float32x4.storeX(c, 4 + 1, SIMD.Float32x4(1, -1, -1, -1));
+  SIMD.Float32x4.storeX(c, 8 + 1, SIMD.Float32x4(2, -1, -1, -1));
+  SIMD.Float32x4.storeX(c, 12 + 1, SIMD.Float32x4(3, -1, -1, -1));
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
   for (var i = 1; i < c.length; i++) {
@@ -327,36 +327,36 @@ test('float32x4 unaligned storeX', function() {
   }
 });
 
-test('float32x4 storeXY', function() {
+test('Float32x4 storeXY', function() {
   var a = new Float32Array(8);
-  SIMD.float32x4.storeXY(a, 0, SIMD.float32x4(0, 1, -1, -1));
-  SIMD.float32x4.storeXY(a, 2, SIMD.float32x4(2, 3, -1, -1));
-  SIMD.float32x4.storeXY(a, 4, SIMD.float32x4(4, 5, -1, -1));
-  SIMD.float32x4.storeXY(a, 6, SIMD.float32x4(6, 7, -1, -1));
+  SIMD.Float32x4.storeXY(a, 0, SIMD.Float32x4(0, 1, -1, -1));
+  SIMD.Float32x4.storeXY(a, 2, SIMD.Float32x4(2, 3, -1, -1));
+  SIMD.Float32x4.storeXY(a, 4, SIMD.Float32x4(4, 5, -1, -1));
+  SIMD.Float32x4.storeXY(a, 6, SIMD.Float32x4(6, 7, -1, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('float32x4 overaligned storeXY', function() {
+test('Float32x4 overaligned storeXY', function() {
   var b = new ArrayBuffer(40);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
-  SIMD.float32x4.storeXY(af, 0, SIMD.float32x4(0, 1, -1, -1));
-  SIMD.float32x4.storeXY(af, 1, SIMD.float32x4(2, 3, -1, -1));
-  SIMD.float32x4.storeXY(af, 2, SIMD.float32x4(4, 5, -1, -1));
-  SIMD.float32x4.storeXY(af, 3, SIMD.float32x4(6, 7, -1, -1));
+  SIMD.Float32x4.storeXY(af, 0, SIMD.Float32x4(0, 1, -1, -1));
+  SIMD.Float32x4.storeXY(af, 1, SIMD.Float32x4(2, 3, -1, -1));
+  SIMD.Float32x4.storeXY(af, 2, SIMD.Float32x4(4, 5, -1, -1));
+  SIMD.Float32x4.storeXY(af, 3, SIMD.Float32x4(6, 7, -1, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('float32x4 unaligned storeXY', function() {
+test('Float32x4 unaligned storeXY', function() {
   var c = new Int8Array(32 + 1);
-  SIMD.float32x4.storeXY(c, 0 + 1, SIMD.float32x4(0, 1, -1, -1));
-  SIMD.float32x4.storeXY(c, 8 + 1, SIMD.float32x4(2, 3, -1, -1));
-  SIMD.float32x4.storeXY(c, 16 + 1, SIMD.float32x4(4, 5, -1, -1));
-  SIMD.float32x4.storeXY(c, 24 + 1, SIMD.float32x4(6, 7, -1, -1));
+  SIMD.Float32x4.storeXY(c, 0 + 1, SIMD.Float32x4(0, 1, -1, -1));
+  SIMD.Float32x4.storeXY(c, 8 + 1, SIMD.Float32x4(2, 3, -1, -1));
+  SIMD.Float32x4.storeXY(c, 16 + 1, SIMD.Float32x4(4, 5, -1, -1));
+  SIMD.Float32x4.storeXY(c, 24 + 1, SIMD.Float32x4(6, 7, -1, -1));
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
   for (var i = 1; i < c.length; i++) {
@@ -368,26 +368,26 @@ test('float32x4 unaligned storeXY', function() {
   }
 });
 
-test('float32x4 storeXYZ', function() {
+test('Float32x4 storeXYZ', function() {
   var a = new Float32Array(9);
-  SIMD.float32x4.storeXYZ(a, 0, SIMD.float32x4(0, 1, 2, -1));
-  SIMD.float32x4.storeXYZ(a, 3, SIMD.float32x4(3, 4, 5, -1));
-  SIMD.float32x4.storeXYZ(a, 6, SIMD.float32x4(6, 7, 8, -1));
+  SIMD.Float32x4.storeXYZ(a, 0, SIMD.Float32x4(0, 1, 2, -1));
+  SIMD.Float32x4.storeXYZ(a, 3, SIMD.Float32x4(3, 4, 5, -1));
+  SIMD.Float32x4.storeXYZ(a, 6, SIMD.Float32x4(6, 7, 8, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('float32x4 overaligned storeXYZ', function() {
+test('Float32x4 overaligned storeXYZ', function() {
   var b = new ArrayBuffer(56);
   var a = new Float32Array(b, 8);
   var af = new Float64Array(b, 8);
   a[3] = -2;
   a[7] = -2;
   a[11] = -2;
-  SIMD.float32x4.storeXYZ(af, 0, SIMD.float32x4(0, 1, 2, -1));
-  SIMD.float32x4.storeXYZ(af, 2, SIMD.float32x4(4, 5, 6, -1));
-  SIMD.float32x4.storeXYZ(af, 4, SIMD.float32x4(8, 9, 10, -1));
+  SIMD.Float32x4.storeXYZ(af, 0, SIMD.Float32x4(0, 1, 2, -1));
+  SIMD.Float32x4.storeXYZ(af, 2, SIMD.Float32x4(4, 5, 6, -1));
+  SIMD.Float32x4.storeXYZ(af, 4, SIMD.Float32x4(8, 9, 10, -1));
   for (var i = 0; i < a.length; i++) {
     if (i % 4 != 3) {
       equal(i, a[i]);
@@ -397,11 +397,11 @@ test('float32x4 overaligned storeXYZ', function() {
   }
 });
 
-test('float32x4 unaligned storeXYZ', function() {
+test('Float32x4 unaligned storeXYZ', function() {
   var c = new Int8Array(36 + 1);
-  SIMD.float32x4.storeXYZ(c, 0 + 1, SIMD.float32x4(0, 1, 2, -1));
-  SIMD.float32x4.storeXYZ(c, 12 + 1, SIMD.float32x4(3, 4, 5, -1));
-  SIMD.float32x4.storeXYZ(c, 24 + 1, SIMD.float32x4(6, 7, 8, -1));
+  SIMD.Float32x4.storeXYZ(c, 0 + 1, SIMD.Float32x4(0, 1, 2, -1));
+  SIMD.Float32x4.storeXYZ(c, 12 + 1, SIMD.Float32x4(3, 4, 5, -1));
+  SIMD.Float32x4.storeXYZ(c, 24 + 1, SIMD.Float32x4(6, 7, 8, -1));
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
   for (var i = 1; i < c.length; i++) {
@@ -413,167 +413,167 @@ test('float32x4 unaligned storeXYZ', function() {
   }
 });
 
-test('float32x4 load exceptions', function () {
+test('Float32x4 load exceptions', function () {
   var a = new Float32Array(8);
   throws(function () {
-    var f = SIMD.float32x4.load(a, -1);
+    var f = SIMD.Float32x4.load(a, -1);
   });
   throws(function () {
-    var f = SIMD.float32x4.load(a, 5);
+    var f = SIMD.Float32x4.load(a, 5);
   });
   throws(function () {
-    var f = SIMD.float32x4.load(a.buffer, 1);
+    var f = SIMD.Float32x4.load(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.float32x4.load(a, "a");
+    var f = SIMD.Float32x4.load(a, "a");
   });
 });
 
-test('float32x4 loadX exceptions', function () {
+test('Float32x4 loadX exceptions', function () {
   var a = new Float32Array(8);
   throws(function () {
-    var f = SIMD.float32x4.loadX(a, -1);
+    var f = SIMD.Float32x4.loadX(a, -1);
   });
   throws(function () {
-    var f = SIMD.float32x4.loadX(a, 8);
+    var f = SIMD.Float32x4.loadX(a, 8);
   });
   throws(function () {
-    var f = SIMD.float32x4.loadX(a.buffer, 1);
+    var f = SIMD.Float32x4.loadX(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.float32x4.loadX(a, "a");
+    var f = SIMD.Float32x4.loadX(a, "a");
   });
 });
 
-test('float32x4 loadXY exceptions', function () {
+test('Float32x4 loadXY exceptions', function () {
   var a = new Float32Array(8);
   throws(function () {
-    var f = SIMD.float32x4.loadXY(a, -1);
+    var f = SIMD.Float32x4.loadXY(a, -1);
   });
   throws(function () {
-    var f = SIMD.float32x4.loadXY(a, 7);
+    var f = SIMD.Float32x4.loadXY(a, 7);
   });
   throws(function () {
-    var f = SIMD.float32x4.loadXY(a.buffer, 1);
+    var f = SIMD.Float32x4.loadXY(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.float32x4.loadXY(a, "a");
+    var f = SIMD.Float32x4.loadXY(a, "a");
   });
 });
 
-test('float32x4 loadXYZ exceptions', function () {
+test('Float32x4 loadXYZ exceptions', function () {
   var a = new Float32Array(8);
   throws(function () {
-    var f = SIMD.float32x4.loadXYZ(a, -1);
+    var f = SIMD.Float32x4.loadXYZ(a, -1);
   });
   throws(function () {
-    var f = SIMD.float32x4.loadXYZ(a, 6);
+    var f = SIMD.Float32x4.loadXYZ(a, 6);
   });
   throws(function () {
-    var f = SIMD.float32x4.loadXYZ(a.buffer, 1);
+    var f = SIMD.Float32x4.loadXYZ(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.float32x4.loadXYZ(a, "a");
+    var f = SIMD.Float32x4.loadXYZ(a, "a");
   });
 });
 
-test('float32x4 store exceptions', function () {
+test('Float32x4 store exceptions', function () {
   var a = new Float32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.float32x4.store(a, -1, f);
+    SIMD.Float32x4.store(a, -1, f);
   });
   throws(function () {
-    SIMD.float32x4.store(a, 5, f);
+    SIMD.Float32x4.store(a, 5, f);
   });
   throws(function () {
-    SIMD.float32x4.store(a.buffer, 1, f);
+    SIMD.Float32x4.store(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.float32x4.store(a, "a", f);
+    SIMD.Float32x4.store(a, "a", f);
   });
   throws(function () {
-    SIMD.float32x4.store(a, 1, i);
+    SIMD.Float32x4.store(a, 1, i);
   });
 });
 
-test('float32x4 storeX exceptions', function () {
+test('Float32x4 storeX exceptions', function () {
   var a = new Float32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.float32x4.storeX(a, -1, f);
+    SIMD.Float32x4.storeX(a, -1, f);
   });
   throws(function () {
-    SIMD.float32x4.storeX(a, 8, f);
+    SIMD.Float32x4.storeX(a, 8, f);
   });
   throws(function () {
-    SIMD.float32x4.storeX(a.buffer, 1, f);
+    SIMD.Float32x4.storeX(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.float32x4.storeX(a, "a", f);
+    SIMD.Float32x4.storeX(a, "a", f);
   });
   throws(function () {
-    SIMD.float32x4.storeX(a, 1, i);
+    SIMD.Float32x4.storeX(a, 1, i);
   });
 });
 
-test('float32x4 storeXY exceptions', function () {
+test('Float32x4 storeXY exceptions', function () {
   var a = new Float32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.float32x4.storeXY(a, -1, f);
+    SIMD.Float32x4.storeXY(a, -1, f);
   });
   throws(function () {
-    SIMD.float32x4.storeXY(a, 7, f);
+    SIMD.Float32x4.storeXY(a, 7, f);
   });
   throws(function () {
-    SIMD.float32x4.storeXY(a.buffer, 1, f);
+    SIMD.Float32x4.storeXY(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.float32x4.storeXY(a, "a", f);
+    SIMD.Float32x4.storeXY(a, "a", f);
   });
   throws(function () {
-    SIMD.float32x4.storeXY(a, 1, i);
+    SIMD.Float32x4.storeXY(a, 1, i);
   });
 });
 
-test('float32x4 storeXYZ exceptions', function () {
+test('Float32x4 storeXYZ exceptions', function () {
   var a = new Float32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.float32x4.storeXYZ(a, -1, f);
+    SIMD.Float32x4.storeXYZ(a, -1, f);
   });
   throws(function () {
-    SIMD.float32x4.storeXYZ(a, 6, f);
+    SIMD.Float32x4.storeXYZ(a, 6, f);
   });
   throws(function () {
-    SIMD.float32x4.storeXYZ(a.buffer, 1, f);
+    SIMD.Float32x4.storeXYZ(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.float32x4.storeXYZ(a, "a", f);
+    SIMD.Float32x4.storeXYZ(a, "a", f);
   });
   throws(function () {
-    SIMD.float32x4.storeXYZ(a, 1, i);
+    SIMD.Float32x4.storeXYZ(a, 1, i);
   });
 });
 
-test('float64x2 load', function() {
+test('Float64x2 load', function() {
   var a = new Float64Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.float64x2.load(a, i);
+    var v = SIMD.Float64x2.load(a, i);
     equal(i, v.x);
     equal(i+1, v.y);
   }
 });
 
-test('float64x2 unaligned load', function() {
+test('Float64x2 unaligned load', function() {
   var a = new Float64Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -586,25 +586,25 @@ test('float64x2 unaligned load', function() {
   }
   // Load the values unaligned.
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.float64x2.load(b, i * 8 + 1);
+    var v = SIMD.Float64x2.load(b, i * 8 + 1);
     equal(i, v.x);
     equal(i+1, v.y);
   }
 });
 
-test('float64x2 loadX', function() {
+test('Float64x2 loadX', function() {
   var a = new Float64Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length; i++) {
-    var v = SIMD.float64x2.loadX(a, i);
+    var v = SIMD.Float64x2.loadX(a, i);
     equal(i, v.x);
     equal(0.0, v.y);
   }
 });
 
-test('float64x2 unaligned loadX', function() {
+test('Float64x2 unaligned loadX', function() {
   var a = new Float64Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -617,27 +617,27 @@ test('float64x2 unaligned loadX', function() {
   }
   // Copy the values unaligned.
   for (var i = 0; i < a.length; i++) {
-    var v = SIMD.float64x2.loadX(b, i * 8 + 1);
+    var v = SIMD.Float64x2.loadX(b, i * 8 + 1);
     equal(i, v.x);
     equal(0.0, v.y);
   }
 });
 
-test('float64x2 store', function() {
+test('Float64x2 store', function() {
   var a = new Float64Array(6);
-  SIMD.float64x2.store(a, 0, SIMD.float64x2(0, 1));
-  SIMD.float64x2.store(a, 2, SIMD.float64x2(2, 3));
-  SIMD.float64x2.store(a, 4, SIMD.float64x2(4, 5));
+  SIMD.Float64x2.store(a, 0, SIMD.Float64x2(0, 1));
+  SIMD.Float64x2.store(a, 2, SIMD.Float64x2(2, 3));
+  SIMD.Float64x2.store(a, 4, SIMD.Float64x2(4, 5));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('float64x2 unaligned store', function() {
+test('Float64x2 unaligned store', function() {
   var c = new Int8Array(48 + 1);
-  SIMD.float64x2.store(c, 0 + 1, SIMD.float64x2(0, 1));
-  SIMD.float64x2.store(c, 16 + 1, SIMD.float64x2(2, 3));
-  SIMD.float64x2.store(c, 32 + 1, SIMD.float64x2(4, 5));
+  SIMD.Float64x2.store(c, 0 + 1, SIMD.Float64x2(0, 1));
+  SIMD.Float64x2.store(c, 16 + 1, SIMD.Float64x2(2, 3));
+  SIMD.Float64x2.store(c, 32 + 1, SIMD.Float64x2(4, 5));
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
   for (var i = 1; i < c.length; i++) {
@@ -649,23 +649,23 @@ test('float64x2 unaligned store', function() {
   }
 });
 
-test('float64x2 storeX', function() {
+test('Float64x2 storeX', function() {
   var a = new Float64Array(4);
-  SIMD.float64x2.storeX(a, 0, SIMD.float64x2(0, -1));
-  SIMD.float64x2.storeX(a, 1, SIMD.float64x2(1, -1));
-  SIMD.float64x2.storeX(a, 2, SIMD.float64x2(2, -1));
-  SIMD.float64x2.storeX(a, 3, SIMD.float64x2(3, -1));
+  SIMD.Float64x2.storeX(a, 0, SIMD.Float64x2(0, -1));
+  SIMD.Float64x2.storeX(a, 1, SIMD.Float64x2(1, -1));
+  SIMD.Float64x2.storeX(a, 2, SIMD.Float64x2(2, -1));
+  SIMD.Float64x2.storeX(a, 3, SIMD.Float64x2(3, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('float64x2 unaligned storeX', function() {
+test('Float64x2 unaligned storeX', function() {
   var c = new Int8Array(32 + 1);
-  SIMD.float64x2.storeX(c, 0 + 1, SIMD.float64x2(0, -1));
-  SIMD.float64x2.storeX(c, 8 + 1, SIMD.float64x2(1, -1));
-  SIMD.float64x2.storeX(c, 16 + 1, SIMD.float64x2(2, -1));
-  SIMD.float64x2.storeX(c, 24 + 1, SIMD.float64x2(3, -1));
+  SIMD.Float64x2.storeX(c, 0 + 1, SIMD.Float64x2(0, -1));
+  SIMD.Float64x2.storeX(c, 8 + 1, SIMD.Float64x2(1, -1));
+  SIMD.Float64x2.storeX(c, 16 + 1, SIMD.Float64x2(2, -1));
+  SIMD.Float64x2.storeX(c, 24 + 1, SIMD.Float64x2(3, -1));
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
   for (var i = 1; i < c.length; i++) {
@@ -677,87 +677,87 @@ test('float64x2 unaligned storeX', function() {
   }
 });
 
-test('float64x2 load exceptions', function () {
+test('Float64x2 load exceptions', function () {
   var a = new Float64Array(8);
   throws(function () {
-    var f = SIMD.float64x2.load(a, -1);
+    var f = SIMD.Float64x2.load(a, -1);
   });
   throws(function () {
-    var f = SIMD.float64x2.load(a, 7);
+    var f = SIMD.Float64x2.load(a, 7);
   });
   throws(function () {
-    var f = SIMD.float64x2.load(a.buffer, 1);
+    var f = SIMD.Float64x2.load(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.float64x2.load(a, "a");
+    var f = SIMD.Float64x2.load(a, "a");
   });
 });
 
-test('float64x2 loadX exceptions', function () {
+test('Float64x2 loadX exceptions', function () {
   var a = new Float64Array(8);
   throws(function () {
-    var f = SIMD.float64x2.loadX(a, -1);
+    var f = SIMD.Float64x2.loadX(a, -1);
   });
   throws(function () {
-    var f = SIMD.float64x2.loadX(a, 8);
+    var f = SIMD.Float64x2.loadX(a, 8);
   });
   throws(function () {
-    var f = SIMD.float64x2.loadX(a.buffer, 1);
+    var f = SIMD.Float64x2.loadX(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.float64x2.loadX(a, "a");
+    var f = SIMD.Float64x2.loadX(a, "a");
   });
 });
 
-test('float64x2 store exceptions', function () {
+test('Float64x2 store exceptions', function () {
   var a = new Float64Array(8);
-  var f = SIMD.float64x2(1, 2);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float64x2(1, 2);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.float64x2.store(a, -1, f);
+    SIMD.Float64x2.store(a, -1, f);
   });
   throws(function () {
-    SIMD.float64x2.store(a, 7, f);
+    SIMD.Float64x2.store(a, 7, f);
   });
   throws(function () {
-    SIMD.float64x2.store(a.buffer, 1, f);
+    SIMD.Float64x2.store(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.float64x2.store(a, "a", f);
+    SIMD.Float64x2.store(a, "a", f);
   });
   throws(function () {
-    SIMD.float64x2.store(a, 1, i);
+    SIMD.Float64x2.store(a, 1, i);
   });
 });
 
-test('float64x2 storeX exceptions', function () {
+test('Float64x2 storeX exceptions', function () {
   var a = new Float64Array(8);
-  var f = SIMD.float64x2(1, 2);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float64x2(1, 2);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.float64x2.storeX(a, -1, f);
+    SIMD.Float64x2.storeX(a, -1, f);
   });
   throws(function () {
-    SIMD.float64x2.storeX(a, 8, f);
+    SIMD.Float64x2.storeX(a, 8, f);
   });
   throws(function () {
-    SIMD.float64x2.storeX(a.buffer, 1, f);
+    SIMD.Float64x2.storeX(a.buffer, 1, f);
   });
   throws(function () {
-    SIMD.float64x2.storeX(a, "a", f);
+    SIMD.Float64x2.storeX(a, "a", f);
   });
   throws(function () {
-    SIMD.float64x2.storeX(a, 1, i);
+    SIMD.Float64x2.storeX(a, 1, i);
   });
 });
 
-test('int32x4 load', function() {
+test('Int32x4 load', function() {
   var a = new Int32Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 3; i++) {
-    var v = SIMD.int32x4.load(a, i);
+    var v = SIMD.Int32x4.load(a, i);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(i+2, v.z);
@@ -765,7 +765,7 @@ test('int32x4 load', function() {
   }
 });
 
-test('int32x4 overaligned load', function() {
+test('Int32x4 overaligned load', function() {
   var b = new ArrayBuffer(40);
   var a = new Int32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -773,7 +773,7 @@ test('int32x4 overaligned load', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 3; i += 2) {
-    var v = SIMD.int32x4.load(af, i / 2);
+    var v = SIMD.Int32x4.load(af, i / 2);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(i+2, v.z);
@@ -781,7 +781,7 @@ test('int32x4 overaligned load', function() {
   }
 });
 
-test('int32x4 unaligned load', function() {
+test('Int32x4 unaligned load', function() {
   var a = new Int32Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -794,7 +794,7 @@ test('int32x4 unaligned load', function() {
   }
   // Load the values unaligned.
   for (var i = 0; i < a.length - 3; i++) {
-    var v = SIMD.int32x4.load(b, i * 4 + 1);
+    var v = SIMD.Int32x4.load(b, i * 4 + 1);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(i+2, v.z);
@@ -802,13 +802,13 @@ test('int32x4 unaligned load', function() {
   }
 });
 
-test('int32x4 loadX', function() {
+test('Int32x4 loadX', function() {
   var a = new Int32Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length ; i++) {
-    var v = SIMD.int32x4.loadX(a, i);
+    var v = SIMD.Int32x4.loadX(a, i);
     equal(i, v.x);
     equal(0, v.y);
     equal(0, v.z);
@@ -816,7 +816,7 @@ test('int32x4 loadX', function() {
   }
 });
 
-test('int32x4 overaligned loadX', function() {
+test('Int32x4 overaligned loadX', function() {
   var b = new ArrayBuffer(40);
   var a = new Int32Array(b, 8);
   var af = new Int32Array(b, 8);
@@ -824,7 +824,7 @@ test('int32x4 overaligned loadX', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length; i++) {
-    var v = SIMD.int32x4.loadX(af, i);
+    var v = SIMD.Int32x4.loadX(af, i);
     equal(i, v.x);
     equal(0, v.y);
     equal(0, v.z);
@@ -832,7 +832,7 @@ test('int32x4 overaligned loadX', function() {
   }
 });
 
-test('int32x4 unaligned loadX', function() {
+test('Int32x4 unaligned loadX', function() {
   var a = new Int32Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -845,7 +845,7 @@ test('int32x4 unaligned loadX', function() {
   }
   // Load the values unaligned.
   for (var i = 0; i < a.length ; i++) {
-    var v = SIMD.int32x4.loadX(b, i * 4 + 1);
+    var v = SIMD.Int32x4.loadX(b, i * 4 + 1);
     equal(i, v.x);
     equal(0, v.y);
     equal(0, v.z);
@@ -853,13 +853,13 @@ test('int32x4 unaligned loadX', function() {
   }
 });
 
-test('int32x4 loadXY', function() {
+test('Int32x4 loadXY', function() {
   var a = new Int32Array(8);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.int32x4.loadXY(a, i);
+    var v = SIMD.Int32x4.loadXY(a, i);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(0, v.z);
@@ -867,7 +867,7 @@ test('int32x4 loadXY', function() {
   }
 });
 
-test('int32x4 overaligned loadXY', function() {
+test('Int32x4 overaligned loadXY', function() {
   var b = new ArrayBuffer(40);
   var a = new Int32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -875,7 +875,7 @@ test('int32x4 overaligned loadXY', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 1; i += 2) {
-    var v = SIMD.int32x4.loadXY(af, i / 2);
+    var v = SIMD.Int32x4.loadXY(af, i / 2);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(0, v.z);
@@ -883,7 +883,7 @@ test('int32x4 overaligned loadXY', function() {
   }
 });
 
-test('int32x4 unaligned loadXY', function() {
+test('Int32x4 unaligned loadXY', function() {
   var a = new Int32Array(8);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -896,7 +896,7 @@ test('int32x4 unaligned loadXY', function() {
   }
   // Load the values unaligned.
   for (var i = 0; i < a.length - 1; i++) {
-    var v = SIMD.int32x4.loadXY(b, i * 4 + 1);
+    var v = SIMD.Int32x4.loadXY(b, i * 4 + 1);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(0, v.z);
@@ -904,13 +904,13 @@ test('int32x4 unaligned loadXY', function() {
   }
 });
 
-test('int32x4 loadXYZ', function() {
+test('Int32x4 loadXYZ', function() {
   var a = new Int32Array(9);
   for (var i = 0; i < a.length; i++) {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 2; i++) {
-    var v = SIMD.int32x4.loadXYZ(a, i);
+    var v = SIMD.Int32x4.loadXYZ(a, i);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(i+2, v.z);
@@ -918,7 +918,7 @@ test('int32x4 loadXYZ', function() {
   }
 });
 
-test('int32x4 overaligned loadXYZ', function() {
+test('Int32x4 overaligned loadXYZ', function() {
   var b = new ArrayBuffer(48);
   var a = new Int32Array(b, 8);
   var af = new Float64Array(b, 8);
@@ -926,7 +926,7 @@ test('int32x4 overaligned loadXYZ', function() {
     a[i] = i;
   }
   for (var i = 0; i < a.length - 2; i += 2) {
-    var v = SIMD.int32x4.loadXYZ(af, i / 2);
+    var v = SIMD.Int32x4.loadXYZ(af, i / 2);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(i+2, v.z);
@@ -935,7 +935,7 @@ test('int32x4 overaligned loadXYZ', function() {
 });
 
 
-test('int32x4 unaligned loadXYZ', function() {
+test('Int32x4 unaligned loadXYZ', function() {
   var a = new Int32Array(9);
   var ai = new Int8Array(a.buffer);
   for (var i = 0; i < a.length; i++) {
@@ -948,40 +948,40 @@ test('int32x4 unaligned loadXYZ', function() {
   }
   // Load the values unaligned.
   for (var i = 0; i < a.length - 2; i++) {
-    var v = SIMD.int32x4.loadXYZ(b, i * 4 + 1);
+    var v = SIMD.Int32x4.loadXYZ(b, i * 4 + 1);
     equal(i, v.x);
     equal(i+1, v.y);
     equal(i+2, v.z);
     equal(0, v.w);
   }
 });
-test('int32x4 store', function() {
+test('Int32x4 store', function() {
   var a = new Int32Array(12);
-  SIMD.int32x4.store(a, 0, SIMD.int32x4(0, 1, 2, 3));
-  SIMD.int32x4.store(a, 4, SIMD.int32x4(4, 5, 6, 7));
-  SIMD.int32x4.store(a, 8, SIMD.int32x4(8, 9, 10, 11));
+  SIMD.Int32x4.store(a, 0, SIMD.Int32x4(0, 1, 2, 3));
+  SIMD.Int32x4.store(a, 4, SIMD.Int32x4(4, 5, 6, 7));
+  SIMD.Int32x4.store(a, 8, SIMD.Int32x4(8, 9, 10, 11));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('int32x4 overaligned store', function() {
+test('Int32x4 overaligned store', function() {
   var b = new ArrayBuffer(56);
   var a = new Int32Array(b, 8);
   var af = new Float64Array(b, 8);
-  SIMD.int32x4.store(af, 0, SIMD.int32x4(0, 1, 2, 3));
-  SIMD.int32x4.store(af, 2, SIMD.int32x4(4, 5, 6, 7));
-  SIMD.int32x4.store(af, 4, SIMD.int32x4(8, 9, 10, 11));
+  SIMD.Int32x4.store(af, 0, SIMD.Int32x4(0, 1, 2, 3));
+  SIMD.Int32x4.store(af, 2, SIMD.Int32x4(4, 5, 6, 7));
+  SIMD.Int32x4.store(af, 4, SIMD.Int32x4(8, 9, 10, 11));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('int32x4 unaligned store', function() {
+test('Int32x4 unaligned store', function() {
   var c = new Int8Array(48 + 1);
-  SIMD.int32x4.store(c, 0 + 1, SIMD.int32x4(0, 1, 2, 3));
-  SIMD.int32x4.store(c, 16 + 1, SIMD.int32x4(4, 5, 6, 7));
-  SIMD.int32x4.store(c, 32 + 1, SIMD.int32x4(8, 9, 10, 11));
+  SIMD.Int32x4.store(c, 0 + 1, SIMD.Int32x4(0, 1, 2, 3));
+  SIMD.Int32x4.store(c, 16 + 1, SIMD.Int32x4(4, 5, 6, 7));
+  SIMD.Int32x4.store(c, 32 + 1, SIMD.Int32x4(8, 9, 10, 11));
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
   for (var i = 1; i < c.length; i++) {
@@ -993,25 +993,25 @@ test('int32x4 unaligned store', function() {
   }
 });
 
-test('int32x4 storeX', function() {
+test('Int32x4 storeX', function() {
   var a = new Int32Array(4);
-  SIMD.int32x4.storeX(a, 0, SIMD.int32x4(0, -1, -1, -1));
-  SIMD.int32x4.storeX(a, 1, SIMD.int32x4(1, -1, -1, -1));
-  SIMD.int32x4.storeX(a, 2, SIMD.int32x4(2, -1, -1, -1));
-  SIMD.int32x4.storeX(a, 3, SIMD.int32x4(3, -1, -1, -1));
+  SIMD.Int32x4.storeX(a, 0, SIMD.Int32x4(0, -1, -1, -1));
+  SIMD.Int32x4.storeX(a, 1, SIMD.Int32x4(1, -1, -1, -1));
+  SIMD.Int32x4.storeX(a, 2, SIMD.Int32x4(2, -1, -1, -1));
+  SIMD.Int32x4.storeX(a, 3, SIMD.Int32x4(3, -1, -1, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('int32x4 overaligned storeX', function() {
+test('Int32x4 overaligned storeX', function() {
   var b = new ArrayBuffer(24);
   var a = new Int32Array(b, 8);
   var af = new Float64Array(b, 8);
   a[1] = -2;
   a[3] = -2;
-  SIMD.int32x4.storeX(af, 0, SIMD.int32x4(0, -1, -1, -1));
-  SIMD.int32x4.storeX(af, 1, SIMD.int32x4(2, -1, -1, -1));
+  SIMD.Int32x4.storeX(af, 0, SIMD.Int32x4(0, -1, -1, -1));
+  SIMD.Int32x4.storeX(af, 1, SIMD.Int32x4(2, -1, -1, -1));
   for (var i = 0; i < a.length; i++) {
     if (i % 2 == 0) {
       equal(i, a[i]);
@@ -1021,12 +1021,12 @@ test('int32x4 overaligned storeX', function() {
 }
 });
 
-test('int32x4 unaligned storeX', function() {
+test('Int32x4 unaligned storeX', function() {
   var c = new Int8Array(16 + 1);
-  SIMD.int32x4.storeX(c, 0 + 1, SIMD.int32x4(0, -1, -1, -1));
-  SIMD.int32x4.storeX(c, 4 + 1, SIMD.int32x4(1, -1, -1, -1));
-  SIMD.int32x4.storeX(c, 8 + 1, SIMD.int32x4(2, -1, -1, -1));
-  SIMD.int32x4.storeX(c, 12 + 1, SIMD.int32x4(3, -1, -1, -1));
+  SIMD.Int32x4.storeX(c, 0 + 1, SIMD.Int32x4(0, -1, -1, -1));
+  SIMD.Int32x4.storeX(c, 4 + 1, SIMD.Int32x4(1, -1, -1, -1));
+  SIMD.Int32x4.storeX(c, 8 + 1, SIMD.Int32x4(2, -1, -1, -1));
+  SIMD.Int32x4.storeX(c, 12 + 1, SIMD.Int32x4(3, -1, -1, -1));
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
   for (var i = 1; i < c.length; i++) {
@@ -1039,35 +1039,35 @@ test('int32x4 unaligned storeX', function() {
 });
 
 
-test('int32x4 storeXY', function() {
+test('Int32x4 storeXY', function() {
   var a = new Int32Array(8);
-  SIMD.int32x4.storeXY(a, 0, SIMD.int32x4(0, 1, -1, -1));
-  SIMD.int32x4.storeXY(a, 2, SIMD.int32x4(2, 3, -1, -1));
-  SIMD.int32x4.storeXY(a, 4, SIMD.int32x4(4, 5, -1, -1));
-  SIMD.int32x4.storeXY(a, 6, SIMD.int32x4(6, 7, -1, -1));
+  SIMD.Int32x4.storeXY(a, 0, SIMD.Int32x4(0, 1, -1, -1));
+  SIMD.Int32x4.storeXY(a, 2, SIMD.Int32x4(2, 3, -1, -1));
+  SIMD.Int32x4.storeXY(a, 4, SIMD.Int32x4(4, 5, -1, -1));
+  SIMD.Int32x4.storeXY(a, 6, SIMD.Int32x4(6, 7, -1, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('int32x4 overaligned storeXY', function() {
+test('Int32x4 overaligned storeXY', function() {
   var a = new Int32Array(8);
   var af = new Float64Array(a.buffer);
-  SIMD.int32x4.storeXY(af, 0, SIMD.int32x4(0, 1, -1, -1));
-  SIMD.int32x4.storeXY(af, 1, SIMD.int32x4(2, 3, -1, -1));
-  SIMD.int32x4.storeXY(af, 2, SIMD.int32x4(4, 5, -1, -1));
-  SIMD.int32x4.storeXY(af, 3, SIMD.int32x4(6, 7, -1, -1));
+  SIMD.Int32x4.storeXY(af, 0, SIMD.Int32x4(0, 1, -1, -1));
+  SIMD.Int32x4.storeXY(af, 1, SIMD.Int32x4(2, 3, -1, -1));
+  SIMD.Int32x4.storeXY(af, 2, SIMD.Int32x4(4, 5, -1, -1));
+  SIMD.Int32x4.storeXY(af, 3, SIMD.Int32x4(6, 7, -1, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('int32x4 unaligned storeXY', function() {
+test('Int32x4 unaligned storeXY', function() {
   var c = new Int8Array(32 + 1);
-  SIMD.int32x4.storeXY(c, 0 + 1, SIMD.int32x4(0, 1, -1, -1));
-  SIMD.int32x4.storeXY(c, 8 + 1, SIMD.int32x4(2, 3, -1, -1));
-  SIMD.int32x4.storeXY(c, 16 + 1, SIMD.int32x4(4, 5, -1, -1));
-  SIMD.int32x4.storeXY(c, 24 + 1, SIMD.int32x4(6, 7, -1, -1));
+  SIMD.Int32x4.storeXY(c, 0 + 1, SIMD.Int32x4(0, 1, -1, -1));
+  SIMD.Int32x4.storeXY(c, 8 + 1, SIMD.Int32x4(2, 3, -1, -1));
+  SIMD.Int32x4.storeXY(c, 16 + 1, SIMD.Int32x4(4, 5, -1, -1));
+  SIMD.Int32x4.storeXY(c, 24 + 1, SIMD.Int32x4(6, 7, -1, -1));
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
   for (var i = 1; i < c.length; i++) {
@@ -1079,26 +1079,26 @@ test('int32x4 unaligned storeXY', function() {
   }
 });
 
-test('int32x4 storeXYZ', function() {
+test('Int32x4 storeXYZ', function() {
   var a = new Int32Array(9);
-  SIMD.int32x4.storeXYZ(a, 0, SIMD.int32x4(0, 1, 2, -1));
-  SIMD.int32x4.storeXYZ(a, 3, SIMD.int32x4(3, 4, 5, -1));
-  SIMD.int32x4.storeXYZ(a, 6, SIMD.int32x4(6, 7, 8, -1));
+  SIMD.Int32x4.storeXYZ(a, 0, SIMD.Int32x4(0, 1, 2, -1));
+  SIMD.Int32x4.storeXYZ(a, 3, SIMD.Int32x4(3, 4, 5, -1));
+  SIMD.Int32x4.storeXYZ(a, 6, SIMD.Int32x4(6, 7, 8, -1));
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);
   }
 });
 
-test('int32x4 overaligned storeXYZ', function() {
+test('Int32x4 overaligned storeXYZ', function() {
   var b = new ArrayBuffer(56);
   var a = new Int32Array(b, 8);
   var af = new Float64Array(b, 8);
   a[3] = -2;
   a[7] = -2;
   a[11] = -2;
-  SIMD.int32x4.storeXYZ(af, 0, SIMD.int32x4(0, 1, 2, -1));
-  SIMD.int32x4.storeXYZ(af, 2, SIMD.int32x4(4, 5, 6, -1));
-  SIMD.int32x4.storeXYZ(af, 4, SIMD.int32x4(8, 9, 10, -1));
+  SIMD.Int32x4.storeXYZ(af, 0, SIMD.Int32x4(0, 1, 2, -1));
+  SIMD.Int32x4.storeXYZ(af, 2, SIMD.Int32x4(4, 5, 6, -1));
+  SIMD.Int32x4.storeXYZ(af, 4, SIMD.Int32x4(8, 9, 10, -1));
   for (var i = 0; i < a.length; i++) {
     if (i % 4 != 3) {
       equal(i, a[i]);
@@ -1108,11 +1108,11 @@ test('int32x4 overaligned storeXYZ', function() {
   }
 });
 
-test('int32x4 unaligned storeXYZ', function() {
+test('Int32x4 unaligned storeXYZ', function() {
   var c = new Int8Array(36 + 1);
-  SIMD.int32x4.storeXYZ(c, 0 + 1, SIMD.int32x4(0, 1, 2, -1));
-  SIMD.int32x4.storeXYZ(c, 12 + 1, SIMD.int32x4(3, 4, 5, -1));
-  SIMD.int32x4.storeXYZ(c, 24 + 1, SIMD.int32x4(6, 7, 8, -1));
+  SIMD.Int32x4.storeXYZ(c, 0 + 1, SIMD.Int32x4(0, 1, 2, -1));
+  SIMD.Int32x4.storeXYZ(c, 12 + 1, SIMD.Int32x4(3, 4, 5, -1));
+  SIMD.Int32x4.storeXYZ(c, 24 + 1, SIMD.Int32x4(6, 7, 8, -1));
   // Copy the bytes, offset by 1.
   var b = new Int8Array(c.length - 1);
   for (var i = 1; i < c.length; i++) {
@@ -1124,151 +1124,151 @@ test('int32x4 unaligned storeXYZ', function() {
   }
 });
 
-test('int32x4 load exceptions', function () {
+test('Int32x4 load exceptions', function () {
   var a = new Int32Array(8);
   throws(function () {
-    var f = SIMD.int32x4.load(a, -1);
+    var f = SIMD.Int32x4.load(a, -1);
   });
   throws(function () {
-    var f = SIMD.int32x4.load(a, 5);
+    var f = SIMD.Int32x4.load(a, 5);
   });
   throws(function () {
-    var f = SIMD.int32x4.load(a.buffer, 1);
+    var f = SIMD.Int32x4.load(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.int32x4.load(a, "a");
+    var f = SIMD.Int32x4.load(a, "a");
   });
 });
 
-test('int32x4 loadX exceptions', function () {
+test('Int32x4 loadX exceptions', function () {
   var a = new Int32Array(8);
   throws(function () {
-    var f = SIMD.int32x4.loadX(a, -1);
+    var f = SIMD.Int32x4.loadX(a, -1);
   });
   throws(function () {
-    var f = SIMD.int32x4.loadX(a, 8);
+    var f = SIMD.Int32x4.loadX(a, 8);
   });
   throws(function () {
-    var f = SIMD.int32x4.loadX(a.buffer, 1);
+    var f = SIMD.Int32x4.loadX(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.int32x4.loadX(a, "a");
+    var f = SIMD.Int32x4.loadX(a, "a");
   });
 });
 
-test('int32x4 loadXY exceptions', function () {
+test('Int32x4 loadXY exceptions', function () {
   var a = new Int32Array(8);
   throws(function () {
-    var f = SIMD.int32x4.loadXY(a, -1);
+    var f = SIMD.Int32x4.loadXY(a, -1);
   });
   throws(function () {
-    var f = SIMD.int32x4.loadXY(a, 7);
+    var f = SIMD.Int32x4.loadXY(a, 7);
   });
   throws(function () {
-    var f = SIMD.int32x4.loadXY(a.buffer, 1);
+    var f = SIMD.Int32x4.loadXY(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.int32x4.loadXY(a, "a");
+    var f = SIMD.Int32x4.loadXY(a, "a");
   });
 });
 
-test('int32x4 loadXYZ exceptions', function () {
+test('Int32x4 loadXYZ exceptions', function () {
   var a = new Int32Array(8);
   throws(function () {
-    var f = SIMD.int32x4.loadXYZ(a, -1);
+    var f = SIMD.Int32x4.loadXYZ(a, -1);
   });
   throws(function () {
-    var f = SIMD.int32x4.loadXYZ(a, 6);
+    var f = SIMD.Int32x4.loadXYZ(a, 6);
   });
   throws(function () {
-    var f = SIMD.int32x4.loadXYZ(a.buffer, 1);
+    var f = SIMD.Int32x4.loadXYZ(a.buffer, 1);
   });
   throws(function () {
-    var f = SIMD.int32x4.loadXYZ(a, "a");
+    var f = SIMD.Int32x4.loadXYZ(a, "a");
   });
 });
 
-test('int32x4 store exceptions', function () {
+test('Int32x4 store exceptions', function () {
   var a = new Int32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.int32x4.store(a, -1, i);
+    SIMD.Int32x4.store(a, -1, i);
   });
   throws(function () {
-    SIMD.int32x4.store(a, 5, i);
+    SIMD.Int32x4.store(a, 5, i);
   });
   throws(function () {
-    SIMD.int32x4.store(a.buffer, 1, i);
+    SIMD.Int32x4.store(a.buffer, 1, i);
   });
   throws(function () {
-    SIMD.int32x4.store(a, "a", i);
+    SIMD.Int32x4.store(a, "a", i);
   });
   throws(function () {
-    SIMD.int32x4.store(a, 1, f);
+    SIMD.Int32x4.store(a, 1, f);
   });
 });
 
-test('int32x4 storeX exceptions', function () {
+test('Int32x4 storeX exceptions', function () {
   var a = new Int32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.int32x4.storeX(a, -1, i);
+    SIMD.Int32x4.storeX(a, -1, i);
   });
   throws(function () {
-    SIMD.int32x4.storeX(a, 8, i);
+    SIMD.Int32x4.storeX(a, 8, i);
   });
   throws(function () {
-    SIMD.int32x4.storeX(a.buffer, 1, i);
+    SIMD.Int32x4.storeX(a.buffer, 1, i);
   });
   throws(function () {
-    SIMD.int32x4.storeX(a, "a", i);
+    SIMD.Int32x4.storeX(a, "a", i);
   });
   throws(function () {
-    SIMD.int32x4.storeX(a, 1, f);
+    SIMD.Int32x4.storeX(a, 1, f);
   });
 });
 
-test('int32x4 storeXY exceptions', function () {
+test('Int32x4 storeXY exceptions', function () {
   var a = new Int32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.int32x4.storeXY(a, -1, i);
+    SIMD.Int32x4.storeXY(a, -1, i);
   });
   throws(function () {
-    SIMD.int32x4.storeXY(a, 7, i);
+    SIMD.Int32x4.storeXY(a, 7, i);
   });
   throws(function () {
-    SIMD.int32x4.storeXY(a.buffer, 1, i);
+    SIMD.Int32x4.storeXY(a.buffer, 1, i);
   });
   throws(function () {
-    SIMD.int32x4.storeXY(a, "a", i);
+    SIMD.Int32x4.storeXY(a, "a", i);
   });
   throws(function () {
-    SIMD.int32x4.storeXY(a, 1, f);
+    SIMD.Int32x4.storeXY(a, 1, f);
   });
 });
 
-test('int32x4 storeXYZ exceptions', function () {
+test('Int32x4 storeXYZ exceptions', function () {
   var a = new Int32Array(8);
-  var f = SIMD.float32x4(1, 2, 3, 4);
-  var i = SIMD.int32x4(1, 2, 3, 4);
+  var f = SIMD.Float32x4(1, 2, 3, 4);
+  var i = SIMD.Int32x4(1, 2, 3, 4);
   throws(function () {
-    SIMD.int32x4.storeXYZ(a, -1, i);
+    SIMD.Int32x4.storeXYZ(a, -1, i);
   });
   throws(function () {
-    SIMD.int32x4.storeXYZ(a, 6, i);
+    SIMD.Int32x4.storeXYZ(a, 6, i);
   });
   throws(function () {
-    SIMD.int32x4.storeXYZ(a.buffer, 1, i);
+    SIMD.Int32x4.storeXYZ(a.buffer, 1, i);
   });
   throws(function () {
-    SIMD.int32x4.storeXYZ(a, "a", i);
+    SIMD.Int32x4.storeXYZ(a, "a", i);
   });
   throws(function () {
-    SIMD.int32x4.storeXYZ(a, 1, f);
+    SIMD.Int32x4.storeXYZ(a, 1, f);
   });
 });
 

--- a/webapi/webapi-simd-nonw3c-tests/simd/float32x4.html
+++ b/webapi/webapi-simd-nonw3c-tests/simd/float32x4.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>SIMD Test: float32x4</title>
+<title>SIMD Test: Float32x4</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="help" href="https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md">
 <link rel="stylesheet" href="ecmascript_simd/src/external/qunit.css">
@@ -40,79 +40,79 @@ Authors:
 <div id="qunit-fixture"></div>
 <script>
 
-test("Check if the zero function of float32x4 can change the parameter to 0.0", function() {
-  var z1 = SIMD.float32x4.zero();
+test("Check if the zero function of Float32x4 can change the parameter to 0.0", function() {
+  var z1 = SIMD.Float32x4.zero();
   equal(0.0, z1.x, "the value of z1.x should be 0.0");
   equal(0.0, z1.y, "the value of z1.y should be 0.0");
   equal(0.0, z1.z, "the value of z1.z should be 0.0");
   equal(0.0, z1.w, "the value of z1.w should be 0.0");
 });
 
-test("Check if the splat function of float32x4 can change the parameter to specified value", function () {
-  var z2 = SIMD.float32x4.splat(5.0);
+test("Check if the splat function of Float32x4 can change the parameter to specified value", function () {
+  var z2 = SIMD.Float32x4.splat(5.0);
   equal(5.0, z2.x, "the value of z2.x should be 5.0");
   equal(5.0, z2.y, "the value of z2.y should be 5.0");
   equal(5.0, z2.z, "the value of z2.z should be 5.0");
   equal(5.0, z2.w, "the value of z2.w should be 5.0");
 });
 
-test("Check if the fromFloat64x2 method of float32x4 is valid", function () {
-  var m = SIMD.float32x4(9.0, 10.0, 11.0, 12.0);
-  var nMask = SIMD.float64x2.fromFloat32x4(m);
-  var n = SIMD.float32x4.fromFloat64x2(nMask);
+test("Check if the fromFloat64x2 method of Float32x4 is valid", function () {
+  var m = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
+  var nMask = SIMD.Float64x2.fromFloat32x4(m);
+  var n = SIMD.Float32x4.fromFloat64x2(nMask);
   equal(9.0, n.x, "the value of n.x should be 9.0");
   equal(10.0, n.y, "the value of n.y should be 10.0");
   equal(0, n.z, "the value of n.z should be 0");
   equal(0, n.w, "the value of n.w should be 0");
 });
 
-test("Check if the fromFloat64x2Bits method of float32x4 is valid", function () {
-  var m = SIMD.float32x4(9.0, 10.0, 11.0, 12.0);
-  var nMask = SIMD.float64x2.fromFloat32x4Bits(m);
-  var n = SIMD.float32x4.fromFloat64x2Bits(nMask);
+test("Check if the fromFloat64x2Bits method of Float32x4 is valid", function () {
+  var m = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
+  var nMask = SIMD.Float64x2.fromFloat32x4Bits(m);
+  var n = SIMD.Float32x4.fromFloat64x2Bits(nMask);
   equal(9.0, n.x, "the value of n.x should be 9.0");
   equal(10.0, n.y, "the value of n.y should be 10.0");
   equal(11.0, n.z, "the value of n.z should be 11.0");
   equal(12.0, n.w, "the value of n.w should be 12.0");
 });
 
-test("Check if the fromInt32x4 method of float32x4 is valid", function () {
-  var m = SIMD.float32x4(9.0, 10.0, 11.0, 12.0);
-  var nMask = SIMD.int32x4.fromFloat32x4(m);
-  var n = SIMD.float32x4.fromInt32x4(nMask);
+test("Check if the fromInt32x4 method of Float32x4 is valid", function () {
+  var m = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
+  var nMask = SIMD.Int32x4.fromFloat32x4(m);
+  var n = SIMD.Float32x4.fromInt32x4(nMask);
   equal(9.0, n.x, "the value of n.x should be 9.0");
   equal(10.0, n.y, "the value of n.y should be 10.0");
   equal(11.0, n.z, "the value of n.z should be 11.0");
   equal(12.0, n.w, "the value of n.w should be 12.0");
 });
 
-test("Check if the fromInt32x4Bits method of float32x4 is valid", function () {
-  var m = SIMD.int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
-  var nMask = SIMD.float32x4.fromInt32x4Bits(m);
-  var n = SIMD.int32x4.fromFloat32x4Bits(nMask);
+test("Check if the fromInt32x4Bits method of Float32x4 is valid", function () {
+  var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
+  var nMask = SIMD.Float32x4.fromInt32x4Bits(m);
+  var n = SIMD.Int32x4.fromFloat32x4Bits(nMask);
   equal(0x3F800000, n.x, "the value of n.x should be 0x3F800000");
   equal(0x40000000, n.y, "the value of n.y should be 0x40000000");
   equal(0x40400000, n.z, "the value of n.z should be 0x40400000");
   equal(0x40800000, n.w, "the value of n.w should be 0x40800000");
 });
 
-test("Check if the select method of float32x4 is valid", function () {
-  var m = SIMD.int32x4.bool(true, true, false, false);
-  var t = SIMD.float32x4(1.0, 2.0, 3.0, 4.0);
-  var f = SIMD.float32x4(5.0, 6.0, 7.0, 8.0);
-  var s = SIMD.float32x4.select(m, t, f);
+test("Check if the select method of Float32x4 is valid", function () {
+  var m = SIMD.Int32x4.bool(true, true, false, false);
+  var t = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
+  var f = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
+  var s = SIMD.Float32x4.select(m, t, f);
   equal(1.0, s.x, "the value of s.x should be 1.0");
   equal(2.0, s.y, "the value of s.y should be 2.0");
   equal(7.0, s.z, "the value of s.z should be 7.0");
   equal(8.0, s.w, "the value of s.w should be 8.0");
 });
 
-test('float32x4 store smi check', function() {
+test('Float32x4 store smi check', function() {
   var a = new Float32Array(12);
   for(var j = 0; j < 1000; j++) {
-    SIMD.float32x4.store(a, 0, SIMD.float32x4(0, 1, 2, 3));
-    SIMD.float32x4.store(a, 4, SIMD.float32x4(4, 5, 6, 7));
-    SIMD.float32x4.store(a, 8, SIMD.float32x4(8, 9, 10, 11));
+    SIMD.Float32x4.store(a, 0, SIMD.Float32x4(0, 1, 2, 3));
+    SIMD.Float32x4.store(a, 4, SIMD.Float32x4(4, 5, 6, 7));
+    SIMD.Float32x4.store(a, 8, SIMD.Float32x4(8, 9, 10, 11));
   }
   for (var i = 0; i < a.length; i++) {
     equal(i, a[i]);

--- a/webapi/webapi-simd-nonw3c-tests/simd/float64x2.html
+++ b/webapi/webapi-simd-nonw3c-tests/simd/float64x2.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>SIMD Test: float64x2</title>
+<title>SIMD Test: Float64x2</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="help" href="https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md">
 <link rel="stylesheet" href="ecmascript_simd/src/external/qunit.css">
@@ -40,179 +40,179 @@ Authors:
 <div id="qunit-fixture"></div>
 <script>
 
-test("Check if float64x2 object can be creat successful", function () {
-  notEqual(undefined, SIMD.float64x2, "the type of float64x2 should not be undefined");
-  notEqual(undefined, SIMD.float64x2(1, 2), "the float64x2 object should not be undefined");
-  var f1 = SIMD.float64x2(1.0, 2.0);
-  var f2 = SIMD.float64x2.check(f1);
+test("Check if Float64x2 object can be creat successful", function () {
+  notEqual(undefined, SIMD.Float64x2, "the type of Float64x2 should not be undefined");
+  notEqual(undefined, SIMD.Float64x2(1, 2), "the Float64x2 object should not be undefined");
+  var f1 = SIMD.Float64x2(1.0, 2.0);
+  var f2 = SIMD.Float64x2.check(f1);
   equal(f1.x, f2.x, "the value of x should equal");
   equal(f1.y, f2.y, "the value of y should equal");
 });
 
-test("Check if the zero function of float64x2 can change the parameter to 0.0", function () {
-  var z1 = SIMD.float64x2.zero();
+test("Check if the zero function of Float64x2 can change the parameter to 0.0", function () {
+  var z1 = SIMD.Float64x2.zero();
   equal(0.0, z1.x, "the value of z1.x should be 0.0");
   equal(0.0, z1.y, "the value of z1.y should be 0.0");
 });
 
-test("Check if the splat function of float64x2 can change the parameter to specified value", function () {
-  var z2 = SIMD.float64x2.splat(5.0);
+test("Check if the splat function of Float64x2 can change the parameter to specified value", function () {
+  var z2 = SIMD.Float64x2.splat(5.0);
   equal(5.0, z2.x, "the value of z2.x should be 5.0");
   equal(5.0, z2.y, "the value of z2.y should be 5.0");
 });
 
-test("Check if the fromFloat32x4Bits method of float64x2 is valid", function () {
-  var m = SIMD.float32x4(9.0, 10.0, 11.0, 12.0);
-  var nMask = SIMD.float64x2.fromFloat32x4Bits(m);
-  var n = SIMD.float32x4.fromFloat64x2Bits(nMask);
+test("Check if the fromFloat32x4Bits method of Float64x2 is valid", function () {
+  var m = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
+  var nMask = SIMD.Float64x2.fromFloat32x4Bits(m);
+  var n = SIMD.Float32x4.fromFloat64x2Bits(nMask);
   equal(9.0, n.x, "the value of n.x should be 9.0");
   equal(10.0, n.y, "the value of n.y should be 10.0");
   equal(11.0, n.z, "the value of n.z should be 11.0");
   equal(12.0, n.w, "the value of n.w should be 12.0");
 });
 
-test("Check if the fromInt32x4Bits method of float64x2 is valid", function () {
-  var m = SIMD.int32x4(9, 10, 11, 12);
-  var nMask = SIMD.float64x2.fromInt32x4Bits(m);
-  var n = SIMD.int32x4.fromFloat64x2Bits(nMask);
+test("Check if the fromInt32x4Bits method of Float64x2 is valid", function () {
+  var m = SIMD.Int32x4(9, 10, 11, 12);
+  var nMask = SIMD.Float64x2.fromInt32x4Bits(m);
+  var n = SIMD.Int32x4.fromFloat64x2Bits(nMask);
   equal(9, n.x, "the value of n.x should be 9");
   equal(10, n.y, "the value of n.y should be 10");
   equal(11, n.z, "the value of n.z should be 11");
   equal(12, n.w, "the value of n.w should be 12");
 });
 
-test("Check if the fromInt32x4 method of float64x2 is valid", function () {
-  var m = SIMD.int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
-  var nMask = SIMD.float64x2.fromInt32x4(m);
-  var n = SIMD.int32x4.fromFloat64x2(nMask);
+test("Check if the fromInt32x4 method of Float64x2 is valid", function () {
+  var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
+  var nMask = SIMD.Float64x2.fromInt32x4(m);
+  var n = SIMD.Int32x4.fromFloat64x2(nMask);
   equal(0x3F800000, n.x, "the value of n.x should be 0x3F800000");
   equal(0x40000000, n.y, "the value of n.y should be 0x40000000");
   equal(0, n.z, "the value of n.z should be 0");
   equal(0, n.w, "the value of n.w should be 0");
 });
 
-test("Check if the fromFloat32x4 method of float64x2 is valid", function () {
-  var m = SIMD.float32x4(9.0, 10.0, 11.0, 12.0);
-  var nMask = SIMD.float64x2.fromFloat32x4(m);
-  var n = SIMD.float32x4.fromFloat64x2(nMask);
+test("Check if the fromFloat32x4 method of Float64x2 is valid", function () {
+  var m = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
+  var nMask = SIMD.Float64x2.fromFloat32x4(m);
+  var n = SIMD.Float32x4.fromFloat64x2(nMask);
   equal(9.0, n.x, "the value of n.x should be 9.0");
   equal(10.0, n.y, "the value of n.y should be 10.0");
   equal(0, n.z, "the value of n.z should be 0");
   equal(0, n.w, "the value of n.w should be 0");
 });
 
-test("Check if the abs method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(-4.0, -3.0);
-  var c = SIMD.float64x2.abs(a);
+test("Check if the abs method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(-4.0, -3.0);
+  var c = SIMD.Float64x2.abs(a);
   equal(4.0, c.x, "the value of c.x should be 4.0");
   equal(3.0, c.y, "the value of c.y should be 3.0");
 });
 
-test("Check if the neg method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(-4.0, -3.0, -2.0, -1.0);
-  var c = SIMD.float64x2.neg(a);
+test("Check if the neg method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(-4.0, -3.0, -2.0, -1.0);
+  var c = SIMD.Float64x2.neg(a);
   equal(4.0, c.x, "the value of c.x should be 4.0");
   equal(3.0, c.y, "the value of c.y should be 3.0");
 });
 
-test("Check if the add method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(4.0, 3.0);
-  var b = SIMD.float64x2(10.0, 20.0);
-  var c = SIMD.float64x2.add(a, b);
+test("Check if the add method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(4.0, 3.0);
+  var b = SIMD.Float64x2(10.0, 20.0);
+  var c = SIMD.Float64x2.add(a, b);
   equal(14.0, c.x, "the value of c.x should be 14.0");
   equal(23.0, c.y, "the value of c.y should be 23.0");
 });
 
 test("Check if the sub method is valid", function () {
-  var a = SIMD.float64x2(4.0, 3.0);
-  var b = SIMD.float64x2(10.0, 20.0);
-  var c = SIMD.float64x2.sub(a, b);
+  var a = SIMD.Float64x2(4.0, 3.0);
+  var b = SIMD.Float64x2(10.0, 20.0);
+  var c = SIMD.Float64x2.sub(a, b);
   equal(-6.0, c.x, "the value of c.x should be -6.0");
   equal(-17.0, c.y, "the value of c.y should be -17.0");
 });
 
-test("Check if the mul method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(4.0, 3.0);
-  var b = SIMD.float64x2(10.0, 20.0);
-  var c = SIMD.float64x2.mul(a, b);
+test("Check if the mul method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(4.0, 3.0);
+  var b = SIMD.Float64x2(10.0, 20.0);
+  var c = SIMD.Float64x2.mul(a, b);
   equal(40.0, c.x, "the value of c.x should be 40.0");
   equal(60.0, c.y, "the value of c.y should be 60.0");
 });
 
 test("Check if the div method is valid", function () {
-  var a = SIMD.float64x2(4.0, 9.0);
-  var b = SIMD.float64x2(2.0, 3.0);
-  var c = SIMD.float64x2.div(a, b);
+  var a = SIMD.Float64x2(4.0, 9.0);
+  var b = SIMD.Float64x2(2.0, 3.0);
+  var c = SIMD.Float64x2.div(a, b);
   equal(2.0, c.x, "the value of c.x should be 2.0");
   equal(3.0, c.y, "the value of c.y should be 3.0");
 });
 
-test("Check if the clamp method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(-20.0, 10.0);
-  var lower = SIMD.float64x2(2.0, 1.0);
-  var upper = SIMD.float64x2(2.5, 5.0);
-  var c = SIMD.float64x2.clamp(a, lower, upper);
+test("Check if the clamp method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(-20.0, 10.0);
+  var lower = SIMD.Float64x2(2.0, 1.0);
+  var upper = SIMD.Float64x2(2.5, 5.0);
+  var c = SIMD.Float64x2.clamp(a, lower, upper);
   equal(2.0, c.x, "the value of c.x should be 2.0");
   equal(5.0, c.y, "the value of c.y should be 5.0");
 });
 
-test("Check if the min method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(-20.0, 10.0, 30.0, 0.5);
-  var lower = SIMD.float64x2(2.0, 1.0, 50.0, 0.0);
-  var c = SIMD.float64x2.min(a, lower);
+test("Check if the min method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(-20.0, 10.0, 30.0, 0.5);
+  var lower = SIMD.Float64x2(2.0, 1.0, 50.0, 0.0);
+  var c = SIMD.Float64x2.min(a, lower);
   equal(-20.0, c.x, "the value of c.x should be -20.0");
   equal(1.0, c.y, "the value of c.y should be 1.0");
 });
 
-test("Check if the max method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(-20.0, 10.0);
-  var upper = SIMD.float64x2(2.5, 5.0);
-  var c = SIMD.float64x2.max(a, upper);
+test("Check if the max method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(-20.0, 10.0);
+  var upper = SIMD.Float64x2(2.5, 5.0);
+  var c = SIMD.Float64x2.max(a, upper);
   equal(2.5, c.x, "the value of c.x should be 2.5");
   equal(10.0, c.y, "the value of c.y should be 10.0");
 });
 
-test("Check if the reciprocal method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(8.0, 4.0);
-  var c = SIMD.float64x2.reciprocal(a);
+test("Check if the reciprocal method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(8.0, 4.0);
+  var c = SIMD.Float64x2.reciprocal(a);
   equal(0.125, c.x, "the value of c.x should be 0.125");
   equal(0.250, c.y, "the value of c.y should be 0.250");
 });
 
-test("Check if the reciprocalSqrt method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(1.0, 0.25);
-  var c = SIMD.float64x2.reciprocalSqrt(a);
+test("Check if the reciprocalSqrt method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(1.0, 0.25);
+  var c = SIMD.Float64x2.reciprocalSqrt(a);
   equal(1.0, c.x, "the value of c.x should be 1.0");
   equal(2.0, c.y, "the value of c.y should be 2.0");
 });
 
-test("Check if the scale method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(8.0, 4.0, 2.0, -2.0);
-  var c = SIMD.float64x2.scale(a, 0.5);
+test("Check if the scale method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(8.0, 4.0, 2.0, -2.0);
+  var c = SIMD.Float64x2.scale(a, 0.5);
   equal(4.0, c.x, "the value of c.x should be 1.0");
   equal(2.0, c.y, "the value of c.y should be 2.0");
 });
 
-test("Check if the sqrt method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(16.0, 9.0);
-  var c = SIMD.float64x2.sqrt(a);
+test("Check if the sqrt method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(16.0, 9.0);
+  var c = SIMD.Float64x2.sqrt(a);
   equal(4.0, c.x, "the value of c.x should be 4.0");
   equal(3.0, c.y, "the value of c.y should be 3.0");
 });
 
-test("Check if the shuffle  method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(4.0, 3.0);
-  var xxxx = SIMD.float64x2.shuffle(a, SIMD.XXXX);
+test("Check if the shuffle  method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(4.0, 3.0);
+  var xxxx = SIMD.Float64x2.shuffle(a, SIMD.XXXX);
   equal(4.0, xxxx.x, "the value of xxxx.x should be 4.0");
   equal(4.0, xxxx.y, "the value of xxxx.y should be 4.0");
 });
 
-test("Check if the shuffleMix  method of float64x2 is valid", function () {
-  var a    = SIMD.float64x2(1.0, 2.0);
-  var b    = SIMD.float64x2(5.0, 6.0);
-  var xyxy = SIMD.float64x2.shuffleMix(a, b, SIMD.XYXY);
-  var zwzw = SIMD.float64x2.shuffleMix(a, b, SIMD.ZWZW);
-  var xxxx = SIMD.float64x2.shuffleMix(a, b, SIMD.XXXX);
+test("Check if the shuffleMix  method of Float64x2 is valid", function () {
+  var a    = SIMD.Float64x2(1.0, 2.0);
+  var b    = SIMD.Float64x2(5.0, 6.0);
+  var xyxy = SIMD.Float64x2.shuffleMix(a, b, SIMD.XYXY);
+  var zwzw = SIMD.Float64x2.shuffleMix(a, b, SIMD.ZWZW);
+  var xxxx = SIMD.Float64x2.shuffleMix(a, b, SIMD.XXXX);
   equal(1.0, xyxy.x, "the value of xyxy.x should be 1.0");
   equal(5.0, xyxy.y, "the value of xyxy.y should be 5.0");
   equal(1.0, zwzw.x, "the value of zwzw.x should be 1.0");
@@ -221,99 +221,99 @@ test("Check if the shuffleMix  method of float64x2 is valid", function () {
   equal(5.0, xxxx.y, "the value of xxxx.y should be 5.0");
 });
 
-test("Check if the withX method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(16.0, 9.0);
-  var c = SIMD.float64x2.withX(a, 20.0);
+test("Check if the withX method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(16.0, 9.0);
+  var c = SIMD.Float64x2.withX(a, 20.0);
   equal(20.0, c.x, "the value of c.x should be 20.0");
   equal(9.0, c.y, "the value of c.y should be 9.0");
 });
 
-test("Check if the withY method of float64x2 is valid", function () {
-  var a = SIMD.float64x2(16.0, 9.0);
-  var c = SIMD.float64x2.withY(a, 20.0);
+test("Check if the withY method of Float64x2 is valid", function () {
+  var a = SIMD.Float64x2(16.0, 9.0);
+  var c = SIMD.Float64x2.withY(a, 20.0);
   equal(16.0, c.x, "the value of c.x should be 16.0");
   equal(20.0, c.y, "the value of c.y should be 20.0");
 });
 
-test("Check if the lessThan method of float64x2 is valid", function () {
-  var m = SIMD.float64x2(1.0, 2.0);
-  var n = SIMD.float64x2(2.0, 2.0);
+test("Check if the lessThan method of Float64x2 is valid", function () {
+  var m = SIMD.Float64x2(1.0, 2.0);
+  var n = SIMD.Float64x2(2.0, 2.0);
   var cmp;
-  cmp = SIMD.float64x2.lessThan(m, n);
+  cmp = SIMD.Float64x2.lessThan(m, n);
   equal(-1, cmp.x, "the value of cmp.x should be -1");
   equal(-1, cmp.y, "the value of cmp.y should be -1");
   equal(0, cmp.z, "the value of cmp.z should be 0");
   equal(0, cmp.w, "the value of cmp.w should be 0");
 });
 
-test("Check if the lessThanOrEqual method of float64x2 is valid", function () {
-  var m = SIMD.float64x2(1.0, 2.0);
-  var n = SIMD.float64x2(2.0, 2.0);
+test("Check if the lessThanOrEqual method of Float64x2 is valid", function () {
+  var m = SIMD.Float64x2(1.0, 2.0);
+  var n = SIMD.Float64x2(2.0, 2.0);
   var cmp;
-  cmp = SIMD.float64x2.lessThanOrEqual(m, n);
+  cmp = SIMD.Float64x2.lessThanOrEqual(m, n);
   equal(-1, cmp.x, "the value of cmp.x should be -1");
   equal(-1, cmp.y, "the value of cmp.y should be -1");
   equal(-1, cmp.z, "the value of cmp.z should be -1");
   equal(-1, cmp.w, "the value of cmp.w should be -1");
 });
 
-test("Check if the equal method of float64x2 is valid", function () {
-  var m = SIMD.float64x2(1.0, 2.0);
-  var n = SIMD.float64x2(2.0, 2.0);
+test("Check if the equal method of Float64x2 is valid", function () {
+  var m = SIMD.Float64x2(1.0, 2.0);
+  var n = SIMD.Float64x2(2.0, 2.0);
   var cmp;
-  cmp = SIMD.float64x2.equal(m, n);
+  cmp = SIMD.Float64x2.equal(m, n);
   equal(0, cmp.x, "the value of cmp.x should be 0");
   equal(0, cmp.y, "the value of cmp.y should be 0");
   equal(-1, cmp.z, "the value of cmp.z should be -1");
   equal(-1, cmp.w, "the value of cmp.w should be -1");
 });
 
-test("Check if the notEqual method of float64x2 is valid", function () {
-  var m = SIMD.float64x2(1.0, 2.0);
-  var n = SIMD.float64x2(2.0, 2.0);
+test("Check if the notEqual method of Float64x2 is valid", function () {
+  var m = SIMD.Float64x2(1.0, 2.0);
+  var n = SIMD.Float64x2(2.0, 2.0);
   var cmp;
-  cmp = SIMD.float64x2.notEqual(m, n);
+  cmp = SIMD.Float64x2.notEqual(m, n);
   equal(-1, cmp.x, "the value of cmp.x should be -1");
   equal(-1, cmp.y, "the value of cmp.y should be -1");
   equal(0, cmp.z, "the value of cmp.z should be 0");
   equal(0, cmp.w, "the value of cmp.w should be 0");
 });
 
-test("Check if the greaterThanOrEqual  method of float64x2 is valid", function () {
-  var m = SIMD.float64x2(1.0, 2.0);
-  var n = SIMD.float64x2(2.0, 2.0);
+test("Check if the greaterThanOrEqual  method of Float64x2 is valid", function () {
+  var m = SIMD.Float64x2(1.0, 2.0);
+  var n = SIMD.Float64x2(2.0, 2.0);
   var cmp;
-  cmp = SIMD.float64x2.greaterThanOrEqual (m, n);
+  cmp = SIMD.Float64x2.greaterThanOrEqual (m, n);
   equal(0, cmp.x, "the value of cmp.x should be 0");
   equal(0, cmp.y, "the value of cmp.y should be 0");
   equal(-1, cmp.z, "the value of cmp.z should be -1");
   equal(-1, cmp.w, "the value of cmp.w should be -1");
 });
 
-test("Check if the greaterThan  method of float64x2 is valid", function () {
-  var m = SIMD.float64x2(1.0, 2.0);
-  var n = SIMD.float64x2(2.0, 2.0);
+test("Check if the greaterThan  method of Float64x2 is valid", function () {
+  var m = SIMD.Float64x2(1.0, 2.0);
+  var n = SIMD.Float64x2(2.0, 2.0);
   var cmp;
-  cmp = SIMD.float64x2.greaterThan (m, n);
+  cmp = SIMD.Float64x2.greaterThan (m, n);
   equal(0, cmp.x, "the value of cmp.x should be 0");
   equal(0, cmp.y, "the value of cmp.y should be 0");
   equal(0, cmp.z, "the value of cmp.z should be 0");
   equal(0, cmp.w, "the value of cmp.w should be 0");
 });
 
-test("Check if the select method of float64x2 is valid", function () {
-  var m = SIMD.int32x4.bool(true, true, false, false);
-  var t = SIMD.float64x2(1.0, 2.0);
-  var f = SIMD.float64x2(5.0, 6.0);
-  var s = SIMD.float64x2.select(m, t, f);
+test("Check if the select method of Float64x2 is valid", function () {
+  var m = SIMD.Int32x4.bool(true, true, false, false);
+  var t = SIMD.Float64x2(1.0, 2.0);
+  var f = SIMD.Float64x2(5.0, 6.0);
+  var s = SIMD.Float64x2.select(m, t, f);
   equal(1.0, s.x, "the value of s.x should be 1");
   equal(6.0, s.y, "the value of s.y should be 6");
 });
 
-test("Check if the bitsToInt32x4 method of float64x2 is valid", function () {
-  var t = SIMD.float64x2(1.0, 2.0);
-  var a = SIMD.float64x2.bitsToInt32x4(t);
-  var s = SIMD.int32x4.bitsToFloat64x2(a);
+test("Check if the bitsToInt32x4 method of Float64x2 is valid", function () {
+  var t = SIMD.Float64x2(1.0, 2.0);
+  var a = SIMD.Float64x2.bitsToInt32x4(t);
+  var s = SIMD.Int32x4.bitsToFloat64x2(a);
   equal(1, s.x, "the value of s.x should be 1");
   equal(2, s.y, "the value of s.y should be 2");
 });

--- a/webapi/webapi-simd-nonw3c-tests/simd/int32x4.html
+++ b/webapi/webapi-simd-nonw3c-tests/simd/int32x4.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>SIMD Test: int32x4</title>
+<title>SIMD Test: Int32x4</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="help" href="https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md">
 <link rel="stylesheet" href="ecmascript_simd/src/external/qunit.css">
@@ -40,123 +40,123 @@ Authors:
 <div id="qunit-fixture"></div>
 <script>
 
-test("Check if int32x4 object can be creat successful", function () {
-  notEqual(undefined, SIMD.int32x4, "the type of int32x4 should not be undefined");
-  notEqual(undefined, SIMD.int32x4(1, 2, 3, 4), "the int32x4 object should not be undefined");
-  var f1 = SIMD.int32x4(1, 2, 3, 4);
-  var f2 = SIMD.int32x4.check(f1);
+test("Check if Int32x4 object can be creat successful", function () {
+  notEqual(undefined, SIMD.Int32x4, "the type of Int32x4 should not be undefined");
+  notEqual(undefined, SIMD.Int32x4(1, 2, 3, 4), "the Int32x4 object should not be undefined");
+  var f1 = SIMD.Int32x4(1, 2, 3, 4);
+  var f2 = SIMD.Int32x4.check(f1);
   equal(f1.x, f2.x, "the value of x should equal");
   equal(f1.y, f2.y, "the value of y should equal");
   equal(f1.z, f2.z, "the value of z should equal");
   equal(f1.w, f2.w, "the value of w should equal");
 });
 
-test("Check if the x value of int32x4 object can be got", function () {
-  var u11 = SIMD.int32x4(1, 2, 3, 4);
+test("Check if the x value of Int32x4 object can be got", function () {
+  var u11 = SIMD.Int32x4(1, 2, 3, 4);
   equal(1, u11.x, "the value of u11.x should be 1");
-  var u21 = new SIMD.int32x4(1, 2, 3, 4);
+  var u21 = new SIMD.Int32x4(1, 2, 3, 4);
   equal(1, u21.x, "the value of u21.x should be 1");
 });
 
-test("Check if the z value of int32x4 object can be got", function () {
-  var u12 = SIMD.int32x4(1, 2, 3, 4);
+test("Check if the z value of Int32x4 object can be got", function () {
+  var u12 = SIMD.Int32x4(1, 2, 3, 4);
   equal(2, u12.y, "the value of u12.y should be 2");
-  var u22 = new SIMD.int32x4(1, 2, 3, 4);
+  var u22 = new SIMD.Int32x4(1, 2, 3, 4);
   equal(2, u22.y, "the value of u22.y should be 2");
 });
 
-test("Check if the w value of int32x4 object can be got", function () {
-  var u13 = SIMD.int32x4(1, 2, 3, 4);
+test("Check if the w value of Int32x4 object can be got", function () {
+  var u13 = SIMD.Int32x4(1, 2, 3, 4);
   equal(3, u13.z, "the value of u13.z should be 3");
-  var u23 = new SIMD.int32x4(1, 2, 3, 4);
+  var u23 = new SIMD.Int32x4(1, 2, 3, 4);
   equal(3, u23.z, "the value of u23.z should be 3");
 });
 
-test("Check if the y value of int32x4 object can be got", function () {
-  var u14 = SIMD.int32x4(1, 2, 3, 4);
+test("Check if the y value of Int32x4 object can be got", function () {
+  var u14 = SIMD.Int32x4(1, 2, 3, 4);
   equal(4, u14.w, "the value of u14.w should be 4");
-  var u24 = new SIMD.int32x4(1, 2, 3, 4);
+  var u24 = new SIMD.Int32x4(1, 2, 3, 4);
   equal(4, u24.w, "the value of u24.w should be 4");
 });
 
-test("Check if the bool function of int32x4 can change the object to (-1, 0, -1, 0)", function () {
-  var u3 = SIMD.int32x4.bool(true, false, true, false);
+test("Check if the bool function of Int32x4 can change the object to (-1, 0, -1, 0)", function () {
+  var u3 = SIMD.Int32x4.bool(true, false, true, false);
   equal(-1, u3.x, "the value of u3.x should be -1");
   equal(0, u3.y, "the value of u3.y should be 0");
   equal(-1, u3.z, "the value of u3.z should be -1");
   equal(0, u3.w, "the value of u3.w should be 0");
 });
 
-test("Check if the splat function of int32x4can change the parameter to specified value", function () {
-  var u4 = SIMD.int32x4.splat(4);
+test("Check if the splat function of Int32x4can change the parameter to specified value", function () {
+  var u4 = SIMD.Int32x4.splat(4);
   equal(4, u4.x, "the value of u4.x should be 4");
   equal(4, u4.y, "the value of u4.y should be 4");
   equal(4, u4.z, "the value of u4.z should be 4");
   equal(4, u4.w, "the value of u4.w should be 4");
 });
 
-test("Check if the flagX of int32x4 object can be got and type of boolean", function () {
-  var u51 = SIMD.int32x4(1, 2, 3, 4);
+test("Check if the flagX of Int32x4 object can be got and type of boolean", function () {
+  var u51 = SIMD.Int32x4(1, 2, 3, 4);
   equal(true, u51.flagX, "the flagX of u51 should be true");
-  var u61 = new SIMD.int32x4(0, 1, 0, 1);
+  var u61 = new SIMD.Int32x4(0, 1, 0, 1);
   equal(false, u61.flagX, "the flagX of u61 should be false");
 });
 
-test("Check if the flagY of int32x4 object can be got and type of boolean", function () {
-  var u52 = SIMD.int32x4(1, 2, 3, 4);
+test("Check if the flagY of Int32x4 object can be got and type of boolean", function () {
+  var u52 = SIMD.Int32x4(1, 2, 3, 4);
   equal(true, u52.flagY, "the flagY of u52 should be true");
-  var u62 = new SIMD.int32x4(0, 1, 0, 1);
+  var u62 = new SIMD.Int32x4(0, 1, 0, 1);
   equal(true, u62.flagY, "the flagY of u62 should be true");
 });
 
-test("Check if the flagZ of int32x4 object can be got and type of boolean", function () {
-  var u53 = SIMD.int32x4(1, 2, 3, 4);
+test("Check if the flagZ of Int32x4 object can be got and type of boolean", function () {
+  var u53 = SIMD.Int32x4(1, 2, 3, 4);
   equal(true, u53.flagZ, "the flagZ of u53 should be true");
-  var u63 = new SIMD.int32x4(0, 1, 0, 1);
+  var u63 = new SIMD.Int32x4(0, 1, 0, 1);
   equal(false, u63.flagZ, "the flagZ of u63 should be false");
 });
 
-test("Check if the flagW of int32x4 object can be got and type of boolean", function () {
-  var u54 = SIMD.int32x4(1, 2, 3, 4);
+test("Check if the flagW of Int32x4 object can be got and type of boolean", function () {
+  var u54 = SIMD.Int32x4(1, 2, 3, 4);
   equal(true, u54.flagW, "the flagW of u54 should be true");
-  var u64 = new SIMD.int32x4(0, 1, 0, 1);
+  var u64 = new SIMD.Int32x4(0, 1, 0, 1);
   equal(true, u64.flagW, "the flagW of u64 should be true");
 });
 
-test("Check if the fromFloat64x2 method of int32x4 is valid", function () {
-  var m = SIMD.int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
-  var nMask = SIMD.float64x2.fromInt32x4(m);
-  var n = SIMD.int32x4.fromFloat64x2(nMask);
+test("Check if the fromFloat64x2 method of Int32x4 is valid", function () {
+  var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
+  var nMask = SIMD.Float64x2.fromInt32x4(m);
+  var n = SIMD.Int32x4.fromFloat64x2(nMask);
   equal(0x3F800000, n.x, "the value of n.x should be 0x3F800000");
   equal(0x40000000, n.y, "the value of n.y should be 0x40000000");
   equal(0, n.z, "the value of n.z should be 0");
   equal(0, n.w, "the value of n.w should be 0");
 });
 
-test("Check if the fromFloat64x2Bits method of int32x4 is valid", function () {
-  var m = SIMD.int32x4(9, 10, 11, 12);
-  var nMask = SIMD.float64x2.fromInt32x4Bits(m);
-  var n = SIMD.int32x4.fromFloat64x2Bits(nMask);
+test("Check if the fromFloat64x2Bits method of Int32x4 is valid", function () {
+  var m = SIMD.Int32x4(9, 10, 11, 12);
+  var nMask = SIMD.Float64x2.fromInt32x4Bits(m);
+  var n = SIMD.Int32x4.fromFloat64x2Bits(nMask);
   equal(9, n.x, "the value of n.x should be 9");
   equal(10, n.y, "the value of n.y should be 10");
   equal(11, n.z, "the value of n.z should be 11");
   equal(12, n.w, "the value of n.w should be 12");
 });
 
-test("Check if the fromFloat32x4 method of int32x4 is valid", function () {
-  var m = SIMD.int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
-  var nMask = SIMD.float32x4.fromInt32x4(m);
-  var n = SIMD.int32x4.fromFloat32x4(nMask);
+test("Check if the fromFloat32x4 method of Int32x4 is valid", function () {
+  var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
+  var nMask = SIMD.Float32x4.fromInt32x4(m);
+  var n = SIMD.Int32x4.fromFloat32x4(nMask);
   equal(0x3F800000, n.x, "the value of n.x should be 0x3F800000");
   equal(0x40000000, n.y, "the value of n.y should be 0x40000000");
   equal(0x40400000, n.z, "the value of n.z should be 0");
   equal(0x40800000, n.w, "the value of n.w should be 0");
 });
 
-test("Check if the fromFloat32x4Bits method of int32x4 is valid", function () {
-  var m = SIMD.int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
-  var nMask = SIMD.float32x4.fromInt32x4Bits(m);
-  var n = SIMD.int32x4.fromFloat32x4Bits(nMask);
+test("Check if the fromFloat32x4Bits method of Int32x4 is valid", function () {
+  var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
+  var nMask = SIMD.Float32x4.fromInt32x4Bits(m);
+  var n = SIMD.Int32x4.fromFloat32x4Bits(nMask);
   equal(0x3F800000, n.x, "the value of n.x should be 0x3F800000");
   equal(0x40000000, n.y, "the value of n.y should be 0x40000000");
   equal(0x40400000, n.z, "the value of n.z should be 0");

--- a/webapi/webapi-simd-nonw3c-tests/tests.full.xml
+++ b/webapi/webapi-simd-nonw3c-tests/tests.full.xml
@@ -3,583 +3,583 @@
 <test_definition>
   <suite category="SIMD" name="webapi-simd-nonw3c-tests">
     <set name="webapi-simd-nonw3c-tests" type="qunit">
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_constructor" priority="P1" purpose="Check float32x4 constructor (0, 2, 2)" status="approved" subcase="6" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_constructor" priority="P1" purpose="Check Float32x4 constructor (0, 2, 2)" status="approved" subcase="6" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=1</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_scalar_getters" priority="P1" purpose="Check float32x4 scalar getters (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_scalar_getters" priority="P1" purpose="Check Float32x4 scalar getters (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=2</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_signMask_getter" priority="P1" purpose="Check float32x4 signMask getter (0, 3, 3)" status="approved" subcase="3" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_signMask_getter" priority="P1" purpose="Check Float32x4 signMask getter (0, 3, 3)" status="approved" subcase="3" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=3</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_vector_getters" priority="P1" purpose="Check float32x4 vector getters (0, 20, 20)" status="approved" subcase="20" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_vector_getters" priority="P1" purpose="Check Float32x4 vector getters (0, 20, 20)" status="approved" subcase="20" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=4</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_abs" priority="P1" purpose="Check float32x4 abs (0, 8, 8)" status="approved" subcase="8" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_abs" priority="P1" purpose="Check Float32x4 abs (0, 8, 8)" status="approved" subcase="8" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=5</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_neg" priority="P1" purpose="Check float32x4 neg (0, 8, 8)" status="approved" subcase="8" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_neg" priority="P1" purpose="Check Float32x4 neg (0, 8, 8)" status="approved" subcase="8" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=6</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_add" priority="P1" purpose="Check float32x4 add (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_add" priority="P1" purpose="Check Float32x4 add (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=7</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_sub" priority="P1" purpose="Check float32x4 sub (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_sub" priority="P1" purpose="Check Float32x4 sub (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=8</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_mul" priority="P1" purpose="Check float32x4 mul (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_mul" priority="P1" purpose="Check Float32x4 mul (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=9</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_div" priority="P1" purpose="Check float32x4 div (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_div" priority="P1" purpose="Check Float32x4 div (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=10</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_clamp" priority="P1" purpose="Check float32x4 clamp (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_clamp" priority="P1" purpose="Check Float32x4 clamp (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=11</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_min" priority="P1" purpose="Check float32x4 min (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_min" priority="P1" purpose="Check Float32x4 min (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=12</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_max" priority="P1" purpose="Check float32x4 max (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_max" priority="P1" purpose="Check Float32x4 max (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=13</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_reciprocal" priority="P1" purpose="Check float32x4 reciprocal (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_reciprocal" priority="P1" purpose="Check Float32x4 reciprocal (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=14</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_reciprocal_sqrt" priority="P1" purpose="Check float32x4 reciprocal sqrt (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_reciprocal_sqrt" priority="P1" purpose="Check Float32x4 reciprocal sqrt (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=15</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_scale" priority="P1" purpose="Check float32x4 scale (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_scale" priority="P1" purpose="Check Float32x4 scale (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=16</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_sqrt" priority="P1" purpose="Check float32x4 sqrt (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_sqrt" priority="P1" purpose="Check Float32x4 sqrt (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=17</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_withX" priority="P1" purpose="Check float32x4 withX (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_withX" priority="P1" purpose="Check Float32x4 withX (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=19</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_withY" priority="P1" purpose="Check float32x4 withY (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_withY" priority="P1" purpose="Check Float32x4 withY (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=20</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_withZ" priority="P1" purpose="Check float32x4 withZ (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_withZ" priority="P1" purpose="Check Float32x4 withZ (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=21</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_withW" priority="P1" purpose="Check float32x4 withW (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_withW" priority="P1" purpose="Check Float32x4 withW (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=22</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_int32x4_conversion" priority="P1" purpose="Check float32x4 int32x4 conversion (0, 20, 20)" status="approved" subcase="20" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_Int32x4_conversion" priority="P1" purpose="Check Float32x4 Int32x4 conversion (0, 20, 20)" status="approved" subcase="20" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=23</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_comparisons" priority="P1" purpose="Check float32x4 comparisons (0, 24, 24)" status="approved" subcase="24" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_comparisons" priority="P1" purpose="Check Float32x4 comparisons (0, 24, 24)" status="approved" subcase="24" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=24</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_select" priority="P1" purpose="Check int32x4 select (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_select" priority="P1" purpose="Check Int32x4 select (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=25</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withX" priority="P1" purpose="Check int32x4 withX (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withX" priority="P1" purpose="Check Int32x4 withX (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=26</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withY" priority="P1" purpose="Check int32x4 withY (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withY" priority="P1" purpose="Check Int32x4 withY (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=27</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withZ" priority="P1" purpose="Check int32x4 withZ (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withZ" priority="P1" purpose="Check Int32x4 withZ (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=28</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withW" priority="P1" purpose="Check int32x4 withW (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withW" priority="P1" purpose="Check Int32x4 withW (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=29</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withFlagX" priority="P1" purpose="Check int32x4 withFlagX (0, 12, 12)" status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withFlagX" priority="P1" purpose="Check Int32x4 withFlagX (0, 12, 12)" status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=30</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withFlagY" priority="P1" purpose="Check int32x4 withFlagY (0, 12, 12)" status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withFlagY" priority="P1" purpose="Check Int32x4 withFlagY (0, 12, 12)" status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=31</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withFlagZ" priority="P1" purpose="Check int32x4 withFlagZ (0, 13, 13)" status="approved" subcase="13" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withFlagZ" priority="P1" purpose="Check Int32x4 withFlagZ (0, 13, 13)" status="approved" subcase="13" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=32</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withFlagW" priority="P1" purpose="Check int32x4 withFlagW (0, 12, 12)" status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withFlagW" priority="P1" purpose="Check Int32x4 withFlagW (0, 12, 12)" status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=33</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_and" priority="P1" purpose="Check int32x4 and (0, 20, 20)" status="approved" subcase="20" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_and" priority="P1" purpose="Check Int32x4 and (0, 20, 20)" status="approved" subcase="20" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=34</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_or" priority="P1" purpose="Check int32x4 or (0, 8, 8)" status="approved" subcase="8" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_or" priority="P1" purpose="Check Int32x4 or (0, 8, 8)" status="approved" subcase="8" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=35</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_xor" priority="P1" purpose="Check int32x4 xor (0, 12, 12)" status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_xor" priority="P1" purpose="Check Int32x4 xor (0, 12, 12)" status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=36</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_neg" priority="P1" purpose="Check int32x4 neg (0, 8, 8)" status="approved" subcase="8" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_neg" priority="P1" purpose="Check Int32x4 neg (0, 8, 8)" status="approved" subcase="8" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=37</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_signMask_getter" priority="P1" purpose="Check int32x4 signMask getter (0, 3, 3)" status="approved" subcase="3" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_signMask_getter" priority="P1" purpose="Check Int32x4 signMask getter (0, 3, 3)" status="approved" subcase="3" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=38</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_add" priority="P1" purpose="Check int32x4 add (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_add" priority="P1" purpose="Check Int32x4 add (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=39</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_sub" priority="P1" purpose="Check int32x4 sub (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_sub" priority="P1" purpose="Check Int32x4 sub (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=40</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_mul" priority="P1" purpose="Check int32x4 mul (0, 4, 4)" status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_mul" priority="P1" purpose="Check Int32x4 mul (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=41</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_shiftLeftByScalar" priority="P1" purpose="Check shiftLeftByScalar method of int32x4 is valid" status="approved" subcase="16" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_shiftLeftByScalar" priority="P1" purpose="Check shiftLeftByScalar method of Int32x4 is valid" status="approved" subcase="16" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=50</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_shiftRightLogicalByScalar" priority="P1" purpose="Check shiftRightLogicalByScalar method of int32x4 is valid" status="approved" subcase="16" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_shiftRightLogicalByScalar" priority="P1" purpose="Check shiftRightLogicalByScalar method of Int32x4 is valid" status="approved" subcase="16" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=51</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_shiftRightArithmeticByScalar" priority="P1" purpose="Check shiftRightArithmeticByScalar method of int32x4 is valid" status="approved" subcase="16" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_shiftRightArithmeticByScalar" priority="P1" purpose="Check shiftRightArithmeticByScalar method of Int32x4 is valid" status="approved" subcase="16" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=52</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_shuffle" priority="P1" purpose="Check shuffle method of float32x4 is valid" status="approved" subcase="24" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_shuffle" priority="P1" purpose="Check shuffle method of Float32x4 is valid" status="approved" subcase="24" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=53</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_swizzle" priority="P1" purpose="Check swizzle method of float64x2 is valid" status="approved" subcase="8" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_swizzle" priority="P1" purpose="Check swizzle method of Float64x2 is valid" status="approved" subcase="8" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=54</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float64x2" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float64x2" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_shuffle" priority="P1" purpose="Check shuffle method of float64x2 is valid" status="approved" subcase="16" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_shuffle" priority="P1" purpose="Check shuffle method of Float64x2 is valid" status="approved" subcase="16" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=55</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="float64x2" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float64x2" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_shuffle" priority="P1" purpose="Check shuffle method of int32x4 is valid" status="approved" subcase="24" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_shuffle" priority="P1" purpose="Check shuffle method of Int32x4 is valid" status="approved" subcase="24" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=56</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_vector_getters" priority="P1" purpose="Check swizzle method of int32x4 is valid" status="approved" subcase="20" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_vector_getters" priority="P1" purpose="Check swizzle method of Int32x4 is valid" status="approved" subcase="20" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=57</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_zero" priority="P1" purpose="Check if the zero function of float32x4 can change the parameter to 0.0." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_zero" priority="P1" purpose="Check if the zero function of Float32x4 can change the parameter to 0.0." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=1</test_script_entry>
         </description>
@@ -591,7 +591,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_splat" priority="P1" purpose="Check if the splat function of float32x4 can change the parameter to specified value." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_splat" priority="P1" purpose="Check if the splat function of Float32x4 can change the parameter to specified value." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=2</test_script_entry>
         </description>
@@ -603,7 +603,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromFloat64x2" priority="P1" purpose="Check if the fromFloat64x2 method of float32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromFloat64x2" priority="P1" purpose="Check if the fromFloat64x2 method of Float32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=3</test_script_entry>
         </description>
@@ -615,7 +615,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromFloat64x2Bits" priority="P1" purpose="Check if the fromFloat64x2Bits method of float32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromFloat64x2Bits" priority="P1" purpose="Check if the fromFloat64x2Bits method of Float32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=4</test_script_entry>
         </description>
@@ -627,7 +627,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromInt32x4" priority="P1" purpose="Check if the fromInt32x4 method of float32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromInt32x4" priority="P1" purpose="Check if the fromInt32x4 method of Float32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=5</test_script_entry>
         </description>
@@ -639,7 +639,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromInt32x4Bits" priority="P1" purpose="Check if the fromInt32x4Bits method of float32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromInt32x4Bits" priority="P1" purpose="Check if the fromInt32x4Bits method of Float32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=6</test_script_entry>
         </description>
@@ -651,7 +651,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_select" priority="P1" purpose="Check if the select method of float32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_select" priority="P1" purpose="Check if the select method of Float32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=7</test_script_entry>
         </description>
@@ -663,7 +663,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_store_smi_check" priority="P1" purpose="Check if the store method of float32x4 with smi check." status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_store_smi_check" priority="P1" purpose="Check if the store method of Float32x4 with smi check." status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=8</test_script_entry>
         </description>
@@ -675,7 +675,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_constructor" priority="P1" purpose="Check if int32x4 object can be creat successful." status="approved" subcase="6" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_constructor" priority="P1" purpose="Check if Int32x4 object can be creat successful." status="approved" subcase="6" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=1</test_script_entry>
         </description>
@@ -687,7 +687,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getX" priority="P1" purpose="Check if the x value of int32x4 object can be got." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getX" priority="P1" purpose="Check if the x value of Int32x4 object can be got." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=2</test_script_entry>
         </description>
@@ -699,7 +699,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getY" priority="P1" purpose="Check if the y value of int32x4 object can be got." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getY" priority="P1" purpose="Check if the y value of Int32x4 object can be got." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=3</test_script_entry>
         </description>
@@ -711,7 +711,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getZ" priority="P1" purpose="Check if the z value of int32x4 object can be got." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getZ" priority="P1" purpose="Check if the z value of Int32x4 object can be got." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=4</test_script_entry>
         </description>
@@ -723,7 +723,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getW" priority="P1" purpose="Check if the w value of int32x4 object can be got." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getW" priority="P1" purpose="Check if the w value of Int32x4 object can be got." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=5</test_script_entry>
         </description>
@@ -735,7 +735,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_bool" priority="P1" purpose="Check if the bool function of int32x4 can change the parameter to (-1, 0, -1, 0)." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_bool" priority="P1" purpose="Check if the bool function of Int32x4 can change the parameter to (-1, 0, -1, 0)." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=6</test_script_entry>
         </description>
@@ -747,7 +747,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_splat" priority="P1" purpose="Check if the splat function of int32x4can change the parameter to specified value." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_splat" priority="P1" purpose="Check if the splat function of Int32x4can change the parameter to specified value." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=7</test_script_entry>
         </description>
@@ -759,7 +759,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagX" priority="P1" purpose="Check if the flagX of int32x4 object can be got and type of boolean." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagX" priority="P1" purpose="Check if the flagX of Int32x4 object can be got and type of boolean." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=8</test_script_entry>
         </description>
@@ -771,7 +771,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagY" priority="P1" purpose="Check if the flagY of int32x4 object can be got and type of boolean." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagY" priority="P1" purpose="Check if the flagY of Int32x4 object can be got and type of boolean." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=9</test_script_entry>
         </description>
@@ -783,7 +783,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagZ" priority="P1" purpose="Check if the flagZ of int32x4 object can be got and type of boolean." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagZ" priority="P1" purpose="Check if the flagZ of Int32x4 object can be got and type of boolean." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=10</test_script_entry>
         </description>
@@ -795,7 +795,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagW" priority="P1" purpose="Check if the flagW of int32x4 object can be got and type of boolean." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagW" priority="P1" purpose="Check if the flagW of Int32x4 object can be got and type of boolean." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=11</test_script_entry>
         </description>
@@ -807,7 +807,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat64x2" priority="P1" purpose="Check if the fromFloat64x2 method of int32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat64x2" priority="P1" purpose="Check if the fromFloat64x2 method of Int32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=12</test_script_entry>
         </description>
@@ -819,7 +819,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat64x2Bits" priority="P1" purpose="Check if the fromFloat64x2Bits method of int32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat64x2Bits" priority="P1" purpose="Check if the fromFloat64x2Bits method of Int32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=13</test_script_entry>
         </description>
@@ -831,7 +831,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat32x4" priority="P1" purpose="Check if the fromFloat32x4 method of int32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat32x4" priority="P1" purpose="Check if the fromFloat32x4 method of Int32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=14</test_script_entry>
         </description>
@@ -843,7 +843,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat32x4Bits" priority="P1" purpose="Check if the fromFloat32x4Bits method of int32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat32x4Bits" priority="P1" purpose="Check if the fromFloat32x4Bits method of Int32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=15</test_script_entry>
         </description>
@@ -855,1153 +855,1153 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_construct" priority="P1" purpose="Check if float64x2 object can be creat successful." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_construct" priority="P1" purpose="Check if Float64x2 object can be creat successful." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=1</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="construct" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="construct" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_zero" priority="P1" purpose="Check if the zero function of float64x2 can change the parameter to 0.0." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_zero" priority="P1" purpose="Check if the zero function of Float64x2 can change the parameter to 0.0." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=2</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="zero" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="zero" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_splat" priority="P1" purpose="Check if the splat function of float64x2 can change the parameter to specified value." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_splat" priority="P1" purpose="Check if the splat function of Float64x2 can change the parameter to specified value." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=3</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="splat" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="splat" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_fromFloat32x4Bits" priority="P1" purpose="Check if the fromFloat32x4Bits method of float64x2 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_fromFloat32x4Bits" priority="P1" purpose="Check if the fromFloat32x4Bits method of Float64x2 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=4</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromFloat32x4Bits" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromFloat32x4Bits" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_fromInt32x4Bits" priority="P1" purpose="Check if the fromInt32x4Bits method of float64x2 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_fromInt32x4Bits" priority="P1" purpose="Check if the fromInt32x4Bits method of Float64x2 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=5</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromInt32x4Bits" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromInt32x4Bits" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_fromInt32x4" priority="P1" purpose="Check if the fromInt32x4 method of float64x2 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_fromInt32x4" priority="P1" purpose="Check if the fromInt32x4 method of Float64x2 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=6</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromInt32x4" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromInt32x4" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_fromFloat32x4" priority="P1" purpose="Check if the fromFloat32x4 method of float64x2 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_fromFloat32x4" priority="P1" purpose="Check if the fromFloat32x4 method of Float64x2 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=7</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromFloat32x4" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromFloat32x4" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_abs" priority="P1" purpose="Check if the abs method of float64x2 is valid." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_abs" priority="P1" purpose="Check if the abs method of Float64x2 is valid." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=8</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="abs" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="abs" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_neg" priority="P1" purpose="Check if the neg method of float64x2 is valid." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_neg" priority="P1" purpose="Check if the neg method of Float64x2 is valid." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=9</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="neg" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="neg" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_add" priority="P1" purpose="Check if the add method of float64x2 is valid." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_add" priority="P1" purpose="Check if the add method of Float64x2 is valid." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=10</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="add" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="add" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_sub" priority="P1" purpose="Check if the sub method of float64x2 is valid." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_sub" priority="P1" purpose="Check if the sub method of Float64x2 is valid." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=11</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="sub" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="sub" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_mul" priority="P1" purpose="Check if the mul method of float64x2 is valid." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_mul" priority="P1" purpose="Check if the mul method of Float64x2 is valid." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=12</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="mul" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="mul" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_div" priority="P1" purpose="Check if the div method of float64x2 is valid." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_div" priority="P1" purpose="Check if the div method of Float64x2 is valid." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=13</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="div" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="div" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_clamp" priority="P1" purpose="Check if the clamp method of float64x2 is valid." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_clamp" priority="P1" purpose="Check if the clamp method of Float64x2 is valid." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=14</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="clamp" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="clamp" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_min" priority="P1" purpose="Check if the min method of float64x2 is valid." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_min" priority="P1" purpose="Check if the min method of Float64x2 is valid." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=15</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="min" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="min" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_max" priority="P1" purpose="Check if the max method of float64x2 is valid." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_max" priority="P1" purpose="Check if the max method of Float64x2 is valid." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=16</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="max" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="max" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_scale" priority="P1" purpose="Check if the scale method of float64x2 is valid." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_scale" priority="P1" purpose="Check if the scale method of Float64x2 is valid." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=19</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="scale" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="scale" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_sqrt" priority="P1" purpose="Check if the sqrt method of float64x2 is valid." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_sqrt" priority="P1" purpose="Check if the sqrt method of Float64x2 is valid." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=20</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="sqrt" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="sqrt" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_withX" priority="P1" purpose="Check if the withX method of float64x2 is valid." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_withX" priority="P1" purpose="Check if the withX method of Float64x2 is valid." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=23</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="withX" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="withX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_withY" priority="P1" purpose="Check if the withY method of float64x2 is valid." status="approved" subcase="2" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_withY" priority="P1" purpose="Check if the withY method of Float64x2 is valid." status="approved" subcase="2" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=24</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="withY" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="withY" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_load" priority="P1" purpose="Check if the load method of float32x4 is valid." status="approved" subcase="20" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_load" priority="P1" purpose="Check if the load method of Float32x4 is valid." status="approved" subcase="20" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=1</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_load" priority="P1" purpose="Check if the overaligned load method of float32x4 is valid." status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_load" priority="P1" purpose="Check if the overaligned load method of Float32x4 is valid." status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=2</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_load" priority="P1" purpose="Check if the unaligned load method of float32x4 is valid." status="approved" subcase="20" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_load" priority="P1" purpose="Check if the unaligned load method of Float32x4 is valid." status="approved" subcase="20" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=3</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_loadX" priority="P1" purpose="Check if the loadX method of float32x4 is valid." status="approved" subcase="32" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_loadX" priority="P1" purpose="Check if the loadX method of Float32x4 is valid." status="approved" subcase="32" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=4</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_loadX" priority="P1" purpose="Check if the overaligned loadX method of float32x4 is valid." status="approved" subcase="16" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_loadX" priority="P1" purpose="Check if the overaligned loadX method of Float32x4 is valid." status="approved" subcase="16" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=5</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_loadX" priority="P1" purpose="Check if the unaligned loadX method of float32x4 is valid." status="approved" subcase="32" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_loadX" priority="P1" purpose="Check if the unaligned loadX method of Float32x4 is valid." status="approved" subcase="32" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=6</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_loadXY" priority="P1" purpose="Check if the loadXY method of float32x4 is valid." status="approved" subcase="28" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_loadXY" priority="P1" purpose="Check if the loadXY method of Float32x4 is valid." status="approved" subcase="28" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=7</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_loadXY" priority="P1" purpose="Check if the overaligned loadXY method of float32x4 is valid." status="approved" subcase="16" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_loadXY" priority="P1" purpose="Check if the overaligned loadXY method of Float32x4 is valid." status="approved" subcase="16" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=8</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_loadXY" priority="P1" purpose="Check if the unaligned loadXY method of float32x4 is valid." status="approved" subcase="28" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_loadXY" priority="P1" purpose="Check if the unaligned loadXY method of Float32x4 is valid." status="approved" subcase="28" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=9</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_loadXYZ" priority="P1" purpose="Check if the loadXYZ method of float32x4 is valid." status="approved" subcase="28" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_loadXYZ" priority="P1" purpose="Check if the loadXYZ method of Float32x4 is valid." status="approved" subcase="28" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=10</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_loadXYZ" priority="P1" purpose="Check if the overaligned loadXYZ method of float32x4 is valid." status="approved" subcase="16" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_loadXYZ" priority="P1" purpose="Check if the overaligned loadXYZ method of Float32x4 is valid." status="approved" subcase="16" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=11</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_loadXYZ" priority="P1" purpose="Check if the unaligned loadXYZ method of float32x4 is valid." status="approved" subcase="28" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_loadXYZ" priority="P1" purpose="Check if the unaligned loadXYZ method of Float32x4 is valid." status="approved" subcase="28" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=12</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_store" priority="P1" purpose="Check if the store method of float32x4 is valid." status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_store" priority="P1" purpose="Check if the store method of Float32x4 is valid." status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=13</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_store" priority="P1" purpose="Check if the overaligned store method of float32x4 is valid." status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_store" priority="P1" purpose="Check if the overaligned store method of Float32x4 is valid." status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=14</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_store" priority="P1" purpose="Check if the unaligned store method of float32x4 is valid." status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_store" priority="P1" purpose="Check if the unaligned store method of Float32x4 is valid." status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=15</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_storeX" priority="P1" purpose="Check if the storeX method of float32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_storeX" priority="P1" purpose="Check if the storeX method of Float32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=16</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_storeX" priority="P1" purpose="Check if the overaligned storeX method of float32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_storeX" priority="P1" purpose="Check if the overaligned storeX method of Float32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=17</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_storeX" priority="P1" purpose="Check if the unaligned storeX method of float32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_storeX" priority="P1" purpose="Check if the unaligned storeX method of Float32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=18</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_storeXY" priority="P1" purpose="Check if the storeXY method of float32x4 is valid." status="approved" subcase="8" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_storeXY" priority="P1" purpose="Check if the storeXY method of Float32x4 is valid." status="approved" subcase="8" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=19</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_storeXY" priority="P1" purpose="Check if the overaligned storeXY method of float32x4 is valid." status="approved" subcase="8" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_storeXY" priority="P1" purpose="Check if the overaligned storeXY method of Float32x4 is valid." status="approved" subcase="8" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=20</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_storeXY" priority="P1" purpose="Check if the unaligned storeXY method of float32x4 is valid." status="approved" subcase="8" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_storeXY" priority="P1" purpose="Check if the unaligned storeXY method of Float32x4 is valid." status="approved" subcase="8" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=21</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_storeXYZ" priority="P1" purpose="Check if the storeXYZ method of float32x4 is valid." status="approved" subcase="9" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_storeXYZ" priority="P1" purpose="Check if the storeXYZ method of Float32x4 is valid." status="approved" subcase="9" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=22</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_storeXYZ" priority="P1" purpose="Check if the overaligned storeXYZ method of float32x4 is valid." status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_storeXYZ" priority="P1" purpose="Check if the overaligned storeXYZ method of Float32x4 is valid." status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=23</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_storeXYZ" priority="P1" purpose="Check if the unaligned storeXYZ method of float32x4 is valid." status="approved" subcase="9" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_storeXYZ" priority="P1" purpose="Check if the unaligned storeXYZ method of Float32x4 is valid." status="approved" subcase="9" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=24</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_load" priority="P1" purpose="Check if the load method of float32x4 throw exception normally." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_load" priority="P1" purpose="Check if the load method of Float32x4 throw exception normally." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=25</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_loadX" priority="P1" purpose="Check if the loadX method of float32x4 throw exception normally." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_loadX" priority="P1" purpose="Check if the loadX method of Float32x4 throw exception normally." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=26</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_loadXY" priority="P1" purpose="Check if the loadXY method of float32x4 throw exception normally." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_loadXY" priority="P1" purpose="Check if the loadXY method of Float32x4 throw exception normally." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=27</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_loadXYZ" priority="P1" purpose="Check if the loadXYZ method of float32x4 throw exception normally." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_loadXYZ" priority="P1" purpose="Check if the loadXYZ method of Float32x4 throw exception normally." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=28</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_store" priority="P1" purpose="Check if the store method of float32x4 throw exception normally." status="approved" subcase="5" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_store" priority="P1" purpose="Check if the store method of Float32x4 throw exception normally." status="approved" subcase="5" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=29</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_storeX" priority="P1" purpose="Check if the storeX method of float32x4 throw exception normally." status="approved" subcase="5" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_storeX" priority="P1" purpose="Check if the storeX method of Float32x4 throw exception normally." status="approved" subcase="5" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=30</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_storeXY" priority="P1" purpose="Check if the storeXY method of float32x4 throw exception normally." status="approved" subcase="5" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_storeXY" priority="P1" purpose="Check if the storeXY method of Float32x4 throw exception normally." status="approved" subcase="5" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=31</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_storeXYZ" priority="P1" purpose="Check if the storeXYZ method of float32x4 throw exception normally." status="approved" subcase="5" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_storeXYZ" priority="P1" purpose="Check if the storeXYZ method of Float32x4 throw exception normally." status="approved" subcase="5" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=32</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_load" priority="P1" purpose="Check if the load method of float64x4 is valid." status="approved" subcase="14" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_load" priority="P1" purpose="Check if the load method of float64x4 is valid." status="approved" subcase="14" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=33</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_unaligned_load" priority="P1" purpose="Check if the unaligned load method of float64x4 is valid." status="approved" subcase="14" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_unaligned_load" priority="P1" purpose="Check if the unaligned load method of float64x4 is valid." status="approved" subcase="14" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=34</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_loadX" priority="P1" purpose="Check if the loadX method of float64x4 is valid." status="approved" subcase="16" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_loadX" priority="P1" purpose="Check if the loadX method of float64x4 is valid." status="approved" subcase="16" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=35</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_unaligned_loadX" priority="P1" purpose="Check if the unaligned loadX method of float64x4 is valid." status="approved" subcase="16" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_unaligned_loadX" priority="P1" purpose="Check if the unaligned loadX method of float64x4 is valid." status="approved" subcase="16" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=36</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_store" priority="P1" purpose="Check if the store method of float64x4 is valid." status="approved" subcase="6" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_store" priority="P1" purpose="Check if the store method of float64x4 is valid." status="approved" subcase="6" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=37</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_unaligned_store" priority="P1" purpose="Check if the unaligned store method of float64x4 is valid." status="approved" subcase="6" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_unaligned_store" priority="P1" purpose="Check if the unaligned store method of float64x4 is valid." status="approved" subcase="6" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=38</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_storeX" priority="P1" purpose="Check if the storeX method of float64x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_storeX" priority="P1" purpose="Check if the storeX method of float64x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=39</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_unaligned_storeX" priority="P1" purpose="Check if the unaligned storeX method of float64x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_unaligned_storeX" priority="P1" purpose="Check if the unaligned storeX method of float64x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=40</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_load_exception" priority="P1" purpose="Check if the load method of float64x4 throw exception noramlly." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_load_exception" priority="P1" purpose="Check if the load method of float64x4 throw exception noramlly." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=41</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_loadX_exception" priority="P1" purpose="Check if the loadX method of float64x4 throw exception noramlly." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_loadX_exception" priority="P1" purpose="Check if the loadX method of float64x4 throw exception noramlly." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=42</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_store_exception" priority="P1" purpose="Check if the store method of float64x4 throw exception noramlly." status="approved" subcase="5" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_store_exception" priority="P1" purpose="Check if the store method of float64x4 throw exception noramlly." status="approved" subcase="5" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=43</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_storeX_exception" priority="P1" purpose="Check if the storeX method of float64x4 throw exception noramlly." status="approved" subcase="5" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_storeX_exception" priority="P1" purpose="Check if the storeX method of float64x4 throw exception noramlly." status="approved" subcase="5" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=44</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_load" priority="P1" purpose="Check if the load method of int32x4 is valid." status="approved" subcase="20" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_load" priority="P1" purpose="Check if the load method of Int32x4 is valid." status="approved" subcase="20" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=45</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_load" priority="P1" purpose="Check if the overaligned load method of int32x4 is valid." status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_load" priority="P1" purpose="Check if the overaligned load method of Int32x4 is valid." status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=46</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_load" priority="P1" purpose="Check if the unaligned load method of int32x4 is valid." status="approved" subcase="20" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_load" priority="P1" purpose="Check if the unaligned load method of Int32x4 is valid." status="approved" subcase="20" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=47</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_loadX" priority="P1" purpose="Check if the loadX method of int32x4 is valid." status="approved" subcase="32" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_loadX" priority="P1" purpose="Check if the loadX method of Int32x4 is valid." status="approved" subcase="32" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=48</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_loadX" priority="P1" purpose="Check if the overaligned loadX method of int32x4 is valid." status="approved" subcase="32" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_loadX" priority="P1" purpose="Check if the overaligned loadX method of Int32x4 is valid." status="approved" subcase="32" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=49</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_loadX" priority="P1" purpose="Check if the unaligned loadX method of int32x4 is valid." status="approved" subcase="32" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_loadX" priority="P1" purpose="Check if the unaligned loadX method of Int32x4 is valid." status="approved" subcase="32" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=50</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_loadXY" priority="P1" purpose="Check if the loadXY method of int32x4 is valid." status="approved" subcase="28" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_loadXY" priority="P1" purpose="Check if the loadXY method of Int32x4 is valid." status="approved" subcase="28" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=51</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_loadXY" priority="P1" purpose="Check if the overaligned loadXY method of int32x4 is valid." status="approved" subcase="16" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_loadXY" priority="P1" purpose="Check if the overaligned loadXY method of Int32x4 is valid." status="approved" subcase="16" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=52</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_loadXY" priority="P1" purpose="Check if the unaligned loadXY method of int32x4 is valid." status="approved" subcase="28" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_loadXY" priority="P1" purpose="Check if the unaligned loadXY method of Int32x4 is valid." status="approved" subcase="28" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=53</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_loadXYZ" priority="P1" purpose="Check if the loadXYZ method of int32x4 is valid." status="approved" subcase="28" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_loadXYZ" priority="P1" purpose="Check if the loadXYZ method of Int32x4 is valid." status="approved" subcase="28" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=54</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_loadXYZ" priority="P1" purpose="Check if the overaligned loadXYZ method of int32x4 is valid." status="approved" subcase="16" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_loadXYZ" priority="P1" purpose="Check if the overaligned loadXYZ method of Int32x4 is valid." status="approved" subcase="16" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=55</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_loadXYZ" priority="P1" purpose="Check if the unaligned loadXYZ method of int32x4 is valid." status="approved" subcase="28" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_loadXYZ" priority="P1" purpose="Check if the unaligned loadXYZ method of Int32x4 is valid." status="approved" subcase="28" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=56</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_store" priority="P1" purpose="Check if the store method of int32x4 is valid." status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_store" priority="P1" purpose="Check if the store method of Int32x4 is valid." status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=57</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_store" priority="P1" purpose="Check if the overaligned store method of int32x4 is valid." status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_store" priority="P1" purpose="Check if the overaligned store method of Int32x4 is valid." status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=58</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_store" priority="P1" purpose="Check if the unaligned store method of int32x4 is valid." status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_store" priority="P1" purpose="Check if the unaligned store method of Int32x4 is valid." status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=59</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_storeX" priority="P1" purpose="Check if the storeX method of int32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_storeX" priority="P1" purpose="Check if the storeX method of Int32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=60</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_storeX" priority="P1" purpose="Check if the overaligned storeX method of int32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_storeX" priority="P1" purpose="Check if the overaligned storeX method of Int32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=61</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_storeX" priority="P1" purpose="Check if the unaligned storeX method of int32x4 is valid." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_storeX" priority="P1" purpose="Check if the unaligned storeX method of Int32x4 is valid." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=62</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_storeXY" priority="P1" purpose="Check if the storeXY method of int32x4 is valid." status="approved" subcase="8" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_storeXY" priority="P1" purpose="Check if the storeXY method of Int32x4 is valid." status="approved" subcase="8" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=63</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_storeXY" priority="P1" purpose="Check if the overaligned storeXY method of int32x4 is valid." status="approved" subcase="8" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_storeXY" priority="P1" purpose="Check if the overaligned storeXY method of Int32x4 is valid." status="approved" subcase="8" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=64</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_storeXY" priority="P1" purpose="Check if the unaligned storeXY method of int32x4 is valid." status="approved" subcase="8" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_storeXY" priority="P1" purpose="Check if the unaligned storeXY method of Int32x4 is valid." status="approved" subcase="8" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=65</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_storeXYZ" priority="P1" purpose="Check if the storeXYZ method of int32x4 is valid." status="approved" subcase="9" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_storeXYZ" priority="P1" purpose="Check if the storeXYZ method of Int32x4 is valid." status="approved" subcase="9" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=66</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_storeXYZ" priority="P1" purpose="Check if the overaligned storeXYZ method of int32x4 is valid." status="approved" subcase="12" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_storeXYZ" priority="P1" purpose="Check if the overaligned storeXYZ method of Int32x4 is valid." status="approved" subcase="12" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=67</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_storeXYZ" priority="P1" purpose="Check if the unaligned storeXYZ method of int32x4 is valid." status="approved" subcase="9" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_storeXYZ" priority="P1" purpose="Check if the unaligned storeXYZ method of Int32x4 is valid." status="approved" subcase="9" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=68</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_load_exceptions" priority="P1" purpose="Check if the load method of int32x4 throw exception noramlly." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_load_exceptions" priority="P1" purpose="Check if the load method of Int32x4 throw exception noramlly." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=69</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_loadX_exceptions" priority="P1" purpose="Check if the loadX method of int32x4 throw exception noramlly." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_loadX_exceptions" priority="P1" purpose="Check if the loadX method of Int32x4 throw exception noramlly." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=70</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_loadXY_exceptions" priority="P1" purpose="Check if the loadXY method of int32x4 throw exception noramlly." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_loadXY_exceptions" priority="P1" purpose="Check if the loadXY method of Int32x4 throw exception noramlly." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=71</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_loadXYZ_exceptions" priority="P1" purpose="Check if the loadXYZ method of int32x4 throw exception noramlly." status="approved" subcase="4" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_loadXYZ_exceptions" priority="P1" purpose="Check if the loadXYZ method of Int32x4 throw exception noramlly." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=72</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_store_exceptions" priority="P1" purpose="Check if the store method of int32x4 throw exception noramlly." status="approved" subcase="5" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_store_exceptions" priority="P1" purpose="Check if the store method of Int32x4 throw exception noramlly." status="approved" subcase="5" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=73</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_storeX_exceptions" priority="P1" purpose="Check if the storeX method of int32x4 throw exception noramlly." status="approved" subcase="5" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_storeX_exceptions" priority="P1" purpose="Check if the storeX method of Int32x4 throw exception noramlly." status="approved" subcase="5" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=74</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_storeXY_exceptions" priority="P1" purpose="Check if the storeXY method of int32x4 throw exception noramlly." status="approved" subcase="5" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_storeXY_exceptions" priority="P1" purpose="Check if the storeXY method of Int32x4 throw exception noramlly." status="approved" subcase="5" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=75</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_storeXYZ_exceptions" priority="P1" purpose="Check if the storeXYZ method of int32x4 throw exception noramlly." status="approved" subcase="5" type="compliance">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_storeXYZ_exceptions" priority="P1" purpose="Check if the storeXYZ method of Int32x4 throw exception noramlly." status="approved" subcase="5" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=76</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
             <spec_statement />
           </spec>

--- a/webapi/webapi-simd-nonw3c-tests/tests.full.xml
+++ b/webapi/webapi-simd-nonw3c-tests/tests.full.xml
@@ -9,9 +9,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -21,9 +21,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -33,9 +33,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -45,9 +45,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -57,9 +57,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -69,9 +69,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -81,9 +81,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -93,9 +93,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -105,9 +105,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -117,9 +117,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -129,9 +129,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -141,9 +141,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -153,9 +153,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -165,9 +165,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -177,9 +177,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -189,9 +189,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -201,9 +201,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -213,9 +213,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -225,9 +225,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -237,9 +237,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -249,9 +249,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -261,9 +261,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -273,9 +273,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -285,9 +285,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -297,9 +297,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -309,9 +309,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -321,9 +321,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -333,9 +333,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -345,9 +345,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -357,9 +357,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -369,9 +369,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -381,9 +381,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -393,9 +393,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -405,9 +405,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -417,9 +417,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -429,9 +429,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -441,9 +441,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -453,9 +453,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -465,9 +465,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -477,9 +477,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -489,9 +489,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -501,9 +501,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -513,9 +513,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -525,9 +525,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -537,9 +537,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float64x2" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float64x2" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -549,9 +549,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float64x2" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float64x2" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -561,9 +561,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -573,9 +573,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -585,9 +585,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -597,9 +597,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -609,9 +609,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromFloat64x2" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromFloat64x2" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -621,9 +621,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromFloat64x2Bits" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromFloat64x2Bits" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -633,9 +633,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromInt32x4" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromInt32x4" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -645,9 +645,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromInt32x4Bits" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromInt32x4Bits" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -657,9 +657,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="select" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="select" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -669,9 +669,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="select" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="select" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -681,9 +681,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -693,9 +693,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -705,9 +705,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -717,9 +717,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -729,9 +729,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -741,9 +741,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -753,9 +753,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -765,9 +765,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -777,9 +777,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -789,9 +789,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -801,9 +801,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="Int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -813,9 +813,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromFloat64x2" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromFloat64x2" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -825,9 +825,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromFloat64x2Bits" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromFloat64x2Bits" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -837,9 +837,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromFloat32x4" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromFloat32x4" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -849,9 +849,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromFloat32x4Bits" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromFloat32x4Bits" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -861,9 +861,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="construct" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="construct" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -873,9 +873,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="zero" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="zero" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -885,9 +885,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="splat" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="splat" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -897,9 +897,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromFloat32x4Bits" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromFloat32x4Bits" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -909,9 +909,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromInt32x4Bits" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromInt32x4Bits" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -921,9 +921,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromInt32x4" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromInt32x4" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -933,9 +933,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="fromFloat32x4" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="fromFloat32x4" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -945,9 +945,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="abs" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="abs" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -957,9 +957,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="neg" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="neg" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -969,9 +969,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="add" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="add" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -981,9 +981,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="sub" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="sub" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -993,9 +993,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="mul" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="mul" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1005,9 +1005,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="div" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="div" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1017,9 +1017,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="clamp" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="clamp" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1029,9 +1029,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="min" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="min" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1041,9 +1041,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="max" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="max" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1053,9 +1053,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="scale" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="scale" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1065,9 +1065,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="sqrt" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="sqrt" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1077,9 +1077,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="withX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="withX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1089,9 +1089,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="withY" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="withY" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1101,9 +1101,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1113,9 +1113,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1125,9 +1125,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1137,9 +1137,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1149,9 +1149,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1161,9 +1161,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1173,9 +1173,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1185,9 +1185,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1197,9 +1197,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1209,9 +1209,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1221,9 +1221,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1233,9 +1233,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1245,9 +1245,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1257,9 +1257,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1269,9 +1269,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1281,9 +1281,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1293,9 +1293,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1305,9 +1305,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1317,9 +1317,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1329,9 +1329,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1341,9 +1341,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1353,9 +1353,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1365,9 +1365,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1377,9 +1377,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1389,9 +1389,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1401,9 +1401,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1413,9 +1413,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1425,9 +1425,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1437,9 +1437,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1449,9 +1449,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1461,9 +1461,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1473,9 +1473,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Float32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1485,9 +1485,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1497,9 +1497,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1509,9 +1509,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1521,9 +1521,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1533,9 +1533,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1545,9 +1545,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1557,9 +1557,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1569,9 +1569,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1581,9 +1581,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1593,9 +1593,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1605,9 +1605,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1617,9 +1617,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Float64x2" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1629,9 +1629,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1641,9 +1641,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1653,9 +1653,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1665,9 +1665,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1677,9 +1677,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1689,9 +1689,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1701,9 +1701,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1713,9 +1713,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1725,9 +1725,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1737,9 +1737,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1749,9 +1749,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1761,9 +1761,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1773,9 +1773,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1785,9 +1785,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1797,9 +1797,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1809,9 +1809,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1821,9 +1821,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1833,9 +1833,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1845,9 +1845,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1857,9 +1857,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1869,9 +1869,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1881,9 +1881,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1893,9 +1893,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1905,9 +1905,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1917,9 +1917,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="load" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1929,9 +1929,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1941,9 +1941,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1953,9 +1953,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="loadXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1965,9 +1965,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="store" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1977,9 +1977,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeX" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -1989,9 +1989,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXY" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>
@@ -2001,9 +2001,9 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD" />
+            <spec_assertion category="SIMD" element_name="storeXYZ" element_type="method" interface="Int32x4" section="SIMD" specification="SIMD"/>
             <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
+            <spec_statement/>
           </spec>
         </specs>
       </testcase>

--- a/webapi/webapi-simd-nonw3c-tests/tests.xml
+++ b/webapi/webapi-simd-nonw3c-tests/tests.xml
@@ -3,837 +3,837 @@
 <test_definition>
   <suite category="SIMD" name="webapi-simd-nonw3c-tests">
     <set name="webapi-simd-nonw3c-tests" type="qunit">
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_constructor" purpose="Check float32x4 constructor (0, 2, 2)" subcase="6">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_constructor" purpose="Check Float32x4 constructor (0, 2, 2)" subcase="6">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_scalar_getters" purpose="Check float32x4 scalar getters (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_scalar_getters" purpose="Check Float32x4 scalar getters (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_signMask_getter" purpose="Check float32x4 signMask getter (0, 3, 3)" subcase="3">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_signMask_getter" purpose="Check Float32x4 signMask getter (0, 3, 3)" subcase="3">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_vector_getters" purpose="Check float32x4 vector getters (0, 20, 20)" subcase="20">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_vector_getters" purpose="Check Float32x4 vector getters (0, 20, 20)" subcase="20">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_abs" purpose="Check float32x4 abs (0, 8, 8)" subcase="8">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_abs" purpose="Check Float32x4 abs (0, 8, 8)" subcase="8">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=5</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_neg" purpose="Check float32x4 neg (0, 8, 8)" subcase="8">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_neg" purpose="Check Float32x4 neg (0, 8, 8)" subcase="8">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=6</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_add" purpose="Check float32x4 add (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_add" purpose="Check Float32x4 add (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=7</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_sub" purpose="Check float32x4 sub (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_sub" purpose="Check Float32x4 sub (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=8</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_mul" purpose="Check float32x4 mul (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_mul" purpose="Check Float32x4 mul (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=9</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_div" purpose="Check float32x4 div (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_div" purpose="Check Float32x4 div (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=10</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_clamp" purpose="Check float32x4 clamp (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_clamp" purpose="Check Float32x4 clamp (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=11</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_min" purpose="Check float32x4 min (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_min" purpose="Check Float32x4 min (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=12</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_max" purpose="Check float32x4 max (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_max" purpose="Check Float32x4 max (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=13</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_reciprocal" purpose="Check float32x4 reciprocal (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_reciprocal" purpose="Check Float32x4 reciprocal (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=14</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_reciprocal_sqrt" purpose="Check float32x4 reciprocal sqrt (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_reciprocal_sqrt" purpose="Check Float32x4 reciprocal sqrt (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=15</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_scale" purpose="Check float32x4 scale (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_scale" purpose="Check Float32x4 scale (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=16</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_sqrt" purpose="Check float32x4 sqrt (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_sqrt" purpose="Check Float32x4 sqrt (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=17</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_withX" purpose="Check float32x4 withX (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_withX" purpose="Check Float32x4 withX (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=19</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_withY" purpose="Check float32x4 withY (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_withY" purpose="Check Float32x4 withY (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=20</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_withZ" purpose="Check float32x4 withZ (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_withZ" purpose="Check Float32x4 withZ (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=21</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_withW" purpose="Check float32x4 withW (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_withW" purpose="Check Float32x4 withW (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=22</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_int32x4_conversion" purpose="Check float32x4 int32x4 conversion (0, 20, 20)" subcase="20">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_Int32x4_conversion" purpose="Check Float32x4 Int32x4 conversion (0, 20, 20)" subcase="20">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=23</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_comparisons" purpose="Check float32x4 comparisons (0, 24, 24)" subcase="24">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_comparisons" purpose="Check Float32x4 comparisons (0, 24, 24)" subcase="24">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=24</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_select" purpose="Check int32x4 select (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_select" purpose="Check Int32x4 select (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=25</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withX" purpose="Check int32x4 withX (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withX" purpose="Check Int32x4 withX (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=26</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withY" purpose="Check int32x4 withY (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withY" purpose="Check Int32x4 withY (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=27</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withZ" purpose="Check int32x4 withZ (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withZ" purpose="Check Int32x4 withZ (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=28</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withW" purpose="Check int32x4 withW (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withW" purpose="Check Int32x4 withW (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=29</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withFlagX" purpose="Check int32x4 withFlagX (0, 12, 12)" subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withFlagX" purpose="Check Int32x4 withFlagX (0, 12, 12)" subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=30</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withFlagY" purpose="Check int32x4 withFlagY (0, 12, 12)" subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withFlagY" purpose="Check Int32x4 withFlagY (0, 12, 12)" subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=31</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withFlagZ" purpose="Check int32x4 withFlagZ (0, 13, 13)" subcase="13">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withFlagZ" purpose="Check Int32x4 withFlagZ (0, 13, 13)" subcase="13">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=32</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_withFlagW" purpose="Check int32x4 withFlagW (0, 12, 12)" subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_withFlagW" purpose="Check Int32x4 withFlagW (0, 12, 12)" subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=33</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_and" purpose="Check int32x4 and (0, 20, 20)" subcase="20">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_and" purpose="Check Int32x4 and (0, 20, 20)" subcase="20">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=34</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_or" purpose="Check int32x4 or (0, 8, 8)" subcase="8">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_or" purpose="Check Int32x4 or (0, 8, 8)" subcase="8">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=35</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_xor" purpose="Check int32x4 xor (0, 12, 12)" subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_xor" purpose="Check Int32x4 xor (0, 12, 12)" subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=36</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_neg" purpose="Check int32x4 neg (0, 8, 8)" subcase="8">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_neg" purpose="Check Int32x4 neg (0, 8, 8)" subcase="8">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=37</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_signMask_getter" purpose="Check int32x4 signMask getter (0, 3, 3)" subcase="3">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_signMask_getter" purpose="Check Int32x4 signMask getter (0, 3, 3)" subcase="3">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=38</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_add" purpose="Check int32x4 add (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_add" purpose="Check Int32x4 add (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=39</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_sub" purpose="Check int32x4 sub (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_sub" purpose="Check Int32x4 sub (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=40</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_mul" purpose="Check int32x4 mul (0, 4, 4)" subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_mul" purpose="Check Int32x4 mul (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=41</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_shiftLeftByScalar" purpose="Check shiftLeftByScalar method of int32x4 is valid" subcase="16">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_shiftLeftByScalar" purpose="Check shiftLeftByScalar method of Int32x4 is valid" subcase="16">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=50</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_shiftRightLogicalByScalar" purpose="Check shiftRightLogicalByScalar method of int32x4 is valid" subcase="16">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_shiftRightLogicalByScalar" purpose="Check shiftRightLogicalByScalar method of Int32x4 is valid" subcase="16">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=51</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_shiftRightArithmeticByScalar" purpose="Check shiftRightArithmeticByScalar method of int32x4 is valid" subcase="16">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_shiftRightArithmeticByScalar" purpose="Check shiftRightArithmeticByScalar method of Int32x4 is valid" subcase="16">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=52</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_shuffle" purpose="Check shuffle method of float32x4 is valid" subcase="24">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_shuffle" purpose="Check shuffle method of Float32x4 is valid" subcase="24">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=53</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_swizzle" purpose="Check swizzle method of float64x2 is valid" subcase="8">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_swizzle" purpose="Check swizzle method of Float64x2 is valid" subcase="8">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=54</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_shuffle" purpose="Check shuffle method of float64x2 is valid" subcase="16">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_shuffle" purpose="Check shuffle method of Float64x2 is valid" subcase="16">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=55</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_shuffle" purpose="Check shuffle method of int32x4 is valid" subcase="24">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_shuffle" purpose="Check shuffle method of Int32x4 is valid" subcase="24">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=56</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_vector_getters" purpose="Check swizzle method of int32x4 is valid" subcase="20">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_vector_getters" purpose="Check swizzle method of Int32x4 is valid" subcase="20">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=57</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_zero" purpose="Check if the zero function of float32x4 can change the parameter to 0.0." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_zero" purpose="Check if the zero function of Float32x4 can change the parameter to 0.0." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_splat" purpose="Check if the splat function of float32x4 can change the parameter to specified value." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_splat" purpose="Check if the splat function of Float32x4 can change the parameter to specified value." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromFloat64x2" purpose="Check if the fromFloat64x2 method of float32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromFloat64x2" purpose="Check if the fromFloat64x2 method of Float32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromFloat64x2Bits" purpose="Check if the fromFloat64x2Bits method of float32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromFloat64x2Bits" purpose="Check if the fromFloat64x2Bits method of Float32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromInt32x4" purpose="Check if the fromInt32x4 method of float32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromInt32x4" purpose="Check if the fromInt32x4 method of Float32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=5</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromInt32x4Bits" purpose="Check if the fromInt32x4Bits method of float32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_fromInt32x4Bits" purpose="Check if the fromInt32x4Bits method of Float32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=6</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_select" purpose="Check if the select method of float32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_select" purpose="Check if the select method of Float32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=7</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_store_smi_check" purpose="Check if the store method of float32x4 with smi check." subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_store_smi_check" purpose="Check if the store method of Float32x4 with smi check." subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=8</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_constructor" purpose="Check if int32x4 object can be creat successful." subcase="6">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_constructor" purpose="Check if Int32x4 object can be creat successful." subcase="6">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getX" purpose="Check if the x value of int32x4 object can be got." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getX" purpose="Check if the x value of Int32x4 object can be got." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getY" purpose="Check if the y value of int32x4 object can be got." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getY" purpose="Check if the y value of Int32x4 object can be got." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getZ" purpose="Check if the z value of int32x4 object can be got." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getZ" purpose="Check if the z value of Int32x4 object can be got." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getW" purpose="Check if the w value of int32x4 object can be got." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_getW" purpose="Check if the w value of Int32x4 object can be got." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=5</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_bool" purpose="Check if the bool function of int32x4 can change the parameter to (-1, 0, -1, 0)." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_bool" purpose="Check if the bool function of Int32x4 can change the parameter to (-1, 0, -1, 0)." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=6</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_splat" purpose="Check if the splat function of int32x4can change the parameter to specified value." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_splat" purpose="Check if the splat function of Int32x4can change the parameter to specified value." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=7</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagX" purpose="Check if the flagX of int32x4 object can be got and type of boolean." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagX" purpose="Check if the flagX of Int32x4 object can be got and type of boolean." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=8</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagY" purpose="Check if the flagY of int32x4 object can be got and type of boolean." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagY" purpose="Check if the flagY of Int32x4 object can be got and type of boolean." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=9</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagZ" purpose="Check if the flagZ of int32x4 object can be got and type of boolean." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagZ" purpose="Check if the flagZ of Int32x4 object can be got and type of boolean." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=10</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagW" purpose="Check if the flagW of int32x4 object can be got and type of boolean." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_flagW" purpose="Check if the flagW of Int32x4 object can be got and type of boolean." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=11</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat64x2" purpose="Check if the fromFloat64x2 method of int32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat64x2" purpose="Check if the fromFloat64x2 method of Int32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=12</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat64x2Bits" purpose="Check if the fromFloat64x2Bits method of int32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat64x2Bits" purpose="Check if the fromFloat64x2Bits method of Int32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=13</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat32x4" purpose="Check if the fromFloat32x4 method of int32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat32x4" purpose="Check if the fromFloat32x4 method of Int32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=14</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat32x4Bits" purpose="Check if the fromFloat32x4Bits method of int32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_fromFloat32x4Bits" purpose="Check if the fromFloat32x4Bits method of Int32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/int32x4.html?testNumber=15</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_construct" purpose="Check if float64x2 object can be creat successful." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_construct" purpose="Check if Float64x2 object can be creat successful." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_zero" purpose="Check if the zero function of float64x2 can change the parameter to 0.0." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_zero" purpose="Check if the zero function of Float64x2 can change the parameter to 0.0." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_splat" purpose="Check if the splat function of float64x2 can change the parameter to specified value." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_splat" purpose="Check if the splat function of Float64x2 can change the parameter to specified value." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_fromFloat32x4Bits" purpose="Check if the fromFloat32x4Bits method of float64x2 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_fromFloat32x4Bits" purpose="Check if the fromFloat32x4Bits method of Float64x2 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_fromInt32x4Bits" purpose="Check if the fromInt32x4Bits method of float64x2 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_fromInt32x4Bits" purpose="Check if the fromInt32x4Bits method of Float64x2 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=5</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_fromInt32x4" purpose="Check if the fromInt32x4 method of float64x2 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_fromInt32x4" purpose="Check if the fromInt32x4 method of Float64x2 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=6</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_fromFloat32x4" purpose="Check if the fromFloat32x4 method of float64x2 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_fromFloat32x4" purpose="Check if the fromFloat32x4 method of Float64x2 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=7</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_abs" purpose="Check if the abs method of float64x2 is valid." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_abs" purpose="Check if the abs method of Float64x2 is valid." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=8</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_neg" purpose="Check if the neg method of float64x2 is valid." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_neg" purpose="Check if the neg method of Float64x2 is valid." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=9</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_add" purpose="Check if the add method of float64x2 is valid." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_add" purpose="Check if the add method of Float64x2 is valid." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=10</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_sub" purpose="Check if the sub method of float64x2 is valid." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_sub" purpose="Check if the sub method of Float64x2 is valid." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=11</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_mul" purpose="Check if the mul method of float64x2 is valid." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_mul" purpose="Check if the mul method of Float64x2 is valid." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=12</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_div" purpose="Check if the div method of float64x2 is valid." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_div" purpose="Check if the div method of Float64x2 is valid." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=13</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_clamp" purpose="Check if the clamp method of float64x2 is valid." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_clamp" purpose="Check if the clamp method of Float64x2 is valid." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=14</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_min" purpose="Check if the min method of float64x2 is valid." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_min" purpose="Check if the min method of Float64x2 is valid." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=15</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_max" purpose="Check if the max method of float64x2 is valid." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_max" purpose="Check if the max method of Float64x2 is valid." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=16</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_scale" purpose="Check if the scale method of float64x2 is valid." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_scale" purpose="Check if the scale method of Float64x2 is valid." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=19</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_sqrt" purpose="Check if the sqrt method of float64x2 is valid." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_sqrt" purpose="Check if the sqrt method of Float64x2 is valid." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=20</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_withX" purpose="Check if the withX method of float64x2 is valid." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_withX" purpose="Check if the withX method of Float64x2 is valid." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=23</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_withY" purpose="Check if the withY method of float64x2 is valid." subcase="2">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_withY" purpose="Check if the withY method of Float64x2 is valid." subcase="2">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float64x2.html?testNumber=24</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_load" purpose="Check if the load method of float32x4 is valid." subcase="20">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_load" purpose="Check if the load method of Float32x4 is valid." subcase="20">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_load" purpose="Check if the overaligned load method of float32x4 is valid." subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_load" purpose="Check if the overaligned load method of Float32x4 is valid." subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_load" purpose="Check if the unaligned load method of float32x4 is valid." subcase="20">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_load" purpose="Check if the unaligned load method of Float32x4 is valid." subcase="20">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_loadX" purpose="Check if the loadX method of float32x4 is valid." subcase="32">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_loadX" purpose="Check if the loadX method of Float32x4 is valid." subcase="32">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_loadX" purpose="Check if the overaligned loadX method of float32x4 is valid." subcase="16">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_loadX" purpose="Check if the overaligned loadX method of Float32x4 is valid." subcase="16">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=5</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_loadX" purpose="Check if the unaligned loadX method of float32x4 is valid." subcase="32">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_loadX" purpose="Check if the unaligned loadX method of Float32x4 is valid." subcase="32">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=6</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_loadXY" purpose="Check if the loadXY method of float32x4 is valid." subcase="28">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_loadXY" purpose="Check if the loadXY method of Float32x4 is valid." subcase="28">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=7</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_loadXY" purpose="Check if the overaligned loadXY method of float32x4 is valid." subcase="16">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_loadXY" purpose="Check if the overaligned loadXY method of Float32x4 is valid." subcase="16">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=8</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_loadXY" purpose="Check if the unaligned loadXY method of float32x4 is valid." subcase="28">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_loadXY" purpose="Check if the unaligned loadXY method of Float32x4 is valid." subcase="28">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=9</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_loadXYZ" purpose="Check if the loadXYZ method of float32x4 is valid." subcase="28">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_loadXYZ" purpose="Check if the loadXYZ method of Float32x4 is valid." subcase="28">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=10</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_loadXYZ" purpose="Check if the overaligned loadXYZ method of float32x4 is valid." subcase="16">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_loadXYZ" purpose="Check if the overaligned loadXYZ method of Float32x4 is valid." subcase="16">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=11</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_loadXYZ" purpose="Check if the unaligned loadXYZ method of float32x4 is valid." subcase="28">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_loadXYZ" purpose="Check if the unaligned loadXYZ method of Float32x4 is valid." subcase="28">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=12</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_store" purpose="Check if the store method of float32x4 is valid." subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_store" purpose="Check if the store method of Float32x4 is valid." subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=13</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_store" purpose="Check if the overaligned store method of float32x4 is valid." subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_store" purpose="Check if the overaligned store method of Float32x4 is valid." subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=14</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_store" purpose="Check if the unaligned store method of float32x4 is valid." subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_store" purpose="Check if the unaligned store method of Float32x4 is valid." subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=15</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_storeX" purpose="Check if the storeX method of float32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_storeX" purpose="Check if the storeX method of Float32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=16</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_storeX" purpose="Check if the overaligned storeX method of float32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_storeX" purpose="Check if the overaligned storeX method of Float32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=17</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_storeX" purpose="Check if the unaligned storeX method of float32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_storeX" purpose="Check if the unaligned storeX method of Float32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=18</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_storeXY" purpose="Check if the storeXY method of float32x4 is valid." subcase="8">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_storeXY" purpose="Check if the storeXY method of Float32x4 is valid." subcase="8">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=19</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_storeXY" purpose="Check if the overaligned storeXY method of float32x4 is valid." subcase="8">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_storeXY" purpose="Check if the overaligned storeXY method of Float32x4 is valid." subcase="8">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=20</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_storeXY" purpose="Check if the unaligned storeXY method of float32x4 is valid." subcase="8">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_storeXY" purpose="Check if the unaligned storeXY method of Float32x4 is valid." subcase="8">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=21</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_storeXYZ" purpose="Check if the storeXYZ method of float32x4 is valid." subcase="9">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_storeXYZ" purpose="Check if the storeXYZ method of Float32x4 is valid." subcase="9">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=22</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_overaligned_storeXYZ" purpose="Check if the overaligned storeXYZ method of float32x4 is valid." subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_overaligned_storeXYZ" purpose="Check if the overaligned storeXYZ method of Float32x4 is valid." subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=23</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_unaligned_storeXYZ" purpose="Check if the unaligned storeXYZ method of float32x4 is valid." subcase="9">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_unaligned_storeXYZ" purpose="Check if the unaligned storeXYZ method of Float32x4 is valid." subcase="9">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=24</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_load" purpose="Check if the load method of float32x4 throw exception normally." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_load" purpose="Check if the load method of Float32x4 throw exception normally." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=25</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_loadX" purpose="Check if the loadX method of float32x4 throw exception normally." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_loadX" purpose="Check if the loadX method of Float32x4 throw exception normally." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=26</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_loadXY" purpose="Check if the loadXY method of float32x4 throw exception normally." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_loadXY" purpose="Check if the loadXY method of Float32x4 throw exception normally." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=27</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_loadXYZ" purpose="Check if the loadXYZ method of float32x4 throw exception normally." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_loadXYZ" purpose="Check if the loadXYZ method of Float32x4 throw exception normally." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=28</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_store" purpose="Check if the store method of float32x4 throw exception normally." subcase="5">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_store" purpose="Check if the store method of Float32x4 throw exception normally." subcase="5">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=29</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_storeX" purpose="Check if the storeX method of float32x4 throw exception normally." subcase="5">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_storeX" purpose="Check if the storeX method of Float32x4 throw exception normally." subcase="5">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=30</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_storeXY" purpose="Check if the storeXY method of float32x4 throw exception normally." subcase="5">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_storeXY" purpose="Check if the storeXY method of Float32x4 throw exception normally." subcase="5">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=31</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float32x4_exception_storeXYZ" purpose="Check if the storeXYZ method of float32x4 throw exception normally." subcase="5">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float32x4_exception_storeXYZ" purpose="Check if the storeXYZ method of Float32x4 throw exception normally." subcase="5">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=32</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_load" purpose="Check if the load method of float64x4 is valid." subcase="14">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_load" purpose="Check if the load method of float64x4 is valid." subcase="14">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=33</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_unaligned_load" purpose="Check if the unaligned load method of float64x4 is valid." subcase="14">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_unaligned_load" purpose="Check if the unaligned load method of float64x4 is valid." subcase="14">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=34</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_loadX" purpose="Check if the loadX method of float64x4 is valid." subcase="16">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_loadX" purpose="Check if the loadX method of float64x4 is valid." subcase="16">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=35</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_unaligned_loadX" purpose="Check if the unaligned loadX method of float64x4 is valid." subcase="16">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_unaligned_loadX" purpose="Check if the unaligned loadX method of float64x4 is valid." subcase="16">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=36</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_store" purpose="Check if the store method of float64x4 is valid." subcase="6">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_store" purpose="Check if the store method of float64x4 is valid." subcase="6">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=37</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_unaligned_store" purpose="Check if the unaligned store method of float64x4 is valid." subcase="6">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_unaligned_store" purpose="Check if the unaligned store method of float64x4 is valid." subcase="6">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=38</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_storeX" purpose="Check if the storeX method of float64x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_storeX" purpose="Check if the storeX method of float64x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=39</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_unaligned_storeX" purpose="Check if the unaligned storeX method of float64x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_unaligned_storeX" purpose="Check if the unaligned storeX method of float64x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=40</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_load_exception" purpose="Check if the load method of float64x4 throw exception noramlly." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_load_exception" purpose="Check if the load method of float64x4 throw exception noramlly." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=41</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_loadX_exception" purpose="Check if the loadX method of float64x4 throw exception noramlly." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_loadX_exception" purpose="Check if the loadX method of float64x4 throw exception noramlly." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=42</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_store_exception" purpose="Check if the store method of float64x4 throw exception noramlly." subcase="5">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_store_exception" purpose="Check if the store method of float64x4 throw exception noramlly." subcase="5">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=43</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="float64x2_storeX_exception" purpose="Check if the storeX method of float64x4 throw exception noramlly." subcase="5">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Float64x2_storeX_exception" purpose="Check if the storeX method of float64x4 throw exception noramlly." subcase="5">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=44</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_load" purpose="Check if the load method of int32x4 is valid." subcase="20">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_load" purpose="Check if the load method of Int32x4 is valid." subcase="20">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=45</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_load" purpose="Check if the overaligned load method of int32x4 is valid." subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_load" purpose="Check if the overaligned load method of Int32x4 is valid." subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=46</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_load" purpose="Check if the unaligned load method of int32x4 is valid." subcase="20">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_load" purpose="Check if the unaligned load method of Int32x4 is valid." subcase="20">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=47</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_loadX" purpose="Check if the loadX method of int32x4 is valid." subcase="32">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_loadX" purpose="Check if the loadX method of Int32x4 is valid." subcase="32">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=48</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_loadX" purpose="Check if the overaligned loadX method of int32x4 is valid." subcase="32">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_loadX" purpose="Check if the overaligned loadX method of Int32x4 is valid." subcase="32">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=49</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_loadX" purpose="Check if the unaligned loadX method of int32x4 is valid." subcase="32">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_loadX" purpose="Check if the unaligned loadX method of Int32x4 is valid." subcase="32">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=50</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_loadXY" purpose="Check if the loadXY method of int32x4 is valid." subcase="28">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_loadXY" purpose="Check if the loadXY method of Int32x4 is valid." subcase="28">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=51</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_loadXY" purpose="Check if the overaligned loadXY method of int32x4 is valid." subcase="16">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_loadXY" purpose="Check if the overaligned loadXY method of Int32x4 is valid." subcase="16">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=52</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_loadXY" purpose="Check if the unaligned loadXY method of int32x4 is valid." subcase="28">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_loadXY" purpose="Check if the unaligned loadXY method of Int32x4 is valid." subcase="28">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=53</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_loadXYZ" purpose="Check if the loadXYZ method of int32x4 is valid." subcase="28">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_loadXYZ" purpose="Check if the loadXYZ method of Int32x4 is valid." subcase="28">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=54</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_loadXYZ" purpose="Check if the overaligned loadXYZ method of int32x4 is valid." subcase="16">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_loadXYZ" purpose="Check if the overaligned loadXYZ method of Int32x4 is valid." subcase="16">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=55</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_loadXYZ" purpose="Check if the unaligned loadXYZ method of int32x4 is valid." subcase="28">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_loadXYZ" purpose="Check if the unaligned loadXYZ method of Int32x4 is valid." subcase="28">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=56</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_store" purpose="Check if the store method of int32x4 is valid." subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_store" purpose="Check if the store method of Int32x4 is valid." subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=57</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_store" purpose="Check if the overaligned store method of int32x4 is valid." subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_store" purpose="Check if the overaligned store method of Int32x4 is valid." subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=58</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_store" purpose="Check if the unaligned store method of int32x4 is valid." subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_store" purpose="Check if the unaligned store method of Int32x4 is valid." subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=59</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_storeX" purpose="Check if the storeX method of int32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_storeX" purpose="Check if the storeX method of Int32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=60</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_storeX" purpose="Check if the overaligned storeX method of int32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_storeX" purpose="Check if the overaligned storeX method of Int32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=61</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_storeX" purpose="Check if the unaligned storeX method of int32x4 is valid." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_storeX" purpose="Check if the unaligned storeX method of Int32x4 is valid." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=62</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_storeXY" purpose="Check if the storeXY method of int32x4 is valid." subcase="8">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_storeXY" purpose="Check if the storeXY method of Int32x4 is valid." subcase="8">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=63</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_storeXY" purpose="Check if the overaligned storeXY method of int32x4 is valid." subcase="8">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_storeXY" purpose="Check if the overaligned storeXY method of Int32x4 is valid." subcase="8">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=64</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_storeXY" purpose="Check if the unaligned storeXY method of int32x4 is valid." subcase="8">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_storeXY" purpose="Check if the unaligned storeXY method of Int32x4 is valid." subcase="8">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=65</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_storeXYZ" purpose="Check if the storeXYZ method of int32x4 is valid." subcase="9">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_storeXYZ" purpose="Check if the storeXYZ method of Int32x4 is valid." subcase="9">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=66</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_overaligned_storeXYZ" purpose="Check if the overaligned storeXYZ method of int32x4 is valid." subcase="12">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_overaligned_storeXYZ" purpose="Check if the overaligned storeXYZ method of Int32x4 is valid." subcase="12">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=67</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_unaligned_storeXYZ" purpose="Check if the unaligned storeXYZ method of int32x4 is valid." subcase="9">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_unaligned_storeXYZ" purpose="Check if the unaligned storeXYZ method of Int32x4 is valid." subcase="9">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=68</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_load_exceptions" purpose="Check if the load method of int32x4 throw exception noramlly." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_load_exceptions" purpose="Check if the load method of Int32x4 throw exception noramlly." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=69</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_loadX_exceptions" purpose="Check if the loadX method of int32x4 throw exception noramlly." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_loadX_exceptions" purpose="Check if the loadX method of Int32x4 throw exception noramlly." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=70</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_loadXY_exceptions" purpose="Check if the loadXY method of int32x4 throw exception noramlly." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_loadXY_exceptions" purpose="Check if the loadXY method of Int32x4 throw exception noramlly." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=71</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_loadXYZ_exceptions" purpose="Check if the loadXYZ method of int32x4 throw exception noramlly." subcase="4">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_loadXYZ_exceptions" purpose="Check if the loadXYZ method of Int32x4 throw exception noramlly." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=72</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_store_exceptions" purpose="Check if the store method of int32x4 throw exception noramlly." subcase="5">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_store_exceptions" purpose="Check if the store method of Int32x4 throw exception noramlly." subcase="5">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=73</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_storeX_exceptions" purpose="Check if the storeX method of int32x4 throw exception noramlly." subcase="5">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_storeX_exceptions" purpose="Check if the storeX method of Int32x4 throw exception noramlly." subcase="5">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=74</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_storeXY_exceptions" purpose="Check if the storeXY method of int32x4 throw exception noramlly." subcase="5">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_storeXY_exceptions" purpose="Check if the storeXY method of Int32x4 throw exception noramlly." subcase="5">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=75</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="int32x4_storeXYZ_exceptions" purpose="Check if the storeXYZ method of int32x4 throw exception noramlly." subcase="5">
+      <testcase component="Supplementary APIs/Experimental/SIMD" execution_type="auto" id="Int32x4_storeXYZ_exceptions" purpose="Check if the storeXYZ method of Int32x4 throw exception noramlly." subcase="5">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html?testNumber=76</test_script_entry>
         </description>


### PR DESCRIPTION
- Change type name from all lower case to first Character upper case<br>
  SIMD.float32x4 -> SIMD.Float32x4<br>
  SIMD.int32x4 -> SIMD.Int32x4<br>
  SIMD.float64x2 -> SIMD.Float64x2<br>
- Failure Analysis:<br>
  https://crosswalk-project.org/jira/browse/XWALK-4147<br>
  https://crosswalk-project.org/jira/browse/XWALK-4148<br>
  https://crosswalk-project.org/jira/browse/XWALK-4222<br>

Impacted tests(approved): new 0, update 1503, delete 0
Unit test platform: Crosswalk Project for Android 16.45.418.0
Unit test result summary: pass 1459, fail 44, block 0

https://crosswalk-project.org/jira/browse/XWALK-5151