### PR TITLE
[Crosswalk-15][webapi]Hidden test by manual in cancel-when-hidden-manual

### DIFF
--- a/webapi/tct-vibration-w3c-tests/vibration/w3c/COPYING
+++ b/webapi/tct-vibration-w3c-tests/vibration/w3c/COPYING
@@ -1,7 +1,11 @@
 All the files except this COPYING come from
 https://github.com/w3c/web-platform-tests/tree/master/vibration
-without modification except necessary adjustment on reference path
-to the testharness.
+with modifications:
+1. necessary adjustment on reference path to the testharness.
+2. cancel-when-hidden-manual.html
+   Base comments in https://crosswalk-project.org/jira/browse/XWALK-4307
+   remove window.open/close, update to hidden by manual.
+
 
 These tests are copyright by W3C and/or the author listed in the test
 file. The tests are dual-licensed under the W3C Test Suite License:

--- a/webapi/tct-vibration-w3c-tests/vibration/w3c/cancel-when-hidden-manual.html
+++ b/webapi/tct-vibration-w3c-tests/vibration/w3c/cancel-when-hidden-manual.html
@@ -14,24 +14,16 @@
 
 <h1>Description</h1>
 <p>
-  After hitting the button below, your device must vibrate for a short period of time (roughly one
-  second). If it vibrates for a longer time (roughly five seconds, it should feel somewhat long) then
-  the test has failed.
+  After hitting the button below, your device must vibrate, and stop when switch test to background.
+  If it does not stop after switch then the test has failed.
 </p>
 <button id='vib'>Vibrate!</button>
 <script src='vendor-prefix.js' data-prefixed-objects='[{"ancestors":["navigator"], "name":"vibrate"}]'></script>
 <script>
-  var win;
 
   if (undefined !== navigator.vibrate) {
     document.getElementById('vib').onclick = function () {
-      navigator.vibrate(5000);
-      setTimeout(function () {
-        win = window.open('about:blank', '_blank');
-        setTimeout(function() {
-          win.close();
-        }, 100);
-      }, 1000);
+      navigator.vibrate(50000);
     };
   }
 </script>


### PR DESCRIPTION
Remove window.open/close, default multiple windows is not
supported in Crosswalk, change test to hidden by manual.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android 15.44.383.0
Unit test result summary: pass 1, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-4307