### PR TITLE
[EmbeddingAPI] Add usecase for WindowManager.LayoutParams.FLAG_SECURE…

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -618,5 +618,14 @@
                 <category android:name="XWalkView.UIClient.ResourceClient" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".basic.XWalkViewWithWindowSecureAsync"
+            android:label="@string/title_activity_xwalk_view_with_window_secure_async"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Basic" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_window_secure_async.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_window_secure_async.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (c) 2014 Intel Corporation. All rights reserved.
+
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.asyncsample.basic.XWalkViewWithWindowSecureAsync">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="By setting Flag WindowManager.LayoutParams.FLAG_SECURE, XWalkView window can prevent from the screenshoting, you can test by pressing the power button and the volume down button at the same time."
+        android:id="@+id/textView" />
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/textView" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
@@ -82,5 +82,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_scrollview_parent_async">XWalkViewWithScrollViewParentAsync</string>
     <string name="title_activity_xwalk_view_with_multi_instance_overlay_async">XWalkViewWithMultiInstanceOverlayAsync</string>
     <string name="title_activity_xwalk_view_with_httpauth_request_async">XWalkViewWithOnReceivedHttpAuthRequestAsync</string>
+    <string name="title_activity_xwalk_view_with_window_secure_async">XWalkViewWithWindowSecureAsync</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -634,3 +634,13 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load, setResourceClient methods
 * ResourceClient interface: onReceivedHttpAuthRequest methods
+
+
+
+### 63. The [XWalkViewWithWindowSecureAsync](basic/XWalkViewWithWindowSecureAsync.java) sample check xwalkview window can prevent from the screenshoting by setting window flag SECURE, include:
+
+* walkview window can prevent from the screenshoting by setting window flag SECURE
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/basic/XWalkViewWithWindowSecureAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/basic/XWalkViewWithWindowSecureAsync.java
@@ -1,0 +1,64 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.asyncsample.basic;
+import org.xwalk.embedded.api.asyncsample.R;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.view.WindowManager;
+
+public class XWalkViewWithWindowSecureAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private XWalkInitializer mXWalkInitializer;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        setContentView(R.layout.activity_xwalk_view_with_window_secure_async);
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView Window can forbid screenshot.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Press the power button and the volume down button at the same time.\n")
+        .append("2. Android system should prevent the window screenshot.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if system prevent the window screenshot.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mXWalkView.load("http://www.baidu.com/", null);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -619,5 +619,14 @@
                 <category android:name="XWalkView.UIClient.ResourceClient" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".basic.XWalkViewWithWindowSecure"
+            android:label="@string/title_activity_xwalk_view_with_window_secure"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Basic" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_window_secure.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_window_secure.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (c) 2014 Intel Corporation. All rights reserved.
+
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.sample.basic.XWalkViewWithWindowSecure">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="By setting Flag WindowManager.LayoutParams.FLAG_SECURE, XWalkView window can prevent from the screenshoting, you can test by pressing the power button and the volume down button at the same time."
+        android:id="@+id/textView" />
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/textView" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
@@ -90,5 +90,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_scrollview_parent">XWalkViewWithScrollViewParent</string>
     <string name="title_activity_xwalk_view_with_multi_instance_overlay">XWalkViewWithMultiInstanceOverlay</string>
     <string name="title_activity_xwalk_view_with_httpauth_request">XWalkViewWithOnReceivedHttpAuthRequest</string>
+    <string name="title_activity_xwalk_view_with_window_secure">XWalkViewWithWindowSecure</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -634,3 +634,13 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load, setResourceClient methods
 * ResourceClient interface: onReceivedHttpAuthRequest methods
+
+
+
+### 63. The [XWalkViewWithWindowSecure](basic/XWalkViewWithWindowSecure.java) sample check xwalkview window can prevent from the screenshoting by setting window flag SECURE, include:
+
+* walkview window can prevent from the screenshoting by setting window flag SECURE
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/basic/XWalkViewWithWindowSecure.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/basic/XWalkViewWithWindowSecure.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.sample.basic;
+
+import org.xwalk.embedded.api.sample.R;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.view.WindowManager;
+
+public class XWalkViewWithWindowSecure extends XWalkActivity {
+    private XWalkView mXWalkView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
+        setContentView(R.layout.activity_xwalk_view_with_window_secure);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView Window can forbid screenshot.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Press the power button and the volume down button at the same time.\n")
+        .append("2. Android system should prevent the window screenshot.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if system prevent the window screenshot.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView.load("http://www.baidu.com/", null);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -777,6 +777,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithWindowSecure" purpose="XWalkViewWithWindowSecure Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -1544,6 +1556,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnReceivedHttpAuthRequestAsync" purpose="XWalkViewWithOnReceivedHttpAuthRequestAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithWindowSecureAsync" purpose="XWalkViewWithWindowSecureAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -872,6 +872,19 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithWindowSecure" platform="android" priority="P0" purpose="XWalkViewWithWindowSecure Test With XWalkActivity" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -1629,6 +1642,19 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnReceivedHttpAuthRequestAsync" platform="android" priority="P0" purpose="XWalkViewWithOnReceivedHttpAuthRequest Async Test With XWalkInitializer" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithWindowSecureAsync" platform="android" priority="P0" purpose="XWalkViewWithWindowSecureAsync Test With XWalkInitializer" status="approved" type="functional_positive">
         <description>
           <pre_condition />
           <post_condition />


### PR DESCRIPTION
… in activity OnCreate method

-Add usecase for WindowManager.LayoutParams.FLAG_SECURE in activity OnCreate method
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5103