### PR TITLE
[stability]Revise to use sample apps instead for launch/exit

### DIFF
--- a/stability/stability-iterative-android-tests/README
+++ b/stability/stability-iterative-android-tests/README
@@ -3,7 +3,15 @@
 This test suite is for testing stability-iterative-android-tests specification
 
 ##Pre condition
-* Don't install any irrelevant apps before test
+* Don't install any irrelevant apps before test expect the sample apps:
+  Hangonman
+  Helloworld
+  Hexgl
+  Memorygame
+  Simd
+  Spacedodgegame
+  Webgl
+  Webrtc
 
 ## Authors:
 

--- a/stability/stability-iterative-android-tests/iterative/Launch_Exit_Repeatedly.py
+++ b/stability/stability-iterative-android-tests/iterative/Launch_Exit_Repeatedly.py
@@ -28,6 +28,7 @@
 #
 # Authors:
 #         Hongjuan, Wang<hongjuanx.wang@intel.com>
+#         Li, Hao<haox.li@intel.com>
 
 import unittest
 import os
@@ -66,16 +67,15 @@ class TestStabilityIterativeFunctions(unittest.TestCase):
         i = 0
         while True:
             i = i + 1
-            apps_list = {'tct_fileapi_w3c_tests': 'TctFileapiW3cTests',
-                         'tct_fullscreen_nonw3c_tests': 'TctFullscreenNonw3cTests',
-                         'tct_mediacapture_w3c_tests': 'TctMediacaptureW3cTests',
-                         'tct_websocket_w3c_tests': 'TctWebsocketW3cTests',
-                         'gallery': 'Gallery',
-                         'hangonman': 'Hangonman',
+            apps_list = {'hangonman': 'Hangonman',
+                         'helloworld': 'Helloworld',
                          'hexgl': 'Hexgl',
-                         'sysapps': 'Sysapps',
-                         'memorygame': 'Memorygame'
-                         }
+                         'memorygame': 'Memorygame',
+                         'simd': 'Simd',
+                         'spacedodgegame': 'Spacedodgegame',
+                         'webgl': 'Webgl',
+                         'webrtc': 'Webrtc'
+                        }
             elapsed_time = time.time() - pre_time
             if elapsed_time >= runtime:
                 print i, elapsed_time, 'Process finished'
@@ -99,11 +99,13 @@ class TestStabilityIterativeFunctions(unittest.TestCase):
                             pkg +
                             'Activity')
                         self.assertNotIn('Error', launchstatus[1])
+                        time.sleep(1)
                         commands.getstatusoutput(
                             'adb -s ' +
                             device +
                             ' shell am force-stop org.xwalk.' +
                             name)
+                        time.sleep(1)
                         stopresult = commands.getstatusoutput(
                             'adb -s ' +
                             device +


### PR DESCRIPTION
Use sample apps instead to test launch/exit repeatly, so only get
test apps from crosswalk sampleapp binary.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android 16.45.418.0
Unit test result summary: pass 1, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5125