### PR TITLE
[apptools-android] Update tests to support crosswalk lite for apptools android

### DIFF
--- a/apptools/apptools-android-tests/README.md
+++ b/apptools/apptools-android-tests/README.md
@@ -13,7 +13,8 @@ This test suite is for apptools-android-tests
    If test devices are "arm" and "x86" platforms, content of the file should be "arm,x86", default value is "x86,arm"
 
 3. Need to edit the file "apptools-android-tests/mode.txt" according to the type of build mode.
-   If build "shared" mode apk, content of the file should be "shared", default value is "embedded".
+   If create project with crosswalk lite zip, content of the file should be "lite". If create project with crosswalk zip and build "shared" mode apk, content of the file should be "shared". If create project with crosswalk zip and build "embedded" mode apk, content of the file should be "embedded".
+(Note: If you test "shared" mode, when uninstall crosswalk runtime library from android device before testing, it will be prompted to download crosswalk runtime library from google play in formal test process.)
 
 4. Need to edit the file "apptools-android-tests/host.txt" according to the type of test host.
    If test host is "Windows" platform, content of the file should be "Windows", default value is "Android".
@@ -28,11 +29,13 @@ This test suite is for apptools-android-tests
 
 ## Precondition for AppTools on Linux or OS X host
 
-1. Download crosswalk-app-tools to apptools-android-tests/tools, then install npm and exec-sync
+1. Download crosswalk-app-tools and release crosswalk zip to apptools-android-tests/tools, then install npm and exec-sync
 
   1.1 cd tools, then clone source code from https://github.com/crosswalk-project/crosswalk-app-tools
 
-  1.2 Run commands: cd crosswalk-app-tools, then run:
+  1.2 Download the release Crosswalk zip which you want to test
+
+  1.3 Run commands: cd crosswalk-app-tools, then run:
 
       sudo npm install
       sudo npm install exec-sync
@@ -52,11 +55,13 @@ This test suite is for apptools-android-tests
 
 ## Precondition for AppTools on Windows host
 
-1. Download crosswalk-app-tools to apptools-android-tests/tools, then install npm
+1. Download crosswalk-app-tools and release crosswalk zip to apptools-android-tests/tools, then install npm
 
   1.1 cd tools, then clone source code from https://github.com/crosswalk-project/crosswalk-app-tools
 
-  1.2 Run commands: cd crosswalk-app-tools, then run:
+  1.2 Download the release Crosswalk zip which you want to test
+
+  1.3 Run commands: cd crosswalk-app-tools, then run:
 
       npm install
       npm install exec-sync

--- a/apptools/apptools-android-tests/apptools/AppTools_Download.html
+++ b/apptools/apptools-android-tests/apptools/AppTools_Download.html
@@ -47,9 +47,11 @@ Authors:
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
         On Windows host: <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; Shared Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
-        &nbsp; &nbsp; Embedded Mode: <br/>
+        &nbsp; &nbsp; Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
         Check the output message on the terminal
     </li>

--- a/apptools/apptools-android-tests/apptools/Manifest_Check_Apk_Size.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Check_Apk_Size.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
         On Windows host: <br/>
@@ -52,11 +54,13 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Remember the size of shared mode apk <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Remember the size of x86 apk and arm apk <br/>
         On Linux or OS X host: <br/>
         &nbsp; &nbsp; Add '"xwalk_android_webp": "80 80 100"' to app/manifest.json file <br/>

--- a/apptools/apptools-android-tests/apptools/Manifest_Check_VersionName.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Check_VersionName.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Update "xwalk_app_version" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Update "xwalk_app_version" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         In android device application list, check if the app version is same with "xwalk_app_version" which you update in manifest.json file

--- a/apptools/apptools-android-tests/apptools/Manifest_Check_WebApp_Name.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Check_WebApp_Name.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Update "name" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Update "name" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         On android device, check if the app name is same with "name" which you update in manifest.json file

--- a/apptools/apptools-android-tests/apptools/Manifest_Command_Line_DisableWebGL.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Command_Line_DisableWebGL.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Replace app/index.html with ../../../testapp/webgl_disable_tests/index.html <br/>
         &nbsp; &nbsp; Set "xwalk-command-line" to "--disable-webgl" in app/manifest.json file <br/>
@@ -54,6 +56,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Replace app\index.html with ..\..\..\testapp\webgl_disable_tests\index.html <br/>
         &nbsp; &nbsp; Set "xwalk-command-line" to "--disable-webgl" in app\manifest.json file <br/>
@@ -61,7 +65,7 @@ Authors:
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device <br/>

--- a/apptools/apptools-android-tests/apptools/Manifest_Command_Line_EnableRemoteDebugging.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Command_Line_EnableRemoteDebugging.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "xwalk-command-line" to "--remote-debugging-port=8080" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "xwalk-command-line" to "--remote-debugging-port=8080" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node  ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device <br/>

--- a/apptools/apptools-android-tests/apptools/Manifest_Command_Line_EnableWebGL.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Command_Line_EnableWebGL.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Replace app/index.html with ../../../testapp/webgl_enable_tests/index.html <br/>
         &nbsp; &nbsp; Set "xwalk-command-line" to "--ignore-gpu-blacklist" in app/manifest.json file <br/>
@@ -54,6 +56,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Replace app\index.html with ..\..\..\testapp\webgl_enable_tests\index.html <br/>
         &nbsp; &nbsp; Set "xwalk-command-line" to "--ignore-gpu-blacklist" in app\manifest.json file <br/>
@@ -61,7 +65,7 @@ Authors:
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device <br/>

--- a/apptools/apptools-android-tests/apptools/Manifest_ContactExtension.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_ContactExtension.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Cope ../../../testapp/extension_permission to app/ <br/>
         &nbsp; &nbsp; Set "start_url" to "extension_permission/index.html" in app/manifest.json file <br/>
@@ -55,6 +57,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Cope ..\..\..\testapp\extension_permission to app\ <br/>
         &nbsp; &nbsp; Set "start_url" to "extension_permission/index.html" in app\manifest.json file <br/>
@@ -63,7 +67,7 @@ Authors:
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device

--- a/apptools/apptools-android-tests/apptools/Manifest_Disable_AnimatableView.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Disable_AnimatableView.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "xwalk_android_animatable_view" to "false" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "xwalk_android_animatable_view" to "false" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device <br/>

--- a/apptools/apptools-android-tests/apptools/Manifest_Display_Fullscreen.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Display_Fullscreen.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "display" to "fullscreen" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "display" to "fullscreen" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device

--- a/apptools/apptools-android-tests/apptools/Manifest_Display_Standalone.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Display_Standalone.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "display" to "standalone" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "display" to "standalone" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device

--- a/apptools/apptools-android-tests/apptools/Manifest_Enable_AnimatableView.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Enable_AnimatableView.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "xwalk_android_animatable_view" to "true" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "xwalk_android_animatable_view" to "true" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device <br/>

--- a/apptools/apptools-android-tests/apptools/Manifest_Keeping_Screen_On.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Keeping_Screen_On.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "xwalk_android_keep_screen_on" to "true" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "xwalk_android_keep_screen_on" to "true" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node  ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Set the device screen off as 15 seconds(Setting->Display->Sleep: 15 seconds) <br/>

--- a/apptools/apptools-android-tests/apptools/Manifest_Orientation_Any.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Orientation_Any.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "any" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "any" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device

--- a/apptools/apptools-android-tests/apptools/Manifest_Orientation_Landscape.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Orientation_Landscape.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "landscape" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "landscape" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device

--- a/apptools/apptools-android-tests/apptools/Manifest_Orientation_LandscapePrimary.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Orientation_LandscapePrimary.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "landscape-primary" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "landscape-primary" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device

--- a/apptools/apptools-android-tests/apptools/Manifest_Orientation_LandscapeSecondary.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Orientation_LandscapeSecondary.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "landscape-secondary" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "landscape-secondary" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device

--- a/apptools/apptools-android-tests/apptools/Manifest_Orientation_Natural.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Orientation_Natural.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "natural" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "natural" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device

--- a/apptools/apptools-android-tests/apptools/Manifest_Orientation_Portrait.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Orientation_Portrait.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "portrait" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "portrait" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device

--- a/apptools/apptools-android-tests/apptools/Manifest_Orientation_PortraitPrimary.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Orientation_PortraitPrimary.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "portrait-primary" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "portrait-primary" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device

--- a/apptools/apptools-android-tests/apptools/Manifest_Orientation_PortraitSecondary.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Orientation_PortraitSecondary.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "portrait-secondary" in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Set "orientation" to "portrait-secondary" in app\manifest.json file <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device

--- a/apptools/apptools-android-tests/apptools/Manifest_Using_Better_Fitting_Size_Icon.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_Using_Better_Fitting_Size_Icon.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Add '{"src": "../../../icon/icon.jpg","sizes": "32x32"}' to "icons" field in app/manifest.json file <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
@@ -53,13 +55,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; Add '{"src": "../../../icon/icon.jpg","sizes": "32x32"}' to "icons" field in app/manifest.json file <br/>
         &nbsp; &nbsp; $ node  ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Check if 'app/icon.png' isn't same with '../../icon/icon.jpg', and 'app/icon.png' is used as the icon of web app on android device

--- a/apptools/apptools-android-tests/apptools/Remote_Debugging.html
+++ b/apptools/apptools-android-tests/apptools/Remote_Debugging.html
@@ -45,6 +45,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build debug <br/>
         On Windows host: <br/>
@@ -52,13 +54,15 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build debug <br/>
         $ cd pkg <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
         &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
         Launch the app on android device <br/>

--- a/apptools/apptools-android-tests/apptools/allpairs.py
+++ b/apptools/apptools-android-tests/apptools/allpairs.py
@@ -145,7 +145,7 @@ def tryRunApp(item, cmd):
         comm.setUp()
         os.chdir(comm.XwalkPath)
         package = cmd[cmd.index("create") + 6:cmd.index("--android-crosswalk")].strip()
-        exec_cmd = comm.HOST_PREFIX + comm.PackTools + cmd + comm.crosswalkVersion + comm.MODE
+        exec_cmd = comm.HOST_PREFIX + comm.PackTools + cmd + comm.crosswalkzip + comm.MODE
         # print exec_cmd
         if 'negative' in item:
             comm.clear(package)

--- a/apptools/apptools-android-tests/apptools/build.py
+++ b/apptools/apptools-android-tests/apptools/build.py
@@ -60,7 +60,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir(comm.XwalkPath)
         cmd = comm.HOST_PREFIX + comm.PackTools + \
             "crosswalk-app create org.xwalk.test --android-crosswalk=" + \
-            comm.crosswalkVersion
+            comm.crosswalkzip
         os.system(cmd)
         os.chdir('org.xwalk.test')
         if comm.ARCH_X86 == "x86":
@@ -97,7 +97,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir(comm.XwalkPath)
         cmd = comm.HOST_PREFIX + comm.PackTools + \
             "crosswalk-app create org.xwalk.test --android-crosswalk=" + \
-            comm.crosswalkVersion
+            comm.crosswalkzip
         os.system(cmd)
         os.chdir('org.xwalk.test')
         shutil.rmtree(

--- a/apptools/apptools-android-tests/apptools/check_target_version.py
+++ b/apptools/apptools-android-tests/apptools/check_target_version.py
@@ -58,7 +58,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir(comm.XwalkPath)
         createcmd = comm.HOST_PREFIX + comm.PackTools + \
             "crosswalk-app create org.xwalk.test" + comm.MODE + " --android-crosswalk=" + \
-            comm.crosswalkVersion
+            comm.crosswalkzip
         (return_create_code, output) = comm.getstatusoutput(createcmd)
         os.chdir(movepath)
         os.mkdir(targetversionpath + "/platforms")

--- a/apptools/apptools-android-tests/apptools/create_basic.py
+++ b/apptools/apptools-android-tests/apptools/create_basic.py
@@ -43,7 +43,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.mkdir("org.xwalk.test")
         cmd = comm.HOST_PREFIX + comm.PackTools + \
             "crosswalk-app create org.xwalk.test" + comm.MODE + " --android-crosswalk=" + \
-            comm.crosswalkVersion
+            comm.crosswalkzip
         return_code = os.system(cmd)
         self.assertNotEquals(return_code, 0)
         comm.clear("org.xwalk.test")

--- a/apptools/apptools-android-tests/apptools/create_no_sdk.py
+++ b/apptools/apptools-android-tests/apptools/create_no_sdk.py
@@ -53,7 +53,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir(comm.XwalkPath)
         cmd = comm.HOST_PREFIX + comm.PackTools + \
             "crosswalk-app create org.xwalk.test" + comm.MODE + " --android-crosswalk=" + \
-            comm.crosswalkVersion
+            comm.crosswalkzip
         (return_create_code, packstatus) = comm.getstatusoutput(cmd)
         os.environ['ANDROID_HOME'] = android_home
         os.environ['PATH'] = allpath

--- a/apptools/apptools-android-tests/apptools/create_package.py
+++ b/apptools/apptools-android-tests/apptools/create_package.py
@@ -48,9 +48,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         cmd = comm.HOST_PREFIX + comm.PackTools + \
             "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " " + comm.ConstPath + "/../testapp/create_package_basic/"
         (return_code, output) = comm.getstatusoutput(cmd)
+        version = comm.check_crosswalk_version(self, "stable")
         apks = os.listdir(os.getcwd())
         apkLength = 0
-        if not comm.ANDROID_MODE:
+        if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
                     apkLength = apkLength + 1
@@ -69,6 +70,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertIn("target android", output[0])
         self.assertNotIn("candle", output[0])
         self.assertNotIn("light", output[0])
+        self.assertIn(version, output[0])
 
     def test_create_package_missing_icon_startUrl(self):
         comm.setUp()
@@ -81,7 +83,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
         apkLength = 0
-        if not comm.ANDROID_MODE:
+        if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
                     apkLength = apkLength + 1
@@ -105,11 +107,12 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.mkdir("org.xwalk.test")
         os.chdir('org.xwalk.test')
         cmd = comm.HOST_PREFIX + comm.PackTools + \
-            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=stable " + comm.ConstPath + "/../testapp/create_package_missing_icon_startUrl/"
-        return_code = os.system(cmd)
+            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=stable " + comm.ConstPath + "/../testapp/create_package_basic/"
+        (return_code, output) = comm.getstatusoutput(cmd)
+        version = comm.check_crosswalk_version(self, "stable")
         apks = os.listdir(os.getcwd())
         apkLength = 0
-        if not comm.ANDROID_MODE:
+        if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
                     apkLength = apkLength + 1
@@ -125,6 +128,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertEquals(return_code, 0)
+        self.assertIn(version, output[0])
 
     def test_create_package_beta(self):
         comm.setUp()
@@ -133,11 +137,12 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.mkdir("org.xwalk.test")
         os.chdir('org.xwalk.test')
         cmd = comm.HOST_PREFIX + comm.PackTools + \
-            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=beta " + comm.ConstPath + "/../testapp/create_package_missing_icon_startUrl/"
-        return_code = os.system(cmd)
+            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=beta " + comm.ConstPath + "/../testapp/create_package_basic/"
+        (return_code, output) = comm.getstatusoutput(cmd)
+        version = comm.check_crosswalk_version(self, "beta")
         apks = os.listdir(os.getcwd())
         apkLength = 0
-        if not comm.ANDROID_MODE:
+        if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
                     apkLength = apkLength + 1
@@ -153,6 +158,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertEquals(return_code, 0)
+        self.assertIn(version, output[0])
 
     def test_create_package_canary(self):
         comm.setUp()
@@ -161,11 +167,12 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.mkdir("org.xwalk.test")
         os.chdir('org.xwalk.test')
         cmd = comm.HOST_PREFIX + comm.PackTools + \
-            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=canary " + comm.ConstPath + "/../testapp/create_package_missing_icon_startUrl/"
-        return_code = os.system(cmd)
+            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=canary " + comm.ConstPath + "/../testapp/create_package_basic/"
+        (return_code, output) = comm.getstatusoutput(cmd)
+        version = comm.check_crosswalk_version(self, "canary")
         apks = os.listdir(os.getcwd())
         apkLength = 0
-        if not comm.ANDROID_MODE:
+        if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
                     apkLength = apkLength + 1
@@ -181,6 +188,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertEquals(return_code, 0)
+        self.assertIn(version, output[0])
 
     def test_create_package_version(self):
         comm.setUp()
@@ -189,11 +197,11 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.mkdir("org.xwalk.test")
         os.chdir('org.xwalk.test')
         cmd = comm.HOST_PREFIX + comm.PackTools + \
-            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=" + comm.crosswalkVersion + " " + comm.ConstPath + "/../testapp/create_package_missing_icon_startUrl/"
+            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=" + comm.crosswalkVersion + " " + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
         apkLength = 0
-        if not comm.ANDROID_MODE:
+        if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
                     apkLength = apkLength + 1
@@ -212,19 +220,16 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
 
     def test_create_package_pathToRelease(self):
         comm.setUp()
-        for i in range(len(os.listdir(comm.XwalkPath))):
-                if os.listdir(comm.XwalkPath)[i].endswith(".zip"):
-                    androidCrosswalk = os.listdir(comm.XwalkPath)[i]
         os.chdir(comm.XwalkPath)
         comm.clear("org.xwalk.test")
         os.mkdir("org.xwalk.test")
         os.chdir('org.xwalk.test')
         cmd = comm.HOST_PREFIX + comm.PackTools + \
-            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=" + comm.XwalkPath + androidCrosswalk + " " + comm.ConstPath + "/../testapp/create_package_missing_icon_startUrl/"
+            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=" + comm.crosswalkzip + " " + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
         apkLength = 0
-        if not comm.ANDROID_MODE:
+        if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
                     apkLength = apkLength + 1
@@ -243,19 +248,16 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
 
     def test_build_package_release(self):
         comm.setUp()
-        for i in range(len(os.listdir(comm.XwalkPath))):
-                if os.listdir(comm.XwalkPath)[i].endswith(".zip"):
-                    androidCrosswalk = os.listdir(comm.XwalkPath)[i]
         os.chdir(comm.XwalkPath)
         comm.clear("org.xwalk.test")
         os.mkdir("org.xwalk.test")
         os.chdir('org.xwalk.test')
         cmd = comm.HOST_PREFIX + comm.PackTools + \
-            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --release=true " + comm.ConstPath + "/../testapp/create_package_missing_icon_startUrl/"
+            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --release=true " + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
         apkLength = 0
-        if not comm.ANDROID_MODE:
+        if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
                     apkLength = apkLength + 1
@@ -274,23 +276,20 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
 
     def test_create_package_crosswalkdir(self):
         comm.setUp()
-        for i in range(len(os.listdir(comm.XwalkPath))):
-                if os.listdir(comm.XwalkPath)[i].endswith(".zip"):
-                    androidCrosswalk = os.listdir(comm.XwalkPath)[i]
         os.chdir(comm.XwalkPath)
         comm.clear("org.xwalk.test")
         os.mkdir("org.xwalk.test")
-        crosswalkzip = zipfile.ZipFile(comm.XwalkPath + androidCrosswalk,'r')
-        for file in crosswalkzip.namelist():
-            crosswalkzip.extract(file, r'.')
-        crosswalkzip.close()
+        crosswalkdir = zipfile.ZipFile(comm.crosswalkzip,'r')
+        for file in crosswalkdir.namelist():
+            crosswalkdir.extract(file, r'.')
+        crosswalkdir.close()
         os.chdir('org.xwalk.test')
         cmd = comm.HOST_PREFIX + comm.PackTools + \
-            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=" + comm.XwalkPath + androidCrosswalk[:androidCrosswalk.index(".zip")] + "/ " + comm.ConstPath + "/../testapp/create_package_basic/"
+            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=" + comm.crosswalkzip[:comm.crosswalkzip.index(".zip")] + "/ " + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
         apkLength = 0
-        if not comm.ANDROID_MODE:
+        if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
                     apkLength = apkLength + 1
@@ -305,43 +304,11 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             self.assertEquals(apkLength, 1)
         comm.run(self)
         comm.clear("org.xwalk.test")
-        shutil.rmtree(androidCrosswalk[:androidCrosswalk.index(".zip")])
-        self.assertEquals(return_code, 0)
-        self.assertEquals(apkLength, 1)
-
-    def test_create_package_without_channel(self):
-        comm.setUp()
-        os.chdir(comm.XwalkPath)
-        comm.clear("org.xwalk.test")
-        os.mkdir("org.xwalk.test")
-        os.chdir('org.xwalk.test')
-        cmd = comm.HOST_PREFIX + comm.PackTools + \
-            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " " + comm.ConstPath + "/../testapp/create_package_basic/"
-        return_code = os.system(cmd)
-        apks = os.listdir(os.getcwd())
-        apkLength = 0
-        if not comm.ANDROID_MODE:
-            for i in range(len(apks)):
-                if apks[i].endswith(".apk") and "x86" in apks[i]:
-                    apkLength = apkLength + 1
-                if apks[i].endswith(".apk") and "arm" in apks[i]:
-                    apkLength = apkLength + 1
-            self.assertEquals(apkLength, 2)
-        else:
-            for i in range(len(apks)):
-                if apks[i].endswith(".apk") and "shared" in apks[i]:
-                    apkLength = apkLength + 1
-                    appVersion = apks[i].split('-')[1]
-            self.assertEquals(apkLength, 1)
-        comm.run(self)
-        comm.clear("org.xwalk.test")
+        shutil.rmtree(comm.crosswalkzip[:comm.crosswalkzip.index(".zip")])
         self.assertEquals(return_code, 0)
 
     def test_create_package_manifest(self):
         comm.setUp()
-        for i in range(len(os.listdir(comm.XwalkPath))):
-                if os.listdir(comm.XwalkPath)[i].endswith(".zip"):
-                    androidCrosswalk = os.listdir(comm.XwalkPath)[i]
         os.chdir(comm.XwalkPath)
         comm.clear("org.xwalk.test")
         os.mkdir("org.xwalk.test")
@@ -349,13 +316,13 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             os.remove(comm.ConstPath + "/../testapp/start_url/manifest.json")
         os.chdir('org.xwalk.test')
         cmd = comm.HOST_PREFIX + comm.PackTools + \
-            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=" + comm.XwalkPath + androidCrosswalk + " --manifest=org.xwalk.test " + comm.ConstPath + "/../testapp/start_url/"
+            "crosswalk-pkg --platforms=android" + comm.ANDROID_MODE + " --crosswalk=" + comm.crosswalkzip + " --manifest=org.xwalk.test " + comm.ConstPath + "/../testapp/start_url/"
         return_code = os.system(cmd)
         with open(comm.ConstPath + "/../testapp/start_url/manifest.json") as json_file:
             data = json.load(json_file)
         apks = os.listdir(os.getcwd())
         apkLength = 0
-        if not comm.ANDROID_MODE:
+        if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
                     apkLength = apkLength + 1
@@ -389,7 +356,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             data = json.load(json_file)
         apks = os.listdir(os.getcwd())
         apkLength = 0
-        if not comm.ANDROID_MODE:
+        if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
                     apkLength = apkLength + 1

--- a/apptools/apptools-android-tests/apptools/create_remote.py
+++ b/apptools/apptools-android-tests/apptools/create_remote.py
@@ -45,22 +45,11 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.clear("org.xwalk.test")
         os.chdir(comm.XwalkPath)
         createcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app create org.xwalk.test" + comm.MODE
-        return_code = os.system(createcmd)
-        htmlDoc = urllib2.urlopen(
-            'https://download.01.org/crosswalk/releases/crosswalk/android/stable/').read()
-        soup = BeautifulSoup(htmlDoc)
-        alist = soup.find_all('a')
-        version = ''
-        for  index in range(-1, -len(alist)-1, -1):
-            aEle = alist[index]
-            version = aEle['href'].strip('/')
-            if re.search('[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*', version):
-                break
-        crosswalk = 'crosswalk-{}.zip'.format(version)
-        namelist = os.listdir(os.getcwd())
+        (return_code, output) = comm.getstatusoutput(createcmd)
+        version = comm.check_crosswalk_version(self, "stable")
         comm.clear("org.xwalk.test")
-        self.assertIn(crosswalk, namelist)
         self.assertEquals(return_code, 0)
+        self.assertIn(version, output[0])
 
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-android-tests/apptools/create_version.py
+++ b/apptools/apptools-android-tests/apptools/create_version.py
@@ -40,13 +40,13 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.clear("org.xwalk.test")
         os.chdir(comm.XwalkPath)
         createcmd = comm.HOST_PREFIX + comm.PackTools + \
-            "crosswalk-app create org.xwalk.test" + comm.MODE + " --android-crosswalk=15.44.384.7"
+            "crosswalk-app create org.xwalk.test" + comm.MODE + " --android-crosswalk=" + comm.crosswalkVersion
         (return_code, output) = comm.getstatusoutput(createcmd)
-        crosswalk = 'crosswalk-15.44.384.7.zip'
+        crosswalk = 'crosswalk-{}.zip'.format(comm.crosswalkVersion)
         namelist = os.listdir(os.getcwd())
         comm.clear("org.xwalk.test")
         self.assertEquals(return_code, 0)
-        self.assertIn("15.44.384.7", output[0])
+        self.assertIn(comm.crosswalkVersion, output[0])
         self.assertIn(crosswalk, namelist)
 
 if __name__ == '__main__':

--- a/apptools/apptools-android-tests/apptools/manifest_versionCode.py
+++ b/apptools/apptools-android-tests/apptools/manifest_versionCode.py
@@ -48,7 +48,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             index = x -1
             if buildstatus[index].find("Using android:versionCode") != -1:
                 break
-        versionCode = buildstatus[index].strip(" *\nUsing android:versionCode")[1:-1]
+        versionCode = buildstatus[index].strip(" *\nUsing android:versionCode").split(' ')[-1][1:-1]
         root = ElementTree.parse(comm.ConstPath + "/../tools/org.xwalk.test/prj/android/AndroidManifest.xml").getroot()
         attributes = root.attrib
         for x in attributes.keys():
@@ -78,7 +78,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             index = x -1
             if buildstatus[index].find("Using android:versionCode") != -1:
                 break
-        versionCode = buildstatus[index].strip(" *\nUsing android:versionCode")[1:-1]
+        versionCode = buildstatus[index].strip(" *\nUsing android:versionCode").split(' ')[-1][1:-1]
         root = ElementTree.parse(comm.ConstPath + "/../tools/org.xwalk.test/prj/android/AndroidManifest.xml").getroot()
         attributes = root.attrib
         for x in attributes.keys():
@@ -109,7 +109,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             index = x -1
             if buildstatus[index].find("Using android:versionCode") != -1:
                 break
-        versionCode = buildstatus[index].strip(" *\nUsing android:versionCode")[1:-1]
+        versionCode = buildstatus[index].strip(" *\nUsing android:versionCode").split(' ')[-1][1:-1]
         root = ElementTree.parse(comm.ConstPath + "/../tools/org.xwalk.test/prj/android/AndroidManifest.xml").getroot()
         attributes = root.attrib
         for x in attributes.keys():

--- a/apptools/apptools-sampleapp-tests/sampleapp-android/Crosswalk_Apptools_SampleApp_Spacedodgegame_Build.html
+++ b/apptools/apptools-sampleapp-tests/sampleapp-android/Crosswalk_Apptools_SampleApp_Spacedodgegame_Build.html
@@ -54,6 +54,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ crosswalk-app create com.example.spacedodge --android-shared</br>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ crosswalk-app create com.example.spacedodge</br>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ crosswalk-app create com.example.spacedodge --android-lite</br>
         &nbsp; &nbsp; $ cd com.example.spacedodge</br>
         &nbsp; &nbsp; $ git clone https://github.com/crosswalk-project/crosswalk-samples.git</br>
         &nbsp; &nbsp; $ mv crosswalk-samples/space-dodge-game/base/* app/</br>
@@ -65,6 +67,8 @@ Authors:
         &nbsp; &nbsp; &nbsp; &nbsp; $ node %crosswalk-app% create com.example.spacedodge --android-shared</br>
         &nbsp; &nbsp; Embedded Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node %crosswalk-app% create com.example.spacedodge</br>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node %crosswalk-app% create com.example.spacedodge --android-lite</br>
         &nbsp; &nbsp; $ cd com.example.spacedodge</br>
         &nbsp; &nbsp; $ git clone https://github.com/crosswalk-project/crosswalk-samples.git</br>
         &nbsp; &nbsp; $ xcopy /s /e /i /y crosswalk-samples\space-dodge-game\base\* app\</br>
@@ -76,7 +80,7 @@ Authors:
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode spacedodge app on your android device which is "arm"
         &nbsp; &nbsp; Install shared mode spacedodge app on your android device which is "x86" architecture<br/>
-        Embedded Mode: <br/>
+        Embedded Mode or Lite Mode: <br/>
         &nbsp; &nbsp; Install arm spacedodge app on your android device which is "arm" architecture
         &nbsp; &nbsp; Install x86 spacedodge app on your android device which is "x86" architecture
       </li>

--- a/apptools/apptools-sampleapp-tests/tests.android.xml
+++ b/apptools/apptools-sampleapp-tests/tests.android.xml
@@ -17,6 +17,8 @@
                     $ crosswalk-app create com.example.spacedodge --android-shared
                   Embedded Mode:
                     $ crosswalk-app create com.example.spacedodge
+                  Lite Mode:
+                    $ crosswalk-app create com.example.spacedodge --android-lite
                   $ cd com.example.spacedodge
                   $ git clone https://github.com/crosswalk-project/crosswalk-samples.git
                   $ mv crosswalk-samples/space-dodge-game/base/* app/
@@ -28,6 +30,8 @@
                     $ node %crosswalk-app% create com.example.spacedodge --android-shared
                   Embedded Mode:
                     $ node %crosswalk-app% create com.example.spacedodge
+                  Lite Mode:
+                    $ node %crosswalk-app% create com.example.spacedodge --android-lite
                   $ cd com.example.spacedodge
                   $ git clone https://github.com/crosswalk-project/crosswalk-samples.git
                   $ xcopy /s /e /i /y crosswalk-samples\space-dodge-game\base\* app\
@@ -42,7 +46,7 @@
                 Shared Mode:
                   Install shared mode spacedodge app on your android device which is "arm" architecture
                   Install shared mode spacedodge app on your android device which is "x86" architecture
-                Embedded Mode:
+                Embedded Mode or Lite Mode:
                   Install arm spacedodge app on your android device which is "arm" architecture
                   Install x86 spacedodge app on your android device which is "x86" architecture
               </step_desc>

--- a/apptools/apptools-sampleapp-tests/tests.full.xml
+++ b/apptools/apptools-sampleapp-tests/tests.full.xml
@@ -17,6 +17,8 @@
                     $ crosswalk-app create com.example.spacedodge --android-shared
                   Embedded Mode:
                     $ crosswalk-app create com.example.spacedodge
+                  Lite Mode:
+                    $ crosswalk-app create com.example.spacedodge --android-lite
                   $ cd com.example.spacedodge
                   $ git clone https://github.com/crosswalk-project/crosswalk-samples.git
                   $ mv crosswalk-samples/space-dodge-game/base/* app/
@@ -28,6 +30,8 @@
                     $ node %crosswalk-app% create com.example.spacedodge --android-shared
                   Embedded Mode:
                     $ node %crosswalk-app% create com.example.spacedodge
+                  Lite Mode:
+                    $ node %crosswalk-app% create com.example.spacedodge --android-lite
                   $ cd com.example.spacedodge
                   $ git clone https://github.com/crosswalk-project/crosswalk-samples.git
                   $ xcopy /s /e /i /y crosswalk-samples\space-dodge-game\base\* app\
@@ -42,7 +46,7 @@
                 Shared Mode:
                   Install shared mode spacedodge app on your android device which is "arm" architecture
                   Install shared mode spacedodge app on your android device which is "x86" architecture
-                Embedded Mode:
+                Embedded Mode or Lite Mode:
                   Install arm spacedodge app on your android device which is "arm" architecture
                   Install x86 spacedodge app on your android device which is "x86" architecture
               </step_desc>

--- a/usecase/usecase-apptools-tests/samples-android/AppToolsOptions/index.html
+++ b/usecase/usecase-apptools-tests/samples-android/AppToolsOptions/index.html
@@ -56,6 +56,8 @@ Authors:
       &nbsp; &nbsp; &nbsp; &nbsp; $ crosswalk-app create org.test.foo --android-shared</br>
       &nbsp; &nbsp; Embedded Mode: <br/>
       &nbsp; &nbsp; &nbsp; &nbsp; $ crosswalk-app create org.test.foo</br>
+      &nbsp; &nbsp; Lite Mode: <br/>
+      &nbsp; &nbsp; &nbsp; &nbsp; $ crosswalk-app create org.test.foo --android-lite</br>
       &nbsp; &nbsp; $ cd org.test.foo</br>
       &nbsp; &nbsp; $ crosswalk-app build</br>
       On Windows host:<br/>
@@ -63,6 +65,8 @@ Authors:
       &nbsp; &nbsp; &nbsp; &nbsp; $ node %crosswalk-app% create org.test.foo --android-shared</br>
       &nbsp; &nbsp; Embedded Mode: <br/>
       &nbsp; &nbsp; &nbsp; &nbsp; $ node %crosswalk-app% create org.test.foo</br>
+      &nbsp; &nbsp; Lite Mode: <br/>
+      &nbsp; &nbsp; &nbsp; &nbsp; $ node %crosswalk-app% create org.test.foo --android-lite</br>
       &nbsp; &nbsp; $ cd org.test.foo</br>
       &nbsp; &nbsp; $ node %crosswalk-app% build
     </li>
@@ -70,7 +74,7 @@ Authors:
       Shared Mode: <br/>
       &nbsp; &nbsp; Install shared mode foo app on your android device which is "arm" architecture<br/>
       &nbsp; &nbsp; Install shared mode foo app on your android device which is "x86" architecture<br/>
-      Embedded Mode: <br/>
+      Embedded Mode or Lite Mode: <br/>
       &nbsp; &nbsp; Install arm foo app on your android device which is "arm" architecture<br/>
       &nbsp; &nbsp; Install x86 foo app on your android device which is "x86" architecture
     </li>

--- a/usecase/usecase-apptools-tests/samples-android/AppTools_install_crosswalk_app/index.html
+++ b/usecase/usecase-apptools-tests/samples-android/AppTools_install_crosswalk_app/index.html
@@ -64,6 +64,8 @@ Authors:
       &nbsp; &nbsp; $ crosswalk-app create org.test.foo --android-shared</br>
       Embedded Mode: <br/>
       &nbsp; &nbsp; $ crosswalk-app create org.test.foo</br>
+      Lite Mode: <br/>
+      &nbsp; &nbsp; $ crosswalk-app create org.test.foo --android-lite</br>
       $ cd org.test.foo</br>
       $ crosswalk-app build
     </li>
@@ -71,7 +73,7 @@ Authors:
       Shared Mode: <br/>
       &nbsp; &nbsp; Install shared mode foo app on your android device which is "arm" architecture<br/>
       &nbsp; &nbsp; Install shared mode foo app on your android device which is "x86" architecture<br/>
-      Embedded Mode: <br/>
+      Embedded Mode or Lite Mode: <br/>
       &nbsp; &nbsp; Install arm foo app on your android device which is "arm" architecture<br/>
       &nbsp; &nbsp; Install x86 foo app on your android device which is "x86" architecture
     </li>

--- a/usecase/usecase-apptools-tests/tests.android.xml
+++ b/usecase/usecase-apptools-tests/tests.android.xml
@@ -15,6 +15,8 @@
                     $ crosswalk-app create org.test.foo --android-shared
                   Embedded Mode:
                     $ crosswalk-app create org.test.foo
+                  Lite Mode:
+                    $ crosswalk-app create org.test.foo --android-lite
                   $ cd org.test.foo
                   $ crosswalk-app build
                 On Windows host:
@@ -22,6 +24,8 @@
                     $ node %crosswalk-app% create org.test.foo --android-shared
                   Embedded Mode:
                     $ node %crosswalk-app% create org.test.foo
+                  Lite Mode:
+                    $ node %crosswalk-app% create org.test.foo --android-lite
                   $ cd org.test.foo
                   $ node %crosswalk-app% build
               </step_desc>
@@ -32,7 +36,7 @@
                 Shared Mode:
                   Install shared mode foo app on your android device which is "arm" architecture
                   Install shared mode foo app on your android device which is "x86" architecture
-                Embedded Mode:
+                Embedded Mode or Lite Mode:
                   Install arm foo app on your android device which is "arm" architecture
                   Install x86 foo app on your android device which is "x86" architecture
               </step_desc>
@@ -85,6 +89,8 @@
                   $ crosswalk-app create org.test.foo --android-shared
                 Embedded Mode:
                   $ crosswalk-app create org.test.foo
+                Lite Mode:
+                  $ crosswalk-app create org.test.foo --android-lite
                 $ cd org.test.foo
                 $ crosswalk-app build
               </step_desc>
@@ -95,7 +101,7 @@
                 Shared Mode:
                   Install shared mode foo app on your android device which is "arm" architecture
                   Install shared mode foo app on your android device which is "x86" architecture
-                Embedded Mode:
+                Embedded Mode or Lite Mode:
                   Install arm foo app on your android device which is "arm" architecture
                   Install x86 foo app on your android device which is "x86" architecture
               </step_desc>

--- a/usecase/usecase-apptools-tests/tests.full.xml
+++ b/usecase/usecase-apptools-tests/tests.full.xml
@@ -15,6 +15,8 @@
                     $ crosswalk-app create org.test.foo --android-shared
                   Embedded Mode:
                     $ crosswalk-app create org.test.foo
+                  Lite Mode:
+                    $ crosswalk-app create org.test.foo --android-lite
                   $ cd org.test.foo
                   $ crosswalk-app build
                 On Windows host:
@@ -22,6 +24,8 @@
                     $ node %crosswalk-app% create org.test.foo --android-shared
                   Embedded Mode:
                     $ node %crosswalk-app% create org.test.foo
+                  Lite Mode:
+                    $ node %crosswalk-app% create org.test.foo --android-lite
                   $ cd org.test.foo
                   $ node %crosswalk-app% build
               </step_desc>
@@ -32,7 +36,7 @@
                 Shared Mode:
                   Install shared mode foo app on your android device which is "arm" architecture
                   Install shared mode foo app on your android device which is "x86" architecture
-                Embedded Mode:
+                Embedded Mode or Lite Mode:
                   Install arm foo app on your android device which is "arm" architecture
                   Install x86 foo app on your android device which is "x86" architecture
               </step_desc>
@@ -85,6 +89,8 @@
                   $ crosswalk-app create org.test.foo --android-shared
                 Embedded Mode:
                   $ crosswalk-app create org.test.foo
+                Lite Mode:
+                  $ crosswalk-app create org.test.foo --android-lite
                 $ cd org.test.foo
                 $ crosswalk-app build
               </step_desc>
@@ -95,7 +101,7 @@
                 Shared Mode:
                   Install shared mode foo app on your android device which is "arm" architecture
                   Install shared mode foo app on your android device which is "x86" architecture
-                Embedded Mode:
+                Embedded Mode or Lite Mode:
                   Install arm foo app on your android device which is "arm" architecture
                   Install x86 foo app on your android device which is "x86" architecture
               </step_desc>


### PR DESCRIPTION
Failure analysis:
At the moment we only have a crosswalk lite release in canary

Impacted tests(approved): new 0, update 118, delete 0
Unit test platform: [Android]
Unit test result summary: pass 107, fail 11, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5441