### PR TITLE
[apptools-android] Kill adb server before clearing project for testing on Windows host

### DIFF
--- a/apptools/apptools-android-tests/apptools/build.py
+++ b/apptools/apptools-android-tests/apptools/build.py
@@ -44,7 +44,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.build(self, buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
-        os.system('adb start-server')
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
     def test_build_release(self):
         comm.setUp()
@@ -54,7 +55,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.build(self, buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
-        os.system('adb start-server')
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
     def test_build_missing_so_file(self):
         comm.setUp()
@@ -91,7 +93,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             self.assertEquals(x86Length, 0)
         comm.run(self)
         comm.clear("org.xwalk.test")
-        os.system('adb start-server')
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
     def test_build_missing_both_so_file(self):
         comm.setUp()

--- a/apptools/apptools-android-tests/apptools/build_path.py
+++ b/apptools/apptools-android-tests/apptools/build_path.py
@@ -49,7 +49,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir('../')
         shutil.rmtree("pkg")
         comm.clear("org.xwalk.test")
-        os.system('adb start-server')
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
     def test_build_path_release(self):
         comm.setUp()
@@ -64,7 +65,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir('../')
         shutil.rmtree("pkg")
         comm.clear("org.xwalk.test")
-        os.system('adb start-server')
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-android-tests/apptools/comm.py
+++ b/apptools/apptools-android-tests/apptools/comm.py
@@ -69,12 +69,12 @@ def setUp():
     mode.close()
 
     host = open(ConstPath + "/../host.txt", 'r')
-    if host.read().strip("\n\t") != "Android":
-        HOST_PREFIX = "node "
-        SHELL_FLAG = "False"
-    else:
+    if host.read().strip("\n\t") != "Windows":
         HOST_PREFIX = ""
         SHELL_FLAG = "True"
+    else:
+        HOST_PREFIX = "node "
+        SHELL_FLAG = "False"
     host.close()
 
     vp = open(ConstPath + "/../version.txt", 'r')
@@ -191,7 +191,8 @@ def run(self):
                 device +
                 ' shell am force-stop org.xwalk.test')
             uninstatus = os.popen('adb -s ' + device + ' uninstall org.xwalk.test').read()
-            os.system('adb kill-server')
+            if SHELL_FLAG == "False":
+                os.system('adb kill-server')
             self.assertEquals(return_inst_code, 0)
             self.assertIn("org.xwalk.test", pmstatus[0])
             self.assertEquals(return_laun_code, 0)

--- a/apptools/apptools-android-tests/apptools/create_offline.py
+++ b/apptools/apptools-android-tests/apptools/create_offline.py
@@ -51,6 +51,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.build(self, buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertNotIn("Looking for", create_output)
 
 if __name__ == '__main__':

--- a/apptools/apptools-android-tests/apptools/create_package.py
+++ b/apptools/apptools-android-tests/apptools/create_package.py
@@ -54,6 +54,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(apkLength, 2)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(return_code, 0)
 
     def test_create_package_missing_icon_startUrl(self):
@@ -75,6 +77,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(apkLength, 2)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(return_code, 0)
 
     def test_create_package_stable(self):
@@ -96,6 +100,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(apkLength, 2)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(return_code, 0)
 
     def test_create_package_beta(self):
@@ -117,6 +123,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(apkLength, 2)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(return_code, 0)
 
     def test_create_package_canary(self):
@@ -138,6 +146,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(apkLength, 2)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(return_code, 0)
 
     def test_create_package_version(self):
@@ -159,6 +169,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(apkLength, 2)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(return_code, 0)
 
     def test_create_package_pathToRelease(self):
@@ -183,6 +195,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(apkLength, 2)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(return_code, 0)
 
     def test_build_package_release(self):
@@ -207,6 +221,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(apkLength, 2)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(return_code, 0)
 
 if __name__ == '__main__':

--- a/apptools/apptools-android-tests/apptools/create_with_target_platform.py
+++ b/apptools/apptools-android-tests/apptools/create_with_target_platform.py
@@ -46,6 +46,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.build(self, buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
     def test_create_with_platform_ios(self):
         comm.setUp()

--- a/apptools/apptools-android-tests/apptools/manifest_apk_name.py
+++ b/apptools/apptools-android-tests/apptools/manifest_apk_name.py
@@ -47,6 +47,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         appVersion = comm.build(self, buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(data['xwalk_app_version'].strip(os.linesep), "0.1")
         self.assertEquals(data['xwalk_app_version'].strip(os.linesep), appVersion)
 
@@ -64,6 +66,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         appVersion = comm.build(self, buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(appVersion, "0.0.1")
 
 if __name__ == '__main__':

--- a/apptools/apptools-android-tests/apptools/manifest_build_webp.py
+++ b/apptools/apptools-android-tests/apptools/manifest_build_webp.py
@@ -52,6 +52,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.build(self, buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
     def test_build_release_webp(self):
         comm.setUp()
@@ -67,6 +69,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.build(self, buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
     def test_build_debug_path_webp(self):
         comm.setUp()
@@ -87,6 +91,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir('../')
         shutil.rmtree("pkg")
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
     def test_build_release_path_webp(self):
         comm.setUp()
@@ -107,6 +113,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir('../')
         shutil.rmtree("pkg")
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
     def test_webp_jpeg_size_valid(self):
         comm.setUp()
@@ -117,12 +125,15 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         jsonfile.close()
         jsonDict = json.loads(jsons)
         jsonDict["xwalk_android_webp"] = "80"
+        jsonDict["icons"][0]["src"] = "icon.jpeg"
         json.dump(jsonDict, open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "w"))
         os.rename("app/icon.png", "app/icon.jpeg")
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
         comm.build(self, buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
     def test_webp_jpeg_size_invalid(self):
         comm.setUp()
@@ -133,6 +144,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         jsonfile.close()
         jsonDict = json.loads(jsons)
         jsonDict["xwalk_android_webp"] = "101"
+        jsonDict["icons"][0]["src"] = "icon.jpeg"
         json.dump(jsonDict, open(comm.ConstPath + "/../tools/org.xwalk.test/app/manifest.json", "w"))
         os.rename("app/icon.png", "app/icon.jpeg")
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
@@ -154,6 +166,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.build(self, buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
     def test_webp_png_size_invalid(self):
         comm.setUp()
@@ -184,6 +198,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.build(self, buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
     def test_webp_alpha_size_invalid(self):
         comm.setUp()
@@ -214,6 +230,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.build(self, buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
 
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-android-tests/apptools/manifest_display.py
+++ b/apptools/apptools-android-tests/apptools/manifest_display.py
@@ -51,6 +51,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildstatus = os.system(buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(buildstatus, 0)
 
     def test_display_standalone(self):
@@ -67,6 +69,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildstatus = os.system(buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(buildstatus, 0)
 
     def test_display_invalid(self):

--- a/apptools/apptools-android-tests/apptools/manifest_multiple_icons.py
+++ b/apptools/apptools-android-tests/apptools/manifest_multiple_icons.py
@@ -51,6 +51,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildstatus = os.system(buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(buildstatus, 0)
 
     def test_icon_change_any_size(self):
@@ -67,6 +69,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildstatus = os.system(buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(buildstatus, 0)
 
     def test_icon_gif(self):
@@ -83,6 +87,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildstatus = os.system(buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(buildstatus, 0)
 
     def test_icon_jpg(self):
@@ -99,6 +105,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildstatus = os.system(buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(buildstatus, 0)
 
     def test_icon_bmp(self):
@@ -115,6 +123,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildstatus = os.system(buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(buildstatus, 0)
 
     def test_multiple_icons(self):
@@ -131,6 +141,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildstatus = os.system(buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(buildstatus, 0)
 
     def test_icons_default(self):
@@ -147,6 +159,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildstatus = os.system(buildcmd)
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(buildstatus, 0)
 
 if __name__ == '__main__':

--- a/apptools/apptools-android-tests/apptools/manifest_versionCode.py
+++ b/apptools/apptools-android-tests/apptools/manifest_versionCode.py
@@ -57,6 +57,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
                 break
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(versionCode, versionCode_xml)
 
     def test_update_app_version(self):
@@ -87,6 +89,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
                 break
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(data['xwalk_app_version'].strip(os.linesep), "1")
         self.assertEquals(versionCode, versionCode_xml)
 
@@ -118,6 +122,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
                 break
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(data['xwalk_app_version'].strip(os.linesep), "0.0.1")
         self.assertEquals(versionCode, versionCode_xml)
 

--- a/apptools/apptools-android-tests/apptools/manifest_versionName.py
+++ b/apptools/apptools-android-tests/apptools/manifest_versionName.py
@@ -53,6 +53,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
                 break
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(buildstatus, 0)
         self.assertEquals(data['xwalk_app_version'].strip("\n\t"), "0.1")
         self.assertEquals(data['xwalk_app_version'].strip("\n\t"), versionName_xml)
@@ -79,6 +81,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
                 break
         comm.run(self)
         comm.clear("org.xwalk.test")
+        if comm.SHELL_FLAG == "False":
+            os.system('adb start-server')
         self.assertEquals(data['xwalk_app_version'].strip("\n\t"), "0.0.1")
         self.assertEquals(buildstatus, 0)
         self.assertEquals(data['xwalk_app_version'].strip("\n\t"), versionName_xml)


### PR DESCRIPTION
Impacted tests(approved): new 0, update 39, delete 0
Unit test platform: [Android]
Unit test result summary: pass 39, fail 0, block 0