### PR TITLE
[webapi] Update flexiblebox tests

### DIFF
--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_align-self.html
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_align-self.html
@@ -35,20 +35,47 @@ Authors:
   <head>
     <title>CSS3 Text Effects Test: CSS3FlexBox_align-self</title>
     <link rel="author" title="Intel" href="http://www.intel.com" />
-    <link rel="help" href="http://www.w3.org/TR/2012/WD-css3-flexbox-20120612/#align-self" />
+    <link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#align-items-property" />
     <meta name="flags" content="" />
     <meta name="assert" content="Check if the 'align-self' property exists" />
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
     <script src="support/flexiblebox.js"></script>
+    <style>
+        #container {
+            display: flex;
+            align-items: center;
+        }
+
+        #no-parent-test {
+            display: flex;
+        }
+    </style>
   </head>
   <body>
     <div id="log"></div>
+    <div id="container">
+        <div id="has-parent-test"></div>
+    </div>
+    <div id="no-parent-test"></div>
     <script>
         test(function () {
             var div = document.getElementById("log");
             assert_true(hasStyle("align-self", div.style), "The align-self property exists");
         }, document.title);
+
+        test(function () {
+            var div = document.getElementById("has-parent-test");
+            var initialValue = getComputedStyle(div)["align-self"];
+            assert_equals(initialValue, "center", "The value of align-self property");
+        }, "Check that 'align-self' computes the value of 'align-items' on the element's parent "
+            + "when the element's 'align-self' set to the default value.");
+
+        test(function () {
+            var div = document.getElementById("no-parent-test");
+            var initialValue = getComputedStyle(div)["align-self"];
+            assert_equals(initialValue, "stretch", "The value of align-self property");
+        }, "Check that 'align-self' computes 'stretch' if the element has no parent.");
     </script>
   </body>
 </html>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_initial_value.html
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_initial_value.html
@@ -33,18 +33,23 @@ Authors:
 <meta charset="utf-8">
 <title>CSS3 Text Effects Test: the initial values</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
-<link rel="help" href="http://www.w3.org/TR/2012/WD-css3-flexbox-20120612/">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/">
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
 <link rel="stylesheet" href="../resources/testharness.css">
 <script src="support/flexiblebox.js"></script>
+<style>
+  #testDiv {
+    display: flex;
+  }
+</style>
 <div id="log"></div>
 <div id="testDiv"></div>
 <script>
 [
   ["align-content", "stretch"],
   ["align-items", "stretch"],
-  ["align-self", "auto"],
+  ["align-self", "stretch"],
   ["flex", "0 1 auto"],
   ["flex-basis", "auto"],
   ["flex-grow", "0"],

--- a/webapi/tct-flexiblebox-css3-tests/tests.full.xml
+++ b/webapi/tct-flexiblebox-css3-tests/tests.full.xml
@@ -75,7 +75,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Flexible Box Layout Module" execution_type="auto" id="CSS3FlexBox_align-self" priority="P1" purpose="Check if the 'align-self' property exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Flexible Box Layout Module" execution_type="auto" id="CSS3FlexBox_align-self" priority="P1" purpose="Check if the 'align-self' property exists" status="approved" type="compliance" subcase="3">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_align-self.html</test_script_entry>
         </description>

--- a/webapi/tct-flexiblebox-css3-tests/tests.xml
+++ b/webapi/tct-flexiblebox-css3-tests/tests.xml
@@ -33,7 +33,7 @@
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_align-items.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Flexible Box Layout Module" execution_type="auto" id="CSS3FlexBox_align-self" purpose="Check if the 'align-self' property exists">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/CSS Flexible Box Layout Module" execution_type="auto" id="CSS3FlexBox_align-self" purpose="Check if the 'align-self' property exists" subcase="3">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_align-self.html</test_script_entry>
         </description>


### PR DESCRIPTION
- justify-content property got pass result
- align-self got fail  when then flex item has no parent

Impacted TCs num(approved): New 2, Update 1, Delete 0
Unit test Platform: Crosswalk Project for Android 17.45.429.0
Unit test result summary: Pass 1, Fail 2, Blocked 0

https://crosswalk-project.org/jira/browse/XWALK-3227