### PR TITLE
[Crosswalk-14][webapi] Update SpeechRecognitionEvent emma test

### DIFF
--- a/webapi/webapi-webspeech-w3c-tests/webspeech/SpeechRecognitionEvent_emma-manual.html
+++ b/webapi/webapi-webspeech-w3c-tests/webspeech/SpeechRecognitionEvent_emma-manual.html
@@ -49,7 +49,7 @@ async_test(function(t) {
   var speechReco = new speechRecognition();
   speechReco.onresult = t.step_func(function (evt) {
     assert_true("emma" in evt, "emma attribute exist in SpeechRecognitionEvent");
-    assert_true(evt.emma.indexOf("<emma:emma version=\"1.0\"") > 0, "EMMA 1.0 representation of this result");
+    assert_equals(evt.emma, null);
     speechReco.stop();
     t.done();
   });


### PR DESCRIPTION
https://github.com/crosswalk-project/blink-crosswalk/blob/master/LayoutTests/fast/speech/scripted/speechrecognition-basics.html
test SpeechRecognitionEvent.emma attribute return null,

but spec(https://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html#speechreco-event) defines
"all implementations must expose a valid XML document complete with EMMA namespace" for emma attribute.

Impacted TCs num(approved): New 0, Update 1, Delete 0
Unit test Platform: Crosswalk Project for Android 14.43.347.0
Unit test result summary: Pass 1, Fail 0, Blocked 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5162