### PR TITLE
[apptools] Add tests to test init manifest with package-id for apptools

### DIFF
--- a/apptools/apptools-android-tests/apptools/init_manifest.py
+++ b/apptools/apptools-android-tests/apptools/init_manifest.py
@@ -77,5 +77,26 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.clear("org.xwalk.test")
         self.assertNotEquals(return_code, 0)
 
+    def test_init_manifest_packageid(self):
+        comm.setUp()
+        os.chdir(comm.XwalkPath)
+        comm.clear("org.xwalk.test")
+        os.mkdir("org.xwalk.test")
+        cmd = comm.HOST_PREFIX + comm.PackTools + \
+            "crosswalk-app manifest " + \
+            comm.XwalkPath + "org.xwalk.test --platforms=android --package-id=org.xwalk.test"
+        os.system(cmd)
+        with open(comm.ConstPath + "/../tools/org.xwalk.test/manifest.json") as json_file:
+            data = json.load(json_file)
+        updatecmd = comm.HOST_PREFIX + comm.PackTools + \
+            "crosswalk-app manifest " + \
+            comm.XwalkPath + "org.xwalk.test --platforms=android --package-id=org.test.foo"
+        os.system(updatecmd)
+        with open(comm.ConstPath + "/../tools/org.xwalk.test/manifest.json") as json_file_update:
+            updatedata = json.load(json_file_update)
+        comm.clear("org.xwalk.test")
+        self.assertEquals(data['xwalk_package_id'].strip(os.linesep), "org.xwalk.test")
+        self.assertEquals(updatedata['xwalk_package_id'].strip(os.linesep), "org.test.foo")
+
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-android-tests/tests.full.xml
+++ b/apptools/apptools-android-tests/tests.full.xml
@@ -143,7 +143,7 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/manifest_display.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" priority="P1" purpose="Android - Validate if the web manifest can be initialised" status="approved" type="Functional" subcase="3">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" priority="P1" purpose="Android - Validate if the web manifest can be initialised and updated" status="approved" type="Functional" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/init_manifest.py</test_script_entry>
         </description>

--- a/apptools/apptools-android-tests/tests.xml
+++ b/apptools/apptools-android-tests/tests.xml
@@ -143,7 +143,7 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/manifest_display.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" purpose="Android - Validate if the web manifest can be initialised" subcase="3">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" purpose="Android - Validate if the web manifest can be initialised and updated" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-android-tests/apptools/init_manifest.py</test_script_entry>
         </description>

--- a/apptools/apptools-windows-tests/apptools/init_manifest.py
+++ b/apptools/apptools-windows-tests/apptools/init_manifest.py
@@ -77,5 +77,26 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.clear("org.xwalk.test")
         self.assertNotEquals(return_code, 0)
 
+    def test_init_manifest_packageid(self):
+        comm.setUp()
+        os.chdir(comm.XwalkPath)
+        comm.clear("org.xwalk.test")
+        os.mkdir("org.xwalk.test")
+        cmd = comm.HOST_PREFIX + comm.PackTools + \
+            "crosswalk-app manifest " + \
+            comm.XwalkPath + "org.xwalk.test --platforms=windows --package-id=org.xwalk.test"
+        os.system(cmd)
+        with open(comm.ConstPath + "/../tools/org.xwalk.test/manifest.json") as json_file:
+            data = json.load(json_file)
+        updatecmd = comm.HOST_PREFIX + comm.PackTools + \
+            "crosswalk-app manifest " + \
+            comm.XwalkPath + "org.xwalk.test --platforms=windows --package-id=org.test.foo"
+        os.system(updatecmd)
+        with open(comm.ConstPath + "/../tools/org.xwalk.test/manifest.json") as json_file_update:
+            updatedata = json.load(json_file_update)
+        comm.clear("org.xwalk.test")
+        self.assertEquals(data['xwalk_package_id'].strip(os.linesep), "org.xwalk.test")
+        self.assertEquals(updatedata['xwalk_package_id'].strip(os.linesep), "org.test.foo")
+
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-windows-tests/tests.full.xml
+++ b/apptools/apptools-windows-tests/tests.full.xml
@@ -78,7 +78,7 @@
           <test_script_entry>/opt/apptools-windows-tests/apptools/manifest_display.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" priority="P1" purpose="Windows - Validate if the web manifest can be initialised" status="approved" type="Functional" subcase="3">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" priority="P1" purpose="Windows - Validate if the web manifest can be initialised and updated" status="approved" type="Functional" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-windows-tests/apptools/init_manifest.py</test_script_entry>
         </description>

--- a/apptools/apptools-windows-tests/tests.xml
+++ b/apptools/apptools-windows-tests/tests.xml
@@ -78,7 +78,7 @@
           <test_script_entry>/opt/apptools-windows-tests/apptools/manifest_display.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" purpose="Windows - Validate if the web manifest can be initialised" subcase="3">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_init_manifest" purpose="Windows - Validate if the web manifest can be initialised and updated" subcase="4">
         <description>
           <test_script_entry>/opt/apptools-windows-tests/apptools/init_manifest.py</test_script_entry>
         </description>


### PR DESCRIPTION
Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Windows]
Unit test result summary: pass 1, fail 0, block 0

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5442