### PR TITLE
i[EmbeddingApi] Add embedding usecase to test XWalkUIClient.onUnhandl…

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -550,6 +550,15 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="XWalkView.Basic" />
             </intent-filter>
-        </activity>                  
+        </activity>
+        <activity
+            android:name=".XWalkViewWithOnUnhandledKeyEventAsync"
+            android:label="XWalkViewWithOnUnhandledKeyEventAsync"
+            android:parentActivityName=".XWalkEmbeddedAPISample">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkview.UIClient.ResourceClient" />
+            </intent-filter>
+        </activity>        
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_on_unhandled_keyevent.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_on_unhandled_keyevent.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (c) 2014 Intel Corporation. All rights reserved.
+
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.sample.XWalkViewWithOnUnhandledKeyEvent">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="If onUnhandledKeyEvent is invoked, below will show the 'onUnhandledKeyEvent is invoked. Event is '"
+        android:id="@+id/textView" />
+    
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textColor="#00ff00"
+        android:id="@+id/unhandled_keyevent_label"
+        android:layout_below="@+id/textView"/>
+    
+    <org.xwalk.core.XWalkView
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/unhandled_keyevent_label" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -556,3 +556,13 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load, setInitialScale methods
 
+
+
+### 57. The [XWalkViewWithOnUnhandledKeyEventAsync](XWalkViewWithOnUnhandledKeyEventAsync.java) sample check XWalkUIClient.onUnhandledKeyEvent method work as same as WebView, include:
+
+* XWalkUIClient.onUnhandledKeyEvent can be invoked
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: XWalkUIClient.onUnhandledKeyEvent methods
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkViewWithOnUnhandledKeyEventAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkViewWithOnUnhandledKeyEventAsync.java
@@ -1,0 +1,94 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.asyncsample;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkUIClient;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.widget.TextView;
+
+
+public class XWalkViewWithOnUnhandledKeyEventAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private TextView mTextView;
+    private XWalkInitializer mXWalkInitializer;
+    private static final String TAG = XWalkViewWithOnUnhandledKeyEventAsync.class.getName();
+
+    class UIClient extends XWalkUIClient {
+
+        public UIClient(XWalkView xwalkView) {
+            super(xwalkView);
+        }
+
+		@Override
+		public void onUnhandledKeyEvent(XWalkView view, KeyEvent event) {
+			// TODO Auto-generated method stub
+			Log.d(TAG, "onUnhandledKeyEvent.");
+			super.onUnhandledKeyEvent(view, event);
+			mTextView.setText("onUnhandledKeyEvent is invoked. Event is " + event);
+		}
+
+		@Override
+		public boolean shouldOverrideKeyEvent(XWalkView view, KeyEvent event) {
+			// TODO Auto-generated method stub
+			Log.d(TAG, "shouldOverrideKeyEvent.");
+			return false;
+		}        
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        setContentView(R.layout.activity_xwalk_view_with_on_unhandled_keyevent);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mTextView = (TextView) findViewById(R.id.unhandled_keyevent_label);    
+    
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView UI Client can override 'onUnhandledKeyEvent' method.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Load baidu webpage.\n")
+        .append("2. Input any words in the input field.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if text shows \"onUnhandledKeyEvent is invoked\".");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView.setUIClient(new UIClient(mXWalkView));
+        mXWalkView.load("http://www.baidu.com/", null);
+    }
+}
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -556,6 +556,15 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="XWalkView.Basic" />
             </intent-filter>
-        </activity>         
+        </activity>
+        <activity
+            android:name=".XWalkViewWithOnUnhandledKeyEvent"
+            android:label="XWalkViewWithOnUnhandledKeyEvent"
+            android:parentActivityName=".XWalkEmbeddedAPISample">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkview.UIClient.ResourceClient" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_on_unhandled_keyevent.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_on_unhandled_keyevent.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (c) 2014 Intel Corporation. All rights reserved.
+
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.sample.XWalkViewWithOnUnhandledKeyEvent">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="If onUnhandledKeyEvent is invoked, below will show the 'onUnhandledKeyEvent is invoked. Event is '"
+        android:id="@+id/textView" />
+    
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textColor="#00ff00"
+        android:id="@+id/unhandled_keyevent_label"
+        android:layout_below="@+id/textView"/>
+    
+    <org.xwalk.core.XWalkView
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/unhandled_keyevent_label" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -564,3 +564,13 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load, setInitialScale methods
 
+
+
+### 57. The [XWalkViewWithOnUnhandledKeyEvent](XWalkViewWithOnUnhandledKeyEvent.java) sample check XWalkUIClient.onUnhandledKeyEvent method work as same as WebView, include:
+
+* XWalkUIClient.onUnhandledKeyEvent can be invoked
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: XWalkUIClient.onUnhandledKeyEvent methods
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithOnUnhandledKeyEvent.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithOnUnhandledKeyEvent.java
@@ -1,0 +1,73 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.sample;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkUIClient;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.widget.TextView;
+
+
+public class XWalkViewWithOnUnhandledKeyEvent extends XWalkActivity {
+    private XWalkView mXWalkView;
+    private TextView mTextView;
+    private static final String TAG = XWalkViewWithOnUnhandledKeyEvent.class.getName();
+
+    class UIClient extends XWalkUIClient {
+
+        public UIClient(XWalkView xwalkView) {
+            super(xwalkView);
+        }
+
+		@Override
+		public void onUnhandledKeyEvent(XWalkView view, KeyEvent event) {
+			// TODO Auto-generated method stub
+			Log.d(TAG, "onUnhandledKeyEvent.");
+			super.onUnhandledKeyEvent(view, event);
+			mTextView.setText("onUnhandledKeyEvent is invoked. Event is " + event);
+		}
+
+		@Override
+		public boolean shouldOverrideKeyEvent(XWalkView view, KeyEvent event) {
+			// TODO Auto-generated method stub
+			Log.d(TAG, "shouldOverrideKeyEvent.");
+			return false;
+		}        
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_xwalk_view_with_on_unhandled_keyevent);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mTextView = (TextView) findViewById(R.id.unhandled_keyevent_label);        
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView UI Client can override 'onUnhandledKeyEvent' method.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Load baidu webpage.\n")
+        .append("2. Input any words in the input field.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if text shows \"onUnhandledKeyEvent is invoked\".");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView.setUIClient(new UIClient(mXWalkView));
+        mXWalkView.load("http://www.baidu.com/", null);
+    }
+}
+

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -692,7 +692,19 @@
           </steps>
           <test_script_entry test_script_expected_result="0" />
         </description>
-      </testcase>      
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnUnhandledKeyEvent" purpose="XWalkViewWithOnUnhandledKeyEvent Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewUIInflationAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -1386,7 +1398,19 @@
           </steps>
           <test_script_entry test_script_expected_result="0" />
         </description>
-      </testcase>      
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnUnhandledKeyEventAsync" purpose="XWalkViewWithOnUnhandledKeyEventAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Auto" type="js" ui-auto="bdd">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="PauseJsTimers" purpose="Pause js timers Test With XWalkActivity">

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -780,7 +780,20 @@
           </steps>
           <test_script_entry test_script_expected_result="0" />
         </description>
-      </testcase>      
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnUnhandledKeyEvent" platform="android" priority="P0" purpose="XWalkViewWithOnUnhandledKeyEvent Test With XWalkActivity" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewUIInflationAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -1458,7 +1471,20 @@
           </steps>
           <test_script_entry test_script_expected_result="0" />
         </description>
-      </testcase>      
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnUnhandledKeyEventAsync" platform="android" priority="P0" purpose="XWalkViewWithOnUnhandledKeyEventAsync Test With XWalkInitializer" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Auto" type="js" ui-auto="bdd">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="auto" id="PauseJsTimers" platform="android" priority="P0" purpose="Pause js timers Test With XWalkActivity" status="approved" type="functional_positive">


### PR DESCRIPTION
…edKeyEvent method

-Add embedding usecase to test XWalkUIClient.onUnhandledKeyEvent method
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-5212