### PR TITLE
[Crosswalk-15][stability] Instead unavailable website for ScrollLargeHightPage

### DIFF
--- a/stability/stability-manual-android-tests/suite.json
+++ b/stability/stability-manual-android-tests/suite.json
@@ -40,7 +40,7 @@
                     "install-path": "testapp",
                     "apk-icon-opt": "",
                     "apk-type": "HOSTEDAPP",
-                    "apk-url-opt": "http://nontroppo.org/timer/"
+                    "apk-url-opt": "http://worlds-highest-website.com"
                 },
                 "downloadtest": {
                     "app-name": "downloadtest",


### PR DESCRIPTION
http://nontroppo.org/timer cannot access now,
use http://worlds-highest-website.com instead.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android 16.45.418.0
Unit test result summary: pass 1, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-5123