### PR TITLE
[EmbeddingAPI-usecase] Add usecase for XWalkResourceClient API onRece…

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -609,5 +609,14 @@
                 <category android:name="XWalkView.Basic" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".client.XWalkViewWithOnReceivedHttpAuthRequestAsync"
+            android:label="@string/title_activity_xwalk_view_with_httpauth_request_async"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.UIClient.ResourceClient" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_on_received_httpauth_request_async.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_on_received_httpauth_request_async.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (c) 2014 Intel Corporation. All rights reserved.
+
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.asyncsample.client.XWalkViewWithOnReceivedHttpAuthRequestAsync">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="If onReceivedHttpAuthRequest is invoked, below will show the 'onReceivedHttpAuthRequest is invoked. Host is '"
+        android:id="@+id/textView" />
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textColor="#00ff00"
+        android:id="@+id/httpauth_request_label"
+        android:layout_below="@+id/textView"/>
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/httpauth_request_label" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
@@ -81,5 +81,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_open_file_chooser_async">XWalkViewWithOpenFileChooserAsync</string>
     <string name="title_activity_xwalk_view_with_scrollview_parent_async">XWalkViewWithScrollViewParentAsync</string>
     <string name="title_activity_xwalk_view_with_multi_instance_overlay_async">XWalkViewWithMultiInstanceOverlayAsync</string>
+    <string name="title_activity_xwalk_view_with_httpauth_request_async">XWalkViewWithOnReceivedHttpAuthRequestAsync</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -623,3 +623,14 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkView interface: load methods
+
+
+
+### 62. The [XWalkViewWithOnReceivedHttpAuthRequestAsync](client/XWalkViewWithOnReceivedHttpAuthRequestAsync.java) sample check onReceivedHttpAuthRequest will be invoked when website needs auth request, include:
+
+* XWalkView can handle an authentication request
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, setResourceClient methods
+* ResourceClient interface: onReceivedHttpAuthRequest methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/client/XWalkViewWithOnReceivedHttpAuthRequestAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/client/XWalkViewWithOnReceivedHttpAuthRequestAsync.java
@@ -1,0 +1,73 @@
+package org.xwalk.embedded.api.asyncsample.client;
+
+import org.xwalk.embedded.api.asyncsample.R;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.widget.TextView;
+
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkHttpAuthHandler;
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkView;
+
+public class XWalkViewWithOnReceivedHttpAuthRequestAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+
+    private XWalkInitializer mXWalkInitializer;
+    private XWalkView mXWalkView;
+    private TextView mTextView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        setContentView(R.layout.activity_xwalk_view_with_on_received_httpauth_request_async);
+
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+            .append("Verifies OnReceivedHttpAuthRequest API can be invoked in XWalkResourceClient.\n\n")
+            .append("Expected Result:\n\n")
+            .append("Test passes if the host name will be shown and it is 'httpbin.org'");
+        new AlertDialog.Builder(this)
+            .setTitle("Info")
+            .setMessage(mess.toString())
+            .setPositiveButton("confirm", null)
+            .show();
+
+        mTextView = (TextView) findViewById(R.id.httpauth_request_label);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mXWalkView.load("http://httpbin.org/basic-auth/user/passwd", null);
+        mXWalkView.setResourceClient(new XWalkResourceClient(mXWalkView) {
+
+            @Override
+            public void onReceivedHttpAuthRequest(XWalkView view,
+                    XWalkHttpAuthHandler handler, String host, String realm) {
+                // TODO Auto-generated method stub
+                super.onReceivedHttpAuthRequest(view, handler, host, realm);
+                mTextView.setText(host);
+            }
+        });
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -610,5 +610,14 @@
                 <category android:name="XWalkView.Basic" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".client.XWalkViewWithOnReceivedHttpAuthRequest"
+            android:label="@string/title_activity_xwalk_view_with_httpauth_request"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.UIClient.ResourceClient" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_on_received_httpauth_request.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_on_received_httpauth_request.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (c) 2014 Intel Corporation. All rights reserved.
+
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.sample.client.XWalkViewWithOnReceivedHttpAuthRequest">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="If onReceivedHttpAuthRequest is invoked, below will show the 'onReceivedHttpAuthRequest is invoked. Host is '"
+        android:id="@+id/textView" />
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textColor="#00ff00"
+        android:id="@+id/httpauth_request_label"
+        android:layout_below="@+id/textView"/>
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/httpauth_request_label" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
@@ -89,5 +89,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_open_file_chooser">XWalkViewWithOpenFileChooser</string>
     <string name="title_activity_xwalk_view_with_scrollview_parent">XWalkViewWithScrollViewParent</string>
     <string name="title_activity_xwalk_view_with_multi_instance_overlay">XWalkViewWithMultiInstanceOverlay</string>
+    <string name="title_activity_xwalk_view_with_httpauth_request">XWalkViewWithOnReceivedHttpAuthRequest</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -623,3 +623,14 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkView interface: load methods
+
+
+
+### 62. The [XWalkViewWithOnReceivedHttpAuthRequest](client/XWalkViewWithOnReceivedHttpAuthRequest.java) sample check onReceivedHttpAuthRequest will be invoked when website needs auth request, include:
+
+* XWalkView can handle an authentication request
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, setResourceClient methods
+* ResourceClient interface: onReceivedHttpAuthRequest methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/client/XWalkViewWithOnReceivedHttpAuthRequest.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/client/XWalkViewWithOnReceivedHttpAuthRequest.java
@@ -1,0 +1,53 @@
+package org.xwalk.embedded.api.sample.client;
+
+import org.xwalk.embedded.api.sample.R;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.widget.TextView;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkHttpAuthHandler;
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkView;
+
+public class XWalkViewWithOnReceivedHttpAuthRequest extends XWalkActivity{
+
+    private XWalkView mXWalkView;
+    private TextView mTextView;
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_xwalk_view_with_on_received_httpauth_request);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+            .append("Verifies OnReceivedHttpAuthRequest API can be invoked in XWalkResourceClient.\n\n")
+            .append("Expected Result:\n\n")
+            .append("Test passes if the host name will be shown and it is 'httpbin.org'");
+        new AlertDialog.Builder(this)
+            .setTitle("Info")
+            .setMessage(mess.toString())
+            .setPositiveButton("confirm", null)
+            .show();
+
+        mTextView = (TextView) findViewById(R.id.httpauth_request_label);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mXWalkView.load("http://httpbin.org/basic-auth/user/passwd", null);
+        mXWalkView.setResourceClient(new XWalkResourceClient(mXWalkView) {
+
+            @Override
+            public void onReceivedHttpAuthRequest(XWalkView view,
+                    XWalkHttpAuthHandler handler, String host, String realm) {
+                // TODO Auto-generated method stub
+                super.onReceivedHttpAuthRequest(view, handler, host, realm);
+                mTextView.setText(host);
+            }
+        });
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -765,6 +765,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnReceivedHttpAuthRequest" purpose="XWalkViewWithOnReceivedHttpAuthRequest Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -1520,6 +1532,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithMultiInstanceOverlayAsync" purpose="XWalkViewWithMultiInstanceOverlayAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnReceivedHttpAuthRequestAsync" purpose="XWalkViewWithOnReceivedHttpAuthRequestAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -859,6 +859,19 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnReceivedHttpAuthRequest" platform="android" priority="P0" purpose="XWalkViewWithOnReceivedHttpAuthRequest Test With XWalkActivity" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -1603,6 +1616,19 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithMultiInstanceOverlayAsync" platform="android" priority="P0" purpose="XWalkViewWithMultiInstanceOverlayAsync Test With XWalkInitializer" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnReceivedHttpAuthRequestAsync" platform="android" priority="P0" purpose="XWalkViewWithOnReceivedHttpAuthRequest Async Test With XWalkInitializer" status="approved" type="functional_positive">
         <description>
           <pre_condition />
           <post_condition />


### PR DESCRIPTION
…ivedHttpAuthRequest

-Add usecase for XWalkResourceClient API onReceivedHttpAuthRequest
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-3477