### PR TITLE
[webapi] Update khronos harness for testkit and wts

### DIFF
--- a/webapi/tct-webgl-nonw3c-tests/webgl-py/khronos/COPYING
+++ b/webapi/tct-webgl-nonw3c-tests/webgl-py/khronos/COPYING
@@ -6,7 +6,11 @@ with modification:
 origin-clean-conformance.html
 readPixelsBadArgs.html
 
- Update cross domain with server.js.
+Update cross domain with server.js.
+
+Update khronos harness for web testing service: js-test-pre.js, unit.js, unit.css
+https://github.com/crosswalk-project/crosswalk-test-suite/pull/2986
+
 
 These tests are copyright by the Khronos Group under MIT License:
 https://www.khronos.org/registry/webgl/sdk/tests/test-guidelines.md

--- a/webapi/tct-webgl-nonw3c-tests/webgl-py/khronos/resources/js-test-pre.js
+++ b/webapi/tct-webgl-nonw3c-tests/webgl-py/khronos/resources/js-test-pre.js
@@ -20,6 +20,25 @@
 ** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
+var caseName = document.title;
+var subcaseIndex = 1;
+
+function KhronosTest(name) {
+  this.name = name;
+  this.status = null;
+  this.message = null;
+}
+
+var khronosTests = [];
+var khronosTestMsg = null;
+
+function Status() {
+  this.status = null;
+  this.message = null;
+}
+
+var statusObj = new Status();
+statusObj.status = 0;
 
 (function() {
   var testHarnessInitialized = false;
@@ -40,7 +59,9 @@
     if (window.layoutTestController) {
       layoutTestController.overridePreference("WebKitWebGLEnabled", "1");
       layoutTestController.dumpAsText();
-      layoutTestController.waitUntilDone();
+      if (waitUntilDone) {
+        layoutTestController.waitUntilDone();
+      }
     }
     if (window.internals) {
       // The WebKit testing system compares console output.
@@ -100,6 +121,11 @@ function description(msg)
     if (msg === undefined) {
       msg = document.title;
     }
+    else {
+      if (document.title.length === 0) {
+        caseName = msg;
+      }
+    }
     // For MSIE 6 compatibility
     var span = document.createElement("span");
     span.innerHTML = '<p>' + msg + '</p><p>On success, you will see a series of "<span class="pass">PASS</span>" messages, followed by "<span class="pass">TEST COMPLETE</span>".</p>';
@@ -124,12 +150,29 @@ function escapeHTML(text)
 
 function testPassed(msg)
 {
+    //console.log("webgl function testPassed:" + msg)
+    if (msg !== "successfullyParsed is true") {
+      var ktest = new KhronosTest(caseName + "/" + subcaseIndex);
+      ktest.status = 0;
+      ktest.message = escapeHTML(msg);
+      khronosTests.push(ktest);
+      subcaseIndex++;
+    }
+
     reportTestResultsToHarness(true, msg);
     debug('<span><span class="pass">PASS</span> ' + escapeHTML(msg) + '</span>');
 }
 
 function testFailed(msg)
 {
+    if (msg.indexOf("successfullyParsed should be true") === -1) {
+        var ktest = new KhronosTest(caseName + "/" + subcaseIndex);
+        ktest.status = 1;
+        ktest.message = escapeHTML(msg);
+        khronosTests.push(ktest);
+        subcaseIndex++;
+    }
+
     reportTestResultsToHarness(false, msg);
     debug('<span><span class="fail">FAIL</span> ' + escapeHTML(msg) + '</span>');
 }

--- a/webapi/tct-webgl-nonw3c-tests/webgl-py/khronos/resources/unit.css
+++ b/webapi/tct-webgl-nonw3c-tests/webgl-py/khronos/resources/unit.css
@@ -25,7 +25,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 */
-.ok {
+.pass {
   color: green;
 }
 .fail {

--- a/webapi/tct-webgl-nonw3c-tests/webgl-py/khronos/resources/unit.js
+++ b/webapi/tct-webgl-nonw3c-tests/webgl-py/khronos/resources/unit.js
@@ -70,6 +70,26 @@ var __testFailCount__ = 0;
 var __testLog__;
 var __backlog__ = [];
 
+var caseName = null;
+var subcaseIndex = 0;
+
+function KhronosUnitTest(name) {
+  this.name = name;
+  this.status = null;
+  this.message = null;
+}
+
+var khronosUnitTests = [];
+var khronosUnitTestMsg = null;
+
+function Status() {
+  this.status = null;
+  this.message = null;
+}
+
+var statusObj = new Status();
+statusObj.status = 0;
+
 Object.toSource = function(a, seen){
   if (a == null) return "null";
   if (typeof a == 'boolean') return a ? "true" : "false";
@@ -166,6 +186,9 @@ function runTests() {
     __testLog__ = document.createElement('div');
     __testSuccess__ = true;
     try {
+      caseName = i;
+      subcaseIndex = 1;
+
       doTestNotify (i);
       var args = setup_args;
       if (Tests.setup != null)
@@ -214,6 +237,12 @@ function doTestNotify(name) {
 }
 
 function testFailed(assertName, name) {
+  var kutest = new KhronosUnitTest(caseName + "/" + subcaseIndex);
+  kutest.status = 1;
+  kutest.message = name;
+  khronosUnitTests.push(kutest);
+  subcaseIndex += 1;
+
   var d = document.createElement('div');
   var h = document.createElement('h3');
   var d1 = document.createElement("span");
@@ -239,6 +268,12 @@ function testFailed(assertName, name) {
 }
 
 function testPassed(assertName, name) {
+  var kutest = new KhronosUnitTest(caseName + "/" + subcaseIndex);
+  kutest.status = 0;
+  kutest.message = name;
+  khronosUnitTests.push(kutest);
+  subcaseIndex += 1;
+
   var d = document.createElement('div');
   var h = document.createElement('h3');
   var d1 = document.createElement("span");
@@ -248,6 +283,7 @@ function testPassed(assertName, name) {
   h.appendChild(document.createTextNode(
       name==null ? assertName : name + " (in " + assertName + ")"));
   d.appendChild(h);
+  kutest.message = name==null ? assertName : name + " (in " + assertName + ")";
   var args = []
   for (var i=2; i<arguments.length; i++) {
     var a = arguments[i];
@@ -255,6 +291,7 @@ function testPassed(assertName, name) {
     p.style.whiteSpace = 'pre';
     p.textContent = (a == null) ? "null" :
                     (typeof a == 'boolean' || typeof a == 'string') ? a : Object.toSource(a);
+    kutest.message += "\n" + p.textContent;
     args.push(p.textContent);
     d.appendChild(p);
   }
@@ -290,7 +327,7 @@ function log(msg) {
 function printTestStatus(testsRun) {
   var status = document.getElementById('test-status');
   if (testsRun) {
-    status.className = checkTestSuccess() ? 'ok' : 'fail';
+    status.className = checkTestSuccess() ? 'pass' : 'fail';
     status.textContent = checkTestSuccess() ? "PASS" : "FAIL";
   } else {
     status.className = 'fail';

--- a/webapi/tct-webgl-nonw3c-tests/webgl/khronos/COPYING
+++ b/webapi/tct-webgl-nonw3c-tests/webgl/khronos/COPYING
@@ -11,9 +11,9 @@ readPixelsBadArgs.html
 - <img id="img" src="http://www.opengl.org/img/opengl_logo.jpg" style="display:none;">
 + <img id="img" src="http://127.0.0.1:8080/opt/tct-webgl-nonw3c-tests/webgl/khronos/resources/opengl_logo.jpg" style="display:none;">
 
-Add completion_callback handle to js-test-pre.js.
+Update khronos harness for testkit: js-test-pre.js, unit.js, unit.css
+https://github.com/crosswalk-project/crosswalk-test-suite/pull/2986
 
-Add completion_callback handle to unit.js.
 
 These tests are copyright by the Khronos Group under MIT License:
 https://www.khronos.org/registry/webgl/sdk/tests/test-guidelines.md

--- a/webapi/tct-webgl-nonw3c-tests/webgl/khronos/resources/js-test-pre.js
+++ b/webapi/tct-webgl-nonw3c-tests/webgl/khronos/resources/js-test-pre.js
@@ -20,6 +20,25 @@
 ** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
+var caseName = document.title;
+var subcaseIndex = 1;
+
+function KhronosTest(name) {
+  this.name = name;
+  this.status = null;
+  this.message = null;
+}
+
+var khronosTests = [];
+var khronosTestMsg = null;
+
+function Status() {
+  this.status = null;
+  this.message = null;
+}
+
+var statusObj = new Status();
+statusObj.status = 0;
 
 (function() {
   var testHarnessInitialized = false;
@@ -100,6 +119,11 @@ function description(msg)
     if (msg === undefined) {
       msg = document.title;
     }
+    else {
+      if (document.title.length === 0) {
+        caseName = msg;
+      }
+    }
     // For MSIE 6 compatibility
     var span = document.createElement("span");
     span.innerHTML = '<p>' + msg + '</p><p>On success, you will see a series of "<span class="pass">PASS</span>" messages, followed by "<span class="pass">TEST COMPLETE</span>".</p>';
@@ -124,12 +148,29 @@ function escapeHTML(text)
 
 function testPassed(msg)
 {
+    //console.log("webgl function testPassed:" + msg)
+    if (msg !== "successfullyParsed is true") {
+      var ktest = new KhronosTest(caseName + "/" + subcaseIndex);
+      ktest.status = 0;
+      ktest.message = escapeHTML(msg);
+      khronosTests.push(ktest);
+      subcaseIndex++;
+    }
+
     reportTestResultsToHarness(true, msg);
     debug('<span><span class="pass">PASS</span> ' + escapeHTML(msg) + '</span>');
 }
 
 function testFailed(msg)
 {
+    if (msg.indexOf("successfullyParsed should be true") === -1) {
+        var ktest = new KhronosTest(caseName + "/" + subcaseIndex);
+        ktest.status = 1;
+        ktest.message = escapeHTML(msg);
+        khronosTests.push(ktest);
+        subcaseIndex++;
+    }
+
     reportTestResultsToHarness(false, msg);
     debug('<span><span class="fail">FAIL</span> ' + escapeHTML(msg) + '</span>');
 }

--- a/webapi/tct-webgl-nonw3c-tests/webgl/khronos/resources/unit.css
+++ b/webapi/tct-webgl-nonw3c-tests/webgl/khronos/resources/unit.css
@@ -25,7 +25,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 */
-.ok {
+.pass {
   color: green;
 }
 .fail {

--- a/webapi/tct-webgl-nonw3c-tests/webgl/khronos/resources/unit.js
+++ b/webapi/tct-webgl-nonw3c-tests/webgl/khronos/resources/unit.js
@@ -70,6 +70,26 @@ var __testFailCount__ = 0;
 var __testLog__;
 var __backlog__ = [];
 
+var caseName = null;
+var subcaseIndex = 0;
+
+function KhronosUnitTest(name) {
+  this.name = name;
+  this.status = null;
+  this.message = null;
+}
+
+var khronosUnitTests = [];
+var khronosUnitTestMsg = null;
+
+function Status() {
+  this.status = null;
+  this.message = null;
+}
+
+var statusObj = new Status();
+statusObj.status = 0;
+
 Object.toSource = function(a, seen){
   if (a == null) return "null";
   if (typeof a == 'boolean') return a ? "true" : "false";
@@ -166,6 +186,9 @@ function runTests() {
     __testLog__ = document.createElement('div');
     __testSuccess__ = true;
     try {
+      caseName = i;
+      subcaseIndex = 1;
+
       doTestNotify (i);
       var args = setup_args;
       if (Tests.setup != null)
@@ -214,6 +237,12 @@ function doTestNotify(name) {
 }
 
 function testFailed(assertName, name) {
+  var kutest = new KhronosUnitTest(caseName + "/" + subcaseIndex);
+  kutest.status = 1;
+  kutest.message = name;
+  khronosUnitTests.push(kutest);
+  subcaseIndex += 1;
+
   var d = document.createElement('div');
   var h = document.createElement('h3');
   var d1 = document.createElement("span");
@@ -239,6 +268,12 @@ function testFailed(assertName, name) {
 }
 
 function testPassed(assertName, name) {
+  var kutest = new KhronosUnitTest(caseName + "/" + subcaseIndex);
+  kutest.status = 0;
+  kutest.message = name;
+  khronosUnitTests.push(kutest);
+  subcaseIndex += 1;
+
   var d = document.createElement('div');
   var h = document.createElement('h3');
   var d1 = document.createElement("span");
@@ -248,6 +283,7 @@ function testPassed(assertName, name) {
   h.appendChild(document.createTextNode(
       name==null ? assertName : name + " (in " + assertName + ")"));
   d.appendChild(h);
+  kutest.message = name==null ? assertName : name + " (in " + assertName + ")";
   var args = []
   for (var i=2; i<arguments.length; i++) {
     var a = arguments[i];
@@ -255,6 +291,7 @@ function testPassed(assertName, name) {
     p.style.whiteSpace = 'pre';
     p.textContent = (a == null) ? "null" :
                     (typeof a == 'boolean' || typeof a == 'string') ? a : Object.toSource(a);
+    kutest.message += "\n" + p.textContent;
     args.push(p.textContent);
     d.appendChild(p);
   }
@@ -290,7 +327,7 @@ function log(msg) {
 function printTestStatus(testsRun) {
   var status = document.getElementById('test-status');
   if (testsRun) {
-    status.className = checkTestSuccess() ? 'ok' : 'fail';
+    status.className = checkTestSuccess() ? 'pass' : 'fail';
     status.textContent = checkTestSuccess() ? "PASS" : "FAIL";
   } else {
     status.className = 'fail';


### PR DESCRIPTION
Support run khronos harness of tct-webgl-nonow3c-tests automatically
on testkit-lite and web testing service

Failure Analysis:
XWALK-3062, XWALK-5086

testkit-lite:
Impacted tests(approved): new 0, update 3, delete 0
Unit test platform: Crosswalk Project for Android 16.45.421.0
Unit test result summary: pass 1591, fail 2, block 0

wts:
Impacted tests(approved): new 0, update 3, delete 0
Unit test platform: Chrome 47
Unit test result summary: pass 14450, fail 5, block 3