### PR TITLE
[Cordova] Add security cases for cordova-appsecurityapi-android-tests

### DIFF
--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_all_optional.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_all_optional.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_createFromSealedData_all_optional</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -45,12 +45,36 @@ setTimeout(function() { test(); }, 500);
 function test() {
   async_test(function(t) {
     try{
+      newExtraKeyInstanceID = null
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          newExtraKeyInstanceID = instanceID
+          intel.security.secureData.createFromData(
+            function(instanceID) {
+              intel.security.secureData.changeExtraKey(
+                function() {
+                  t.step(function() {
+                    assert_true(true, 'success to change the extra key');
+                  });
+                  t.done();
+                },
+                function(errorObj) {
+                  t.step(function() {
+                    assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+                  });
+                  t.done();
+                },
+                {'instanceID': instanceID, 'extraKey': 0 }
+              );
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            {'data': 'plaintext data', 'tag': 'Test', 'extraKey': newExtraKeyInstanceID, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,7 +82,7 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'test1', 'noRead': true, 'noStore': true}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_data_below.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_data_below.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_ changeExtraKey_data_below</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,17 +40,42 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_bad_data = 7
 setTimeout(function() { test(); }, 500);
 
 function test() {
   async_test(function(t) {
     try{
+      newExtraKeyInstanceID = null
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          newExtraKeyInstanceID = instanceID
+          intel.security.secureData.createFromData(
+            function(instanceID) {
+              intel.security.secureData.changeExtraKey(
+                function(){
+                  t.step(function() {
+                    assert_unreached("changeExtraKey should fail");
+                  });
+                  t.done();
+                },
+                function(errorObj){
+                  t.step(function() {
+                    assert_equals(errorObj.code, error_code_bad_data);
+                  });
+                  t.done();
+                },
+                {'instanceID': instanceID, 'extraKey': newExtraKeyInstanceID }
+              );
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            {'data': 'plaintext data', 'tag': 'Test', 'extraKey': 0, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,7 +83,7 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': '123', 'noRead': true, 'noStore': true}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_invalid_instanceID.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_invalid_instanceID.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_changeExtraKey_invalid_instanceID</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,6 +40,7 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_invalid_instance = 9
 setTimeout(function() { test(); }, 500);
 
 function test() {
@@ -47,10 +48,21 @@ function test() {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureData.changeExtraKey(
+            function(){
+              t.step(function() {
+                assert_unreached("changeExtraKey should fail");
+              });
+              t.done();
+            },
+            function(errorObj){
+              t.step(function() {
+                assert_equals(errorObj.code, error_code_invalid_instance);
+              });
+              t.done();
+            },
+            {'instanceID': 1234, 'extraKey': instanceID }
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,7 +70,7 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'test1', 'noRead': true, 'noStore': true}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_noRead_false.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_noRead_false.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_changeExtraKey_noRead_false</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,17 +40,42 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_policy_violation = 13
 setTimeout(function() { test(); }, 500);
 
 function test() {
   async_test(function(t) {
     try{
+      newExtraKeyInstanceID = null
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          newExtraKeyInstanceID = instanceID
+          intel.security.secureData.createFromData(
+            function(instanceID) {
+              intel.security.secureData.changeExtraKey(
+                function(){
+                  t.step(function() {
+                    assert_unreached("changeExtraKey should fail");
+                  });
+                  t.done();
+                },
+                function(errorObj){
+                  t.step(function() {
+                    assert_equals(errorObj.code, error_code_policy_violation);
+                  });
+                  t.done();
+                },
+                {'instanceID': instanceID, 'extraKey': newExtraKeyInstanceID }
+              );
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            {'data': 'plaintext data', 'tag': 'Test', 'extraKey': 0, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,7 +83,7 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'test1', 'noRead': false, 'noStore': true}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_noStore_false.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_noStore_false.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_changeExtraKey_noStore_false</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,17 +40,42 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_policy_violation = 13
 setTimeout(function() { test(); }, 500);
 
 function test() {
   async_test(function(t) {
     try{
+      newExtraKeyInstanceID = null
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          newExtraKeyInstanceID = instanceID
+          intel.security.secureData.createFromData(
+            function(instanceID) {
+              intel.security.secureData.changeExtraKey(
+                function(){
+                  t.step(function() {
+                    assert_unreached("changeExtraKey should fail");
+                  });
+                  t.done();
+                },
+                function(errorObj){
+                  t.step(function() {
+                    assert_equals(errorObj.code, error_code_policy_violation);
+                  });
+                  t.done();
+                },
+                {'instanceID': instanceID, 'extraKey': newExtraKeyInstanceID }
+              );
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            {'data': 'plaintext data', 'tag': 'Test', 'extraKey': 0, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,7 +83,7 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'test1', 'noRead': true, 'noStore': false}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_createFromSealedData_all_optional.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_createFromSealedData_all_optional.html
@@ -45,7 +45,7 @@ setTimeout(function() { test(); }, 500);
 function test() {
   async_test(function(t) {
     try{
-      extraKey = null
+      extraKey = null;
       intel.security.secureData.createFromData(
         function(instanceID) {
           extraKey = instanceID

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_delete_all_optional.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_delete_all_optional.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_delete_all_optional</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -41,16 +41,50 @@ Authors:
 <script type="text/javascript">
 
 setTimeout(function() { test(); }, 500);
-
 function test() {
   async_test(function(t) {
     try{
+      extraKey = null;
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          extraKey = instanceID
+          intel.security.secureData.createFromData(
+            function(instanceID) {
+              intel.security.secureStorage.write(
+	        function() {
+                  intel.security.secureStorage.delete(
+                    function() {
+                      t.step(function() {
+                        assert_true(true, 'success to delete the data');
+                      });
+                      t.done();
+                    },
+                    function(errorObj) {
+                      t.step(function() {
+                        assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+                      });
+                      t.done();
+                    },
+                    {'id': 'id1', 'storageType': 0}
+                  );
+                },
+	        function(errorObj) {
+                  t.step(function() {
+                    assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+                  });
+                  t.done();
+                },
+	        {'id': 'id1', 'instanceID': instanceID}
+	      );
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            {'data': 'plaintext data', 'tag': 'Test', 'extraKey': extraKey, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,9 +92,9 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'test1', 'noRead': true, 'noStore': true}
       );
-    } catch (e){
+    } catch (e) {
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_delete_invalid_id.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_delete_invalid_id.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_delete_invalid_id</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,27 +40,27 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_system_error = 1
 setTimeout(function() { test(); }, 500);
-
 function test() {
   async_test(function(t) {
     try{
-      intel.security.secureData.createFromData(
-        function(instanceID) {
+      intel.security.secureStorage.delete(
+        function() {
           t.step(function() {
-            assert_not_equals(instanceID, null);
+            assert_unreached("read should fail");
           });
           t.done();
         },
         function(errorObj) {
           t.step(function() {
-            assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+            assert_equals(errorObj.code, error_code_system_error);
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'id': 'id2', 'storageType': 0}
       );
-    } catch (e){
+    } catch (e) {
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_delete_no_optional.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_delete_no_optional.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_delete_no_optional</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -41,16 +41,50 @@ Authors:
 <script type="text/javascript">
 
 setTimeout(function() { test(); }, 500);
-
 function test() {
   async_test(function(t) {
     try{
+      extraKey = null;
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          extraKey = instanceID
+          intel.security.secureData.createFromData(
+            function(instanceID) {
+              intel.security.secureStorage.write(
+	        function() {
+                  intel.security.secureStorage.delete(
+                    function() {
+                      t.step(function() {
+                        assert_true(true, 'success to delete the data');
+                      });
+                      t.done();
+                    },
+                    function(errorObj) {
+                      t.step(function() {
+                        assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+                      });
+                      t.done();
+                    },
+                    {'id': 'id1'}
+                  );
+                },
+	        function(errorObj) {
+                  t.step(function() {
+                    assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+                  });
+                  t.done();
+                },
+	        {'id': 'id1', 'instanceID': instanceID}
+	      );
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            {'data': 'plaintext data', 'tag': 'Test', 'extraKey': extraKey, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,9 +92,9 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'test1', 'noRead': true, 'noStore': true}
       );
-    } catch (e){
+    } catch (e) {
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_destory_correct_instance.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_destory_correct_instance.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_destory_correct_instance</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -47,10 +47,32 @@ function test() {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureData.createFromData(
+            function(instanceID) {
+              intel.security.secureData.destroy(
+                function(){
+                  t.step(function() {
+                    assert_true(true, 'success to destroy the security data');
+                  });
+                  t.done();
+                },
+                function(errorObj){
+                  t.step(function() {
+                    assert_true(false, 'fail:code = '+ errorObj.code + ', message = ' + errorObj.message);
+                  });
+                  t.done();
+                },
+                instanceID
+              );
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = '+ errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            {'data': 'plaintext data', 'tag': 'Test', 'extraKey': instanceID, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,7 +80,7 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'test1', 'noRead': true, 'noStore': true}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_destory_invalid_instance.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_destory_invalid_instance.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_destory_invalid_instance</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,25 +40,26 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_invalid_instance = 9
 setTimeout(function() { test(); }, 500);
 
 function test() {
   async_test(function(t) {
     try{
-      intel.security.secureData.createFromData(
-        function(instanceID) {
+      intel.security.secureData.destroy(
+        function(){
           t.step(function() {
-            assert_not_equals(instanceID, null);
+            assert_true(false, 'fail:code = '+ errorObj.code + ', message = ' + errorObj.message);
           });
           t.done();
         },
-        function(errorObj) {
+        function(errorObj){
           t.step(function() {
-            assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+            assert_equals(errorObj.code, error_code_invalid_instance);
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        1234
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getCreator_correct_instance.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getCreator_correct_instance.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getCreator_correct_instance</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -47,10 +47,21 @@ function test() {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureData.getCreator(
+            function(creator){
+              t.step(function() {
+                assert_equals(creator, 0);
+              });
+              t.done();
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            instanceID
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,12 +69,13 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'plaintext data', 'tag': 'Test', 'extraKey': 0, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
+
 </script>
 

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getCreator_invalid_instance.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getCreator_invalid_instance.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getCreator_invalid_instance</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,30 +40,31 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_invalid_instance = 9
 setTimeout(function() { test(); }, 500);
 
 function test() {
   async_test(function(t) {
     try{
-      intel.security.secureData.createFromData(
-        function(instanceID) {
+      intel.security.secureData.getCreator(
+        function(creator){
           t.step(function() {
-            assert_not_equals(instanceID, null);
+            assert_unreached("getCreator should fail");
           });
           t.done();
         },
-        function(errorObj) {
+        function(errorObj){
           t.step(function() {
-            assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+            assert_equals(errorObj.code, error_code_invalid_instance);
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        1234
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
-</script>
 
+</script>

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getData_correct_instance.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getData_correct_instance.html
@@ -52,7 +52,7 @@ function test() {
               intel.security.secureData.getData(
                 function(data){
                   t.step(function() {
-                    assert_equals(data, 'plaintext data', "Check if the getData can pass with correct instanceID");
+                    assert_equals(data, 'plaintext data');
                   });
                   t.done();
                 },

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getOwners_correct_instance.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getOwners_correct_instance.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getOwners_correct_instance</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -47,10 +47,21 @@ function test() {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureData.getOwners(
+            function(owners){
+              t.step(function() {
+                assert_equals(owners[0], 0);
+              });
+              t.done();
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            instanceID
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,12 +69,13 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'plaintext data', 'tag': 'Test', 'extraKey': 0, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
+
 </script>
 

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getOwners_invalid_instance.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getOwners_invalid_instance.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getOwners_invalid_instance</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,30 +40,31 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_invalid_instance = 9
 setTimeout(function() { test(); }, 500);
 
 function test() {
   async_test(function(t) {
     try{
-      intel.security.secureData.createFromData(
-        function(instanceID) {
+      intel.security.secureData.getOwners(
+        function(owners){
           t.step(function() {
-            assert_not_equals(instanceID, null);
+            assert_unreached("getOwners should fail");
           });
           t.done();
         },
-        function(errorObj) {
+        function(errorObj){
           t.step(function() {
-            assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+            assert_equals(errorObj.code, error_code_invalid_instance);
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        1234
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
-</script>
 
+</script>

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_appAccessControl.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_appAccessControl.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getPolicy_appAccessControl</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -47,10 +47,21 @@ function test() {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureData.getPolicy(
+            function(policy){
+              t.step(function() {
+                assert_equals(policy.appAccessControl, 0);
+              });
+              t.done();
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            instanceID
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,12 +69,13 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'plaintext data', 'tag': 'Test', 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
+
 </script>
 

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_deviceLocality.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_deviceLocality.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getPolicy_deviceLocality</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -47,10 +47,21 @@ function test() {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureData.getPolicy(
+            function(policy){
+              t.step(function() {
+                assert_equals(policy.deviceLocality, 0);
+              });
+              t.done();
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            instanceID
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,12 +69,13 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'plaintext data', 'tag': 'Test', 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
+
 </script>
 

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_invalid_instance.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_invalid_instance.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getData_correct_instance</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,30 +40,31 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_invalid_instance = 9
 setTimeout(function() { test(); }, 500);
 
 function test() {
   async_test(function(t) {
     try{
-      intel.security.secureData.createFromData(
-        function(instanceID) {
+      intel.security.secureData.getPolicy(
+        function(policy){
           t.step(function() {
-            assert_not_equals(instanceID, null);
+            assert_unreached("getPolicy should fail");
           });
           t.done();
         },
-        function(errorObj) {
+        function(errorObj){
           t.step(function() {
-            assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+            assert_equals(errorObj.code, error_code_invalid_instance);
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        1234
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
-</script>
 
+</script>

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_noRead.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_noRead.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getPolicy_noStore</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -47,10 +47,21 @@ function test() {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureData.getPolicy(
+            function(policy){
+              t.step(function() {
+                assert_equals(policy.noStore, true);
+              });
+              t.done();
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            instanceID
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,12 +69,13 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'plaintext data', 'tag': 'Test', 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': true, 'noRead': true}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
+
 </script>
 

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_noStore.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_noStore.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getPolicy_noStore</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -47,10 +47,21 @@ function test() {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureData.getPolicy(
+            function(policy){
+              t.step(function() {
+                assert_equals(policy.noStore, true);
+              });
+              t.done();
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            instanceID
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,12 +69,13 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'plaintext data', 'tag': 'Test', 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': true, 'noRead': true}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
+
 </script>
 

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_sensitivityLevel.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_sensitivityLevel.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getPolicy_sensitivityLevel</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -47,10 +47,21 @@ function test() {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureData.getPolicy(
+            function(policy){
+              t.step(function() {
+                assert_equals(policy.sensitivityLevel, 0);
+              });
+              t.done();
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            instanceID
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,12 +69,13 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'plaintext data', 'tag': 'Test', 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
+
 </script>
 

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getTag_correct_instance.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getTag_correct_instance.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getTag_correct_instance</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -47,10 +47,21 @@ function test() {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureData.getTag(
+            function(tag){
+              t.step(function() {
+                assert_equals(tag, 'Test');
+              });
+              t.done();
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            instanceID
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,12 +69,13 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'plaintext data', 'tag': 'Test'}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
+
 </script>
 

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getTag_invalid_instance.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getTag_invalid_instance.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getTag_invalid_instance</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,30 +40,31 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_invalid_instance = 9
 setTimeout(function() { test(); }, 500);
 
 function test() {
   async_test(function(t) {
     try{
-      intel.security.secureData.createFromData(
-        function(instanceID) {
+      intel.security.secureData.getTag(
+        function(tag){
           t.step(function() {
-            assert_not_equals(instanceID, null);
+            assert_unreached("getTag should fail");
           });
           t.done();
         },
-        function(errorObj) {
+        function(errorObj){
           t.step(function() {
-            assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+            assert_equals(errorObj.code, error_code_invalid_instance);
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        1234
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
-</script>
 
+</script>

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getWebOwners_correct_instance.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getWebOwners_correct_instance.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getWebOwners_correct_instance</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -47,10 +47,21 @@ function test() {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureData.getWebOwners(
+            function(webOwners){
+              t.step(function() {
+                assert_equals(webOwners, 'webOwners1');
+              });
+              t.done();
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail:code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            instanceID
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,12 +69,13 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'plaintext data', 'tag': 'Test', 'extraKey': 0, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': 'webOwners1'}
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
+
 </script>
 

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getWebOwners_invalid_instance.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getWebOwners_invalid_instance.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_getWebOwners_invalid_instance</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,30 +40,31 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_invalid_instance = 9
 setTimeout(function() { test(); }, 500);
 
 function test() {
   async_test(function(t) {
     try{
-      intel.security.secureData.createFromData(
-        function(instanceID) {
+      intel.security.secureData.getWebOwners(
+        function(webOwners){
           t.step(function() {
-            assert_not_equals(instanceID, null);
+            assert_unreached("getWebOwners should fail");
           });
           t.done();
         },
-        function(errorObj) {
+        function(errorObj){
           t.step(function() {
-            assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+            assert_equals(errorObj.code, error_code_invalid_instance);
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        1234
       );
     } catch (e){
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
-</script>
 
+</script>

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_all_optional.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_all_optional.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_read_all_optional</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -41,16 +41,50 @@ Authors:
 <script type="text/javascript">
 
 setTimeout(function() { test(); }, 500);
-
 function test() {
   async_test(function(t) {
     try{
+      extraKey = null;
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          extraKey = instanceID
+          intel.security.secureData.createFromData(
+            function(instanceID) {
+              intel.security.secureStorage.write(
+	        function() {
+                  intel.security.secureStorage.read(
+                    function(instanceID) {
+                      t.step(function() {
+                        assert_not_equals(instanceID, null);
+                      });
+                      t.done();
+                    },
+                    function(errorObj) {
+                      t.step(function() {
+                        assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+                      });
+                      t.done();
+                    },
+                    {'id': 'id1', 'storageType': 0, 'extraKey': extraKey}
+                  );
+                },
+	        function(errorObj) {
+                  t.step(function() {
+                    assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+                  });
+                  t.done();
+                },
+	        {'id': 'id1', 'instanceID': instanceID}
+	      );
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            {'data': 'plaintext data', 'tag': 'Test', 'extraKey': extraKey, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,9 +92,9 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'test1', 'noRead': true, 'noStore': true}
       );
-    } catch (e){
+    } catch (e) {
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_integrity_detected.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_integrity_detected.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_getSealedData_correct_instance</title>
+<title>Secure Data Test: AppSecurityApi_read_integrity_detected</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,38 +40,64 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_integrity_detected = 8
 setTimeout(function() { test(); }, 500);
-
 function test() {
   async_test(function(t) {
     try{
+      extraKey1 = null;
+      extraKey2 = null;
       intel.security.secureData.createFromData(
         function(instanceID) {
+          extraKey1 = instanceID
           intel.security.secureData.createFromData(
             function(instanceID) {
-              intel.security.secureData.getSealedData(
-                function(data){
+              extraKey2 = instanceID
+              intel.security.secureData.createFromData(
+                function(instanceID) {
+                  intel.security.secureStorage.write(
+	            function() {
+                      intel.security.secureStorage.read(
+                        function(instanceID) {
+                          t.step(function() {
+                            assert_unreached("read should fail");
+                          });
+                          t.done();
+                        },
+                        function(errorObj) {
+                          t.step(function() {
+                            assert_equals(errorObj.code, error_code_integrity_detected);
+                          });
+                          t.done();
+                        },
+                        {'id': 'id1', 'storageType': 0, 'extraKey': extraKey2}
+                      );
+                    },
+	            function(errorObj) {
+                      t.step(function() {
+                        assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+                      });
+                      t.done();
+                    },
+	            {'id': 'id1', 'instanceID': instanceID}
+	          );
+                },
+                function(errorObj) {
                   t.step(function() {
-                    assert_not_equals(data, null);
+                    assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
                   });
                   t.done();
                 },
-                function(errorObj){
-                  t.step(function() {
-                    assert_true(false, 'fail:code = ' + errorObj.code+', message = ' + errorObj.message);
-                  });
-                  t.done();
-                },
-                instanceID
+                {'data': 'plaintext data', 'tag': 'Test', 'extraKey': extraKey1, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
               );
             },
             function(errorObj) {
               t.step(function() {
-                assert_true(false, 'fail:code = ' + errorObj.code+', message = ' + errorObj.message);
+                assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
               });
               t.done();
             },
-            {'data': 'plaintext data', 'tag': 'Test', 'extraKey': instanceID, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
+            {'data': 'test2', 'noRead': true, 'noStore': true}
           );
         },
         function(errorObj) {
@@ -82,11 +108,10 @@ function test() {
         },
         {'data': 'test1', 'noRead': true, 'noStore': true}
       );
-    } catch (e){
+    } catch (e) {
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
-
 </script>
 

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_invalid_id.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_invalid_id.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_read_invalid_id</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,17 +40,28 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_system_error = 1
 setTimeout(function() { test(); }, 500);
-
 function test() {
   async_test(function(t) {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureStorage.read(
+            function(instanceID) {
+              t.step(function() {
+                assert_unreached("read should fail");
+              });
+              t.done();
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_equals(errorObj.code, error_code_system_error);
+              });
+              t.done();
+            },
+            {'id': 'id2', 'storageType': 0, 'extraKey': instanceID}
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -58,9 +69,9 @@ function test() {
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'data': 'test1', 'noRead': true, 'noStore': true}
       );
-    } catch (e){
+    } catch (e) {
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_noRead_false.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_noRead_false.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_getSealedData_correct_instance</title>
+<title>Secure Data Test: AppSecurityApi_read_noRead_false</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,38 +40,64 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_policy_violation = 13
 setTimeout(function() { test(); }, 500);
-
 function test() {
   async_test(function(t) {
     try{
+      extraKey1 = null;
+      extraKey2 = null;
       intel.security.secureData.createFromData(
         function(instanceID) {
+          extraKey1 = instanceID
           intel.security.secureData.createFromData(
             function(instanceID) {
-              intel.security.secureData.getSealedData(
-                function(data){
+              extraKey2 = instanceID
+              intel.security.secureData.createFromData(
+                function(instanceID) {
+                  intel.security.secureStorage.write(
+	            function() {
+                      intel.security.secureStorage.read(
+                        function(instanceID) {
+                          t.step(function() {
+                            assert_unreached("read should fail");
+                          });
+                          t.done();
+                        },
+                        function(errorObj) {
+                          t.step(function() {
+                            assert_equals(errorObj.code, error_code_policy_violation);
+                          });
+                          t.done();
+                        },
+                        {'id': 'id1', 'storageType': 0, 'extraKey': extraKey2}
+                      );
+                    },
+	            function(errorObj) {
+                      t.step(function() {
+                        assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+                      });
+                      t.done();
+                    },
+	            {'id': 'id1', 'instanceID': instanceID}
+	          );
+                },
+                function(errorObj) {
                   t.step(function() {
-                    assert_not_equals(data, null);
+                    assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
                   });
                   t.done();
                 },
-                function(errorObj){
-                  t.step(function() {
-                    assert_true(false, 'fail:code = ' + errorObj.code+', message = ' + errorObj.message);
-                  });
-                  t.done();
-                },
-                instanceID
+                {'data': 'plaintext data', 'tag': 'Test', 'extraKey': extraKey1, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
               );
             },
             function(errorObj) {
               t.step(function() {
-                assert_true(false, 'fail:code = ' + errorObj.code+', message = ' + errorObj.message);
+                assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
               });
               t.done();
             },
-            {'data': 'plaintext data', 'tag': 'Test', 'extraKey': instanceID, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
+            {'data': 'test1', 'noRead': false, 'noStore': true}
           );
         },
         function(errorObj) {
@@ -82,11 +108,10 @@ function test() {
         },
         {'data': 'test1', 'noRead': true, 'noStore': true}
       );
-    } catch (e){
+    } catch (e) {
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
-
 </script>
 

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_noStore_false.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_noStore_false.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_getSealedData_correct_instance</title>
+<title>Secure Data Test: AppSecurityApi_read_noStore_false</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,38 +40,64 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_policy_violation = 13
 setTimeout(function() { test(); }, 500);
-
 function test() {
   async_test(function(t) {
     try{
+      extraKey1 = null;
+      extraKey2 = null;
       intel.security.secureData.createFromData(
         function(instanceID) {
+          extraKey1 = instanceID
           intel.security.secureData.createFromData(
             function(instanceID) {
-              intel.security.secureData.getSealedData(
-                function(data){
+              extraKey2 = instanceID
+              intel.security.secureData.createFromData(
+                function(instanceID) {
+                  intel.security.secureStorage.write(
+	            function() {
+                      intel.security.secureStorage.read(
+                        function(instanceID) {
+                          t.step(function() {
+                            assert_unreached("read should fail");
+                          });
+                          t.done();
+                        },
+                        function(errorObj) {
+                          t.step(function() {
+                            assert_equals(errorObj.code, error_code_policy_violation);
+                          });
+                          t.done();
+                        },
+                        {'id': 'id1', 'storageType': 0, 'extraKey': extraKey2}
+                      );
+                    },
+	            function(errorObj) {
+                      t.step(function() {
+                        assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+                      });
+                      t.done();
+                    },
+	            {'id': 'id1', 'instanceID': instanceID}
+	          );
+                },
+                function(errorObj) {
                   t.step(function() {
-                    assert_not_equals(data, null);
+                    assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
                   });
                   t.done();
                 },
-                function(errorObj){
-                  t.step(function() {
-                    assert_true(false, 'fail:code = ' + errorObj.code+', message = ' + errorObj.message);
-                  });
-                  t.done();
-                },
-                instanceID
+                {'data': 'plaintext data', 'tag': 'Test', 'extraKey': extraKey1, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
               );
             },
             function(errorObj) {
               t.step(function() {
-                assert_true(false, 'fail:code = ' + errorObj.code+', message = ' + errorObj.message);
+                assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
               });
               t.done();
             },
-            {'data': 'plaintext data', 'tag': 'Test', 'extraKey': instanceID, 'appAccessControl': 0, 'deviceLocality': 0, 'sensitivityLevel': 0, 'noStore': false, 'noRead': false, 'creator': 0, 'owners': [0], 'webOwners': ''}
+            {'data': 'test1', 'noRead': true, 'noStore': false}
           );
         },
         function(errorObj) {
@@ -82,11 +108,10 @@ function test() {
         },
         {'data': 'test1', 'noRead': true, 'noStore': true}
       );
-    } catch (e){
+    } catch (e) {
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);
 }
-
 </script>
 

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_no_optional.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_no_optional.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_write_no_optional</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -41,16 +41,37 @@ Authors:
 <script type="text/javascript">
 
 setTimeout(function() { test(); }, 500);
-
 function test() {
   async_test(function(t) {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureStorage.write(
+	    function() {
+              intel.security.secureStorage.read(
+                function(instanceID) {
+                  t.step(function() {
+                    assert_not_equals(instanceID, null);
+                  });
+                  t.done();
+                },
+                function(errorObj) {
+                  t.step(function() {
+                    assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+                  });
+                  t.done();
+                },
+                {'id': 'id1'}
+              );
+            },
+	    function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+	    {'id': 'id1', 'instanceID': instanceID}
+	  );
         },
         function(errorObj) {
           t.step(function() {
@@ -60,7 +81,7 @@ function test() {
         },
         {'data': 'plaintext data'}
       );
-    } catch (e){
+    } catch (e) {
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_write_all_optional.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_write_all_optional.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_write_all_optional</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -47,10 +47,21 @@ function test() {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureStorage.write(
+        function(){
+              t.step(function() {
+                assert_true(true, 'success to write the security data');
+              });
+              t.done();
+            },
+            function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+            {'id': 'id1', 'instanceID': instanceID, 'storageType': 0}
+          );
         },
         function(errorObj) {
           t.step(function() {
@@ -60,7 +71,7 @@ function test() {
         },
         {'data': 'plaintext data'}
       );
-    } catch (e){
+    } catch (e) {
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_write_invalid_instance.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_write_invalid_instance.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_write_invalid_instance</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -40,27 +40,28 @@ Authors:
 <div id="log"></div>
 <script type="text/javascript">
 
+var error_code_invalid_instance = 9
 setTimeout(function() { test(); }, 500);
 
 function test() {
   async_test(function(t) {
     try{
-      intel.security.secureData.createFromData(
-        function(instanceID) {
+      intel.security.secureStorage.write(
+        function(){
           t.step(function() {
-            assert_not_equals(instanceID, null);
+            assert_unreached("write should fail");
           });
           t.done();
         },
         function(errorObj) {
           t.step(function() {
-            assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+            assert_equals(errorObj.code, error_code_invalid_instance);
           });
           t.done();
         },
-        {'data': 'plaintext data'}
+        {'id': 'id1', 'instanceID': 1234, 'storageType': 0}
       );
-    } catch (e){
+    } catch (e) {
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);

--- a/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_write_no_optional.html
+++ b/cordova/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_write_no_optional.html
@@ -31,7 +31,7 @@ Authors:
 -->
 
 <meta charset='utf-8'>
-<title>Secure Data Test: AppSecurityApi_createFromData_no_optional</title>
+<title>Secure Data Test: AppSecurityApi_write_no_optional</title>
 <link rel="author" title="Intel" href="http://www.intel.com/">
 <link rel="help" href="https://software.intel.com/en-us/app-security-api/api">
 <script src="../resources/testharness.js"></script>
@@ -47,10 +47,21 @@ function test() {
     try{
       intel.security.secureData.createFromData(
         function(instanceID) {
-          t.step(function() {
-            assert_not_equals(instanceID, null);
-          });
-          t.done();
+          intel.security.secureStorage.write(
+	    function() {
+              t.step(function() {
+                assert_true(true, 'success to write the security data');
+              });
+              t.done();
+            },
+	    function(errorObj) {
+              t.step(function() {
+                assert_true(false, 'fail: code = ' + errorObj.code + ', message = ' + errorObj.message);
+              });
+              t.done();
+            },
+	    {'id': 'id1', 'instanceID': instanceID}
+	  );            
         },
         function(errorObj) {
           t.step(function() {
@@ -60,7 +71,7 @@ function test() {
         },
         {'data': 'plaintext data'}
       );
-    } catch (e){
+    } catch (e) {
       assert_true(false, "Exception: {" + e.message + "}");
     }
   }, document.title);

--- a/cordova/cordova-appsecurityapi-android-tests/tests.full.xml
+++ b/cordova/cordova-appsecurityapi-android-tests/tests.full.xml
@@ -73,9 +73,179 @@
           <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getData_invalid_instance.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getSealedData_correct_instance" purpose="Test checks if the getSealedData can pass with correct instanceID" priority="P1" status="approved" type="compliance">
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getSealedData_correct_instance" priority="P1" purpose="Test checks if the getSealedData can pass with correct instanceID"  status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getSealedData_correct_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getSealedData_invalid_instance" priority="P1" purpose="Test checks if the getSealedData can fail with invalid instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getSealedData_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getTag_correct_instance" priority="P1" purpose="Test checks if the getTag can pass with correct instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getTag_correct_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getTag_invalid_instance" priority="P1" purpose="Test checks if the getTag can fail with invalid instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getTag_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getPolicy_appAccessControl" priority="P1" purpose="Test checks if the getPolicy can get appAccessControl with correct instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_appAccessControl.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getPolicy_deviceLocality" priority="P1" purpose="Test checks if the getPolicy can get deviceLocality with correct instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_deviceLocality.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getPolicy_sensitivityLevel" priority="P1" purpose="Test checks if the getPolicy can get sensitivityLevel with correct instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_sensitivityLevel.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getPolicy_noStore" priority="P1" purpose="Test checks if the getPolicy can get noStore with correct instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_noStore.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getPolicy_noRead" purpose="Test checks if the getPolicy can get noRead with correct instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_noRead.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getPolicy_invalid_instance" priority="P1" purpose="Test checks if the getPolicy can fail with invalid instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getOwners_correct_instance" priority="P1" purpose="Test checks if the getOwners can pass with correct instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getOwners_correct_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getOwners_invalid_instance" priority="P1" purpose="Test checks if the getOwners can fail with invalid instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getOwners_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getCreator_correct_instance" priority="P1" purpose="Test checks if the getCreator can pass with correct instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getCreator_correct_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getCreator_invalid_instance" priority="P1" purpose="Test checks if the getCreator can fail with invalid instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getCreator_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getWebOwners_correct_instance" priority="P1" purpose="Test checks if the getWebOwners can pass with correct instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getWebOwners_correct_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getWebOwners_invalid_instance" priority="P1" purpose="Test checks if the getWebOwners can fail with invalid instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getWebOwners_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_changeExtraKey_all_optional" priority="P1" purpose="Test checks if the changeExtraKey can pass with correct arguments" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_all_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_changeExtraKey_invalid_instanceID" priority="P1" purpose="Test checks if the changeExtraKey can fail with invalid instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_invalid_instanceID.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_changeExtraKey_data_below" priority="P1" purpose="Test checks if the changeExtraKey can fail with extraKey data's length is below 4" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_data_below.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_changeExtraKey_noStore_false" priority="P1" purpose="Test checks if the changeExtraKey can fail with extraKey data's noStore is false" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_noStore_false.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_changeExtraKey_noRead_false" priority="P1" purpose="Test checks if the changeExtraKey can fail with extraKey data's noRead is false" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_noRead_false.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_destory_correct_instance" priority="P1" purpose="Test checks if the destory can pass with correct instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_destory_correct_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_destory_invalid_instance" priority="P1" purpose="Test checks if the destory can fail with invalid instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_destory_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_write_no_optional" priority="P1" purpose="Test checks if the write can pass without optional parameter" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_write_no_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_write_all_optional" priority="P1" purpose="Test checks if the write can pass with all optional parameters" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_write_all_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_write_invalid_instance" priority="P1" purpose="Test checks if the write can pass without invalid instanceID" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_write_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_read_no_optional" priority="P1" purpose="Test checks if the read can pass without optional parameter" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_no_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_read_all_optional" priority="P1" purpose="Test checks if the read can pass with all optional parameters" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_all_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_read_integrity_detected" priority="P1" purpose="Test checks if the read can fail because of integrity etected" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_integrity_detected.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_read_noStore_false" priority="P1" purpose="Test checks if the read can fail with extraKey data's nostore is false" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_noStore_false.html</test_script_entry> 
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_read_noRead_false" priority="P1" purpose="Test checks if the read can fail with extraKey data's noRead is false" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_noRead_false.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_read_invalid_id" priority="P1" purpose="Test checks if the read can fail with invalid id" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_invalid_id.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_delete_all_optional" priority="P1" purpose="Test checks if the delete can pass with all optional parameters" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_delete_all_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_delete_no_optional" priority="P1" purpose="Test checks if the delete can pass without optional parameter" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_delete_no_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_delete_invalid_id" priority="P1" purpose="Test checks if the delete can fail with invalid id" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_delete_invalid_id.html</test_script_entry>
         </description>
       </testcase>
     </set>

--- a/cordova/cordova-appsecurityapi-android-tests/tests.xml
+++ b/cordova/cordova-appsecurityapi-android-tests/tests.xml
@@ -23,7 +23,7 @@
           <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_createFromData_noRead_false.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_createFromData_data_below" purpose="Test checks if the createFromData can fail with data's length is below 4">
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_createFromData_data_below" purpose="Test checks if the createFromData can fail with extraKey data's length is below 4">
         <description>
           <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_createFromData_data_below.html</test_script_entry>
         </description>
@@ -53,7 +53,7 @@
           <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_createFromSealedData_noRead_false.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_createFromSealedData_data_below" purpose="Test checks if the createFromSealedData can fail with data's length is below 4">
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_createFromSealedData_data_below" purpose="Test checks if the createFromSealedData can fail with extraKey data's length is below 4">
         <description>
           <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_createFromSealedData_data_below.html</test_script_entry>
         </description>
@@ -76,6 +76,176 @@
       <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getSealedData_correct_instance" purpose="Test checks if the getSealedData can pass with correct instanceID">
         <description>
           <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getSealedData_correct_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getSealedData_invalid_instance" purpose="Test checks if the getSealedData can fail with invalid instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getSealedData_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getTag_correct_instance" purpose="Test checks if the getTag can pass with correct instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getTag_correct_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getTag_invalid_instance" purpose="Test checks if the getTag can fail with invalid instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getTag_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getPolicy_appAccessControl" purpose="Test checks if the getPolicy can get appAccessControl with correct instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_appAccessControl.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getPolicy_deviceLocality" purpose="Test checks if the getPolicy can get deviceLocality with correct instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_deviceLocality.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getPolicy_sensitivityLevel" purpose="Test checks if the getPolicy can get sensitivityLevel with correct instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_sensitivityLevel.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getPolicy_noStore" purpose="Test checks if the getPolicy can get noStore with correct instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_noStore.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getPolicy_noRead" purpose="Test checks if the getPolicy can get noRead with correct instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_noRead.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getPolicy_invalid_instance" purpose="Test checks if the getPolicy can fail with invalid instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getPolicy_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getOwners_correct_instance" purpose="Test checks if the getOwners can pass with correct instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getOwners_correct_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getOwners_invalid_instance" purpose="Test checks if the getOwners can fail with invalid instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getOwners_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getCreator_correct_instance" purpose="Test checks if the getCreator can pass with correct instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getCreator_correct_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getCreator_invalid_instance" purpose="Test checks if the getCreator can fail with invalid instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getCreator_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getWebOwners_correct_instance" purpose="Test checks if the getWebOwners can pass with correct instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getWebOwners_correct_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_getWebOwners_invalid_instance" purpose="Test checks if the getWebOwners can fail with invalid instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_getWebOwners_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_changeExtraKey_all_optional" purpose="Test checks if the changeExtraKey can pass with correct arguments">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_all_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_changeExtraKey_invalid_instanceID" purpose="Test checks if the changeExtraKey can fail with invalid instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_invalid_instanceID.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_changeExtraKey_data_below" purpose="Test checks if the changeExtraKey can fail with extraKey data's length is below 4">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_data_below.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_changeExtraKey_noStore_false" purpose="Test checks if the changeExtraKey can fail with extraKey data's noStore is false">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_noStore_false.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_changeExtraKey_noRead_false" purpose="Test checks if the changeExtraKey can fail with extraKey data's noRead is false">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_changeExtraKey_noRead_false.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_destory_correct_instance" purpose="Test checks if the destory can pass with correct instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_destory_correct_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_destory_invalid_instance" purpose="Test checks if the destory can fail with invalid instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_destory_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_write_no_optional" purpose="Test checks if the write can pass without optional parameter">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_write_no_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_write_all_optional" purpose="Test checks if the write can pass with all optional parameters">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_write_all_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_write_invalid_instance" purpose="Test checks if the write can pass without invalid instanceID">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_write_invalid_instance.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_read_no_optional" purpose="Test checks if the read can pass without optional parameter">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_no_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_read_all_optional" purpose="Test checks if the read can pass with all optional parameters">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_all_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_read_integrity_detected" purpose="Test checks if the read can fail because of integrity etected">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_integrity_detected.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_read_noStore_false" purpose="Test checks if the read can fail with extraKey data's nostore is false">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_noStore_false.html</test_script_entry> 
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_read_noRead_false" purpose="Test checks if the read can fail with extraKey data's noRead is false">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_noRead_false.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_read_invalid_id" purpose="Test checks if the read can fail with invalid id">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_read_invalid_id.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_delete_all_optional" purpose="Test checks if the delete can pass with all optional parameters">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_delete_all_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_delete_no_optional" purpose="Test checks if the delete can pass without optional parameter">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_delete_no_optional.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Features/AppSecurityApi" execution_type="auto" id="AppSecurityApi_delete_invalid_id" purpose="Test checks if the delete can fail with invalid id">
+        <description>
+          <test_script_entry>/opt/cordova-appsecurityapi-android-tests/appsecurityapi/AppSecurityApi_delete_invalid_id.html</test_script_entry>
         </description>
       </testcase>
     </set>


### PR DESCRIPTION
- Fail Analyse: XWALK-5575, XWALK-5579

Impacted tests(approved): new 33, update 16, delete 0
Unit test platform: Crosswalk Project for Android 16.45.421.1
Unit test result summary: pass 44, fail 5, block 0

https://crosswalk-project.org/jira/browse/XWALK-5098