### PR TITLE
[apptools] Add tests to test init manifest with platforms for apptools

### DIFF
--- a/apptools/apptools-android-tests/apptools/init_manifest.py
+++ b/apptools/apptools-android-tests/apptools/init_manifest.py
@@ -51,5 +51,31 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.clear("org.xwalk.test")
         self.assertEquals(data['xwalk_target_platforms'].strip(os.linesep), "android")
 
+    def test_init_manifest_androidPlatforms(self):
+        comm.setUp()
+        os.chdir(comm.XwalkPath)
+        comm.clear("org.xwalk.test")
+        os.mkdir("org.xwalk.test")
+        cmd = comm.HOST_PREFIX + comm.PackTools + \
+            "crosswalk-app manifest " + \
+            comm.XwalkPath + "org.xwalk.test --platforms=android"
+        os.system(cmd)
+        with open(comm.ConstPath + "/../tools/org.xwalk.test/manifest.json") as json_file:
+            data = json.load(json_file)
+        comm.clear("org.xwalk.test")
+        self.assertEquals(data['xwalk_target_platforms'].strip(os.linesep), "android")
+
+    def test_init_manifest_invalidPlatforms(self):
+        comm.setUp()
+        os.chdir(comm.XwalkPath)
+        comm.clear("org.xwalk.test")
+        os.mkdir("org.xwalk.test")
+        cmd = comm.HOST_PREFIX + comm.PackTools + \
+            "crosswalk-app manifest " + \
+            comm.XwalkPath + "org.xwalk.test --platforms=invalid"
+        return_code = os.system(cmd)
+        comm.clear("org.xwalk.test")
+        self.assertNotEquals(return_code, 0)
+
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-android-tests/tests.full.xml
+++ b/apptools/apptools-android-tests/tests.full.xml
@@ -143,7 +143,7 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/manifest_display.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" priority="P1" purpose="Android - Validate if the web manifest can be initialised" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" priority="P1" purpose="Android - Validate if the web manifest can be initialised" status="approved" type="Functional" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/init_manifest.py</test_script_entry>
         </description>

--- a/apptools/apptools-android-tests/tests.xml
+++ b/apptools/apptools-android-tests/tests.xml
@@ -143,7 +143,7 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/manifest_display.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" purpose="Android - Validate if the web manifest can be initialised">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" purpose="Android - Validate if the web manifest can be initialised" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/init_manifest.py</test_script_entry>
         </description>

--- a/apptools/apptools-windows-tests/apptools/init_manifest.py
+++ b/apptools/apptools-windows-tests/apptools/init_manifest.py
@@ -51,5 +51,31 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.clear("org.xwalk.test")
         self.assertEquals(data['xwalk_target_platforms'].strip(os.linesep), "android")
 
+    def test_init_manifest_windowsPlatforms(self):
+        comm.setUp()
+        os.chdir(comm.XwalkPath)
+        comm.clear("org.xwalk.test")
+        os.mkdir("org.xwalk.test")
+        cmd = comm.HOST_PREFIX + comm.PackTools + \
+            "crosswalk-app manifest " + \
+            comm.XwalkPath + "org.xwalk.test --platforms=windows"
+        os.system(cmd)
+        with open(comm.ConstPath + "/../tools/org.xwalk.test/manifest.json") as json_file:
+            data = json.load(json_file)
+        comm.clear("org.xwalk.test")
+        self.assertEquals(data['xwalk_target_platforms'].strip(os.linesep), "windows")
+
+    def test_init_manifest_invalidPlatforms(self):
+        comm.setUp()
+        os.chdir(comm.XwalkPath)
+        comm.clear("org.xwalk.test")
+        os.mkdir("org.xwalk.test")
+        cmd = comm.HOST_PREFIX + comm.PackTools + \
+            "crosswalk-app manifest " + \
+            comm.XwalkPath + "org.xwalk.test --platforms=invalid"
+        return_code = os.system(cmd)
+        comm.clear("org.xwalk.test")
+        self.assertNotEquals(return_code, 0)
+
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-windows-tests/tests.full.xml
+++ b/apptools/apptools-windows-tests/tests.full.xml
@@ -78,7 +78,7 @@
           <test_script_entry>/opt/apptools-windows-tests/apptools/manifest_display.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" priority="P1" purpose="Windows - Validate if the web manifest can be initialised" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" priority="P1" purpose="Windows - Validate if the web manifest can be initialised" status="approved" type="Functional" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-windows-tests/apptools/init_manifest.py</test_script_entry>
         </description>

--- a/apptools/apptools-windows-tests/tests.xml
+++ b/apptools/apptools-windows-tests/tests.xml
@@ -78,7 +78,7 @@
           <test_script_entry>/opt/apptools-windows-tests/apptools/manifest_display.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" purpose="Windows - Validate if the web manifest can be initialised">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" purpose="Windows - Validate if the web manifest can be initialised" subcase="3">
         <description>
           <test_script_entry>/opt/apptools-windows-tests/apptools/init_manifest.py</test_script_entry>
         </description>


### PR DESCRIPTION
Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Windows]
Unit test result summary: pass 2, fail 0, block 0

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-5562