### PR TITLE
[apptools] Add tests to test build project without channel for apptools

### DIFF
--- a/apptools/apptools-android-tests/apptools/create_package.py
+++ b/apptools/apptools-android-tests/apptools/create_package.py
@@ -257,5 +257,26 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(return_code, 0)
         self.assertEquals(apkLength, 1)
 
+    def test_create_package_without_channel(self):
+        comm.setUp()
+        os.chdir(comm.XwalkPath)
+        comm.clear("org.xwalk.test")
+        os.mkdir("org.xwalk.test")
+        os.chdir('org.xwalk.test')
+        cmd = comm.HOST_PREFIX + comm.PackTools + \
+            "crosswalk-pkg --platforms=android  " + comm.ConstPath + "/../testapp/create_package_basic/"
+        return_code = os.system(cmd)
+        apks = os.listdir(os.getcwd())
+        apkLength = 0
+        for i in range(len(apks)):
+            if apks[i].endswith(".apk") and "x86" in apks[i]:
+                apkLength = apkLength + 1
+            if apks[i].endswith(".apk") and "arm" in apks[i]:
+                apkLength = apkLength + 1
+        self.assertEquals(apkLength, 2)
+        comm.run(self)
+        comm.clear("org.xwalk.test")
+        self.assertEquals(return_code, 0)
+
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-android-tests/tests.full.xml
+++ b/apptools/apptools-android-tests/tests.full.xml
@@ -123,7 +123,7 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/create_offline.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_package" priority="P1" purpose="Android - Validate if package can be created without a project" status="approved" type="Functional" subcase="9">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_package" priority="P1" purpose="Android - Validate if package can be created without a project" status="approved" type="Functional" subcase="10">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/create_package.py</test_script_entry>
         </description>

--- a/apptools/apptools-android-tests/tests.xml
+++ b/apptools/apptools-android-tests/tests.xml
@@ -123,7 +123,7 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/create_offline.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_package" purpose="Android - Validate if package can be created without a project" subcase="9">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_package" purpose="Android - Validate if package can be created without a project" subcase="10">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/create_package.py</test_script_entry>
         </description>

--- a/apptools/apptools-windows-tests/apptools/create_package.py
+++ b/apptools/apptools-windows-tests/apptools/create_package.py
@@ -151,5 +151,34 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(return_code, 0)
         self.assertEquals(apkLength, 1)
 
+    def test_create_package_without_channel(self):
+        comm.setUp()
+        os.chdir(comm.XwalkPath)
+        comm.clear("org.xwalk.test")
+        os.mkdir("org.xwalk.test")
+        os.chdir('org.xwalk.test')
+        cmd = comm.HOST_PREFIX + comm.PackTools + \
+            "crosswalk-pkg --platforms=windows " + comm.ConstPath + "/../testapp/create_package_basic/"
+        (return_code, output) = comm.getstatusoutput(cmd)
+        version = comm.check_crosswalk_version(self, "stable")
+        crosswalk = 'crosswalk-{}.zip'.format(version)
+        apks = os.listdir(os.getcwd())
+        apkLength = 0
+        for i in range(len(apks)):
+            if apks[i].endswith(".msi"):
+                apkLength = apkLength + 1
+        comm.clear("org.xwalk.test")
+        if not comm.cachedir:
+            namelist = os.listdir(os.getcwd())
+        else:
+            newcachedir = os.environ.get('CROSSWALK_APP_TOOLS_CACHE_DIR')
+            os.chdir(newcachedir)
+            namelist = os.listdir(os.getcwd())
+        self.assertEquals(return_code, 0)
+        self.assertIn("stable", output[0])
+        self.assertIn(version, output[0])
+        self.assertIn(crosswalk, namelist)
+        self.assertEquals(apkLength, 1)
+
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-windows-tests/tests.full.xml
+++ b/apptools/apptools-windows-tests/tests.full.xml
@@ -68,7 +68,7 @@
           <test_script_entry>/opt/apptools-windows-tests/apptools/manifest_file_name.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_package" priority="P1" purpose="Windows - Validate if package can be created without a project" status="approved" type="Functional" subcase="5">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_package" priority="P1" purpose="Windows - Validate if package can be created without a project" status="approved" type="Functional" subcase="6">
         <description>
           <test_script_entry>/opt/apptools-windows-tests/apptools/create_package.py</test_script_entry>
         </description>

--- a/apptools/apptools-windows-tests/tests.xml
+++ b/apptools/apptools-windows-tests/tests.xml
@@ -68,7 +68,7 @@
           <test_script_entry>/opt/apptools-windows-tests/apptools/manifest_file_name.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_package" purpose="Windows - Validate if package can be created without a project" subcase="5">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create_package" purpose="Windows - Validate if package can be created without a project" subcase="6">
         <description>
           <test_script_entry>/opt/apptools-windows-tests/apptools/create_package.py</test_script_entry>
         </description>


### PR DESCRIPTION
Failure analysis:
At the moment we only have a windows release in canary.

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Windows]
Unit test result summary: pass 1, fail 1, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5555