### PR TITLE
[EmbeddingApi-usecase] Add usecase for UIClient.openFileChooser to op…

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -578,5 +578,14 @@
                 <category android:name="XWalkView.Basic" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".XWalkViewWithOpenFileChooserAsync"
+            android:label="XWalkViewWithOpenFileChooserAsync"
+            android:parentActivityName=".XWalkEmbeddedAPISample">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkview.UIClient.ResourceClient" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/open_file.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/open_file.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>Open System Media Picture:<br><br><input type="file"></body>
+</html>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/openfile_layout.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/openfile_layout.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (c) 2014 Intel Corporation. All rights reserved.
+
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file.
+-->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" >
+
+    <org.xwalk.core.XWalkView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/xwalkview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="5" >
+    </org.xwalk.core.XWalkView>
+    
+    <ImageView
+        android:id="@+id/imageview"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:layout_weight="1"
+        android:scaleType="centerCrop"
+        android:background="#0000ff" />
+
+</LinearLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -586,3 +586,13 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load
 
+
+
+### 59. The [XWalkViewWithOpenFileChooser](XWalkViewWithOpenFileChooser.java) sample check XWalkView can open local file, include:
+
+* XWalkUIClient.openFileChooser can be invoked
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: XWalkUIClient.openFileChooser methods
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkViewWithOpenFileChooserAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/XWalkViewWithOpenFileChooserAsync.java
@@ -1,0 +1,111 @@
+package org.xwalk.embedded.api.asyncsample;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkUIClient;
+import org.xwalk.core.XWalkView;
+
+import android.content.ContentResolver;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.Bundle;
+import android.provider.MediaStore;
+import android.webkit.ValueCallback;
+import android.widget.ImageView;
+
+public class XWalkViewWithOpenFileChooserAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private XWalkInitializer mXWalkInitializer;
+    private ImageView mImageView;
+    private ValueCallback<Uri> mUploadMessage;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        setContentView(R.layout.openfile_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mImageView = (ImageView) findViewById(R.id.imageview);
+
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can open local file.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Click 'Choose File' button.\n")
+        .append("2. Select system gallery app and choose one photo.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if this photo shows on the green background region.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView.setUIClient(new UIClient(mXWalkView));
+        mXWalkView.load("file:///android_asset/open_file.html", null);
+    }
+
+
+    class UIClient extends XWalkUIClient {
+
+        public UIClient(XWalkView xwalkView) {
+            super(xwalkView);
+        }
+
+        public void openFileChooser(XWalkView view, ValueCallback<Uri> uploadFile,
+                String acceptType, String capture) {
+            super.openFileChooser(view, uploadFile, acceptType, capture);
+            mUploadMessage = uploadFile;
+        }
+    }
+
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        // TODO Auto-generated method stub
+        if (mUploadMessage == null) return;
+        Uri result = intent == null || resultCode != RESULT_OK ? null : intent.getData();
+        mUploadMessage.onReceiveValue(result);
+        mUploadMessage = null;
+
+        Bitmap bm = null;
+        ContentResolver resolver = getContentResolver();
+        try {
+            bm = MediaStore.Images.Media.getBitmap(resolver, result);
+            mImageView.setImageBitmap(bm);
+            bm = null;
+        } catch (FileNotFoundException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -584,5 +584,14 @@
                 <category android:name="XWalkView.Basic" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".XWalkViewWithOpenFileChooser"
+            android:label="XWalkViewWithOpenFileChooser"
+            android:parentActivityName=".XWalkEmbeddedAPISample">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkview.UIClient.ResourceClient" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/assets/open_file.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/assets/open_file.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>Open System Media Picture:<br><br><input type="file"></body>
+</html>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/openfile_layout.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/openfile_layout.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (c) 2014 Intel Corporation. All rights reserved.
+
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file.
+-->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" >
+
+    <org.xwalk.core.XWalkView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/xwalkview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="5" >
+    </org.xwalk.core.XWalkView>
+    
+    <ImageView
+        android:id="@+id/imageview"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:layout_weight="1"
+        android:scaleType="centerCrop"
+        android:background="#0000ff" />
+
+</LinearLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -594,3 +594,13 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load
 
+
+
+### 59. The [XWalkViewWithOpenFileChooser](XWalkViewWithOpenFileChooser.java) sample check XWalkView can open local file, include:
+
+* XWalkUIClient.openFileChooser can be invoked
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: XWalkUIClient.openFileChooser methods
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithOpenFileChooser.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/XWalkViewWithOpenFileChooser.java
@@ -1,0 +1,90 @@
+package org.xwalk.embedded.api.sample;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkUIClient;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.content.ContentResolver;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.Bundle;
+import android.provider.MediaStore;
+import android.webkit.ValueCallback;
+import android.widget.ImageView;
+
+public class XWalkViewWithOpenFileChooser extends XWalkActivity {
+    private XWalkView mXWalkView;
+    private ImageView mImageView;
+    private ValueCallback<Uri> mUploadMessage;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.openfile_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mImageView = (ImageView) findViewById(R.id.imageview);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can open local file.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Click 'Choose File' button.\n")
+        .append("2. Select system gallery app and choose one photo.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if this photo shows on the green background region.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView.setUIClient(new UIClient(mXWalkView));
+        mXWalkView.load("file:///android_asset/open_file.html", null);
+    }
+
+
+    class UIClient extends XWalkUIClient {
+
+        public UIClient(XWalkView xwalkView) {
+            super(xwalkView);
+        }
+
+        public void openFileChooser(XWalkView view, ValueCallback<Uri> uploadFile,
+                String acceptType, String capture) {
+            super.openFileChooser(view, uploadFile, acceptType, capture);
+            mUploadMessage = uploadFile;
+        }
+    }
+
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        // TODO Auto-generated method stub
+        if (mUploadMessage == null) return;
+        Uri result = intent == null || resultCode != RESULT_OK ? null : intent.getData();
+        mUploadMessage.onReceiveValue(result);
+        mUploadMessage = null;
+
+        Bitmap bm = null;
+        ContentResolver resolver = getContentResolver();
+        try {
+            bm = MediaStore.Images.Media.getBitmap(resolver, result);
+            mImageView.setImageBitmap(bm);
+            bm = null;
+        } catch (FileNotFoundException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -729,6 +729,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOpenFileChooser" purpose="XWalkViewWithOpenFileChooser Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewUIInflationAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -1448,6 +1460,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithEncodingDisplayAsync" purpose="XWalkViewWithEncodingDisplay Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOpenFileChooserAsync" purpose="XWalkViewWithOpenFileChooserAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -820,6 +820,19 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOpenFileChooser" platform="android" priority="P0" purpose="XWalkViewWithOpenFileChooser Test With XWalkActivity" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewUIInflationAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -1525,6 +1538,19 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithEncodingDisplayAsync" platform="android" priority="P0" purpose="XWalkViewWithEncodingDisplay Test With XWalkInitializer" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOpenFileChooserAsync" platform="android" priority="P0" purpose="XWalkViewWithOpenFileChooserAsync Test With XWalkInitializer" status="approved" type="functional_positive">
         <description>
           <pre_condition />
           <post_condition />


### PR DESCRIPTION
…en local file

-Add usecase for UIClient.openFileChooser to open local file
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5212