### PR TITLE
[Cordova] Add setBackgroundColor usecase

### DIFF
--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-pack_cordova_sample.py is used for auto build Cordova sample apps, including mobilespec, helloworld, remotedebugging, spacedodge, renamePkg, xwalkCommandLine, and except renamePkg and xwalkCommandLine only support Cordova 4.x, privateNotes only support Cordova 3.6, others support both Cordova 3.6 and Cordova 4.x build.  
+pack_cordova_sample.py is used for auto build Cordova sample apps, including mobilespec, helloworld, remotedebugging, spacedodge, renamePkg, setBackgroundColor, xwalkCommandLine, and except renamePkg, setBackgroundColor and xwalkCommandLine only support Cordova 4.x, privateNotes only support Cordova 3.6, others support both Cordova 3.6 and Cordova 4.x build.  
 **Note**: For cordova 4.x pkg, need to configure crosswalk version in crosswalk-test-suite/VERSION file
 
 ## Pre-conditions
@@ -36,7 +36,7 @@ pack_cordova_sample.py is used for auto build Cordova sample apps, including mob
 ## Usage
 
 * ```./pack_cordova_sample.py -n <pkg-name> --cordova-version <cordova-version> [-m <pkg-mode>] [-a <pkg-arch>] [--tools=<tools-path>]```  
-**pkg-name**: mobilespec, helloworld, remotedebugging, spacedodge, CIRC, statusbar, renamePkg, xwalkCommandLine, privateNotes  
+**pkg-name**: mobilespec, helloworld, remotedebugging, spacedodge, CIRC, statusbar, renamePkg, setBackgroundColor, xwalkCommandLine, privateNotes  
 **cordova-version**: 3.6, 4.x  
 **pkg-mode**: embedded(default), shared  
 **pkg-arch**: arm(default), x86  

--- a/tools/build/build_cordova.py
+++ b/tools/build/build_cordova.py
@@ -122,9 +122,9 @@ def packCordova_cli(
         xwalk_version = "org.xwalk:xwalk_%s_library_beta:%s" % (pkg_mode_tmp, CROSSWALK_VERSION)
 
     webview_plugin_name = "cordova-plugin-crosswalk-webview"
-    install_variable_cmd = ""
     plugin_dirs = os.listdir(plugin_tool)
     for i_dir in plugin_dirs:
+        install_variable_cmd = ""
         i_plugin_dir = os.path.join(plugin_tool, i_dir)
         plugin_crosswalk_source = i_plugin_dir
         if i_dir == webview_plugin_name:

--- a/tools/build/pack_cordova_sample.py
+++ b/tools/build/pack_cordova_sample.py
@@ -53,7 +53,7 @@ sys.setdefaultencoding('utf8')
 TOOL_VERSION = "v0.1"
 VERSION_FILE = "VERSION"
 DEFAULT_CMD_TIMEOUT = 600
-PKG_NAMES = ["spacedodge", "helloworld", "remotedebugging", "mobilespec", "CIRC", "Eh", "statusbar", "renamePkg", "xwalkCommandLine", "privateNotes"]
+PKG_NAMES = ["spacedodge", "helloworld", "remotedebugging", "mobilespec", "CIRC", "Eh", "statusbar", "renamePkg", "setBackgroundColor", "xwalkCommandLine", "privateNotes"]
 CORDOVA_VERSIONS = ["3.6", "4.x"]
 PKG_MODES = ["shared", "embedded"]
 PKG_ARCHS = ["x86", "arm"]
@@ -312,6 +312,13 @@ def createIndexFile(index_file_path=None, hosted_app=None):
                            '<button onclick="StatusBar.show();">Status Bar Show</button><br><br>\n' \
                            '<p>Click "Status Bar Hide" button to hide status bar:</p>\n' \
                            '<button onclick="StatusBar.hide();">Status Bar Hide</button>'
+        elif hosted_app == "setBackgroundColor":
+            html_content = '<script src="./cordova.js"></script>\n' \
+                           '<div id="header">\n' \
+                           '  <h3 id="main_page_title">BackgroundColor Test</h3>\n' \
+                           '</div>\n<br><br>\n' \
+                           '<p>This page\'s background color should be red</p>\n' \
+                           '<a href="https://crosswalk-project.org">crosswalk</a>\n'
         index_file = open(index_file_path, "w")
         index_file.write(html_content)
         index_file.close()
@@ -550,10 +557,10 @@ def installPlugins(plugin_tool, app_name):
         xwalk_version = "org.xwalk:xwalk_%s_library_beta:%s" % (pkg_mode_tmp, CROSSWALK_VERSION)
 
     webview_plugin_name = "cordova-plugin-crosswalk-webview"
-    install_variable_cmd = ""
     if os.path.exists(plugin_tool): 
         plugin_dirs = os.listdir(plugin_tool)
         for i_dir in plugin_dirs:
+            install_variable_cmd = ""
             i_plugin_dir = os.path.join(plugin_tool, i_dir)
             plugin_crosswalk_source = i_plugin_dir
             if i_dir == webview_plugin_name:
@@ -943,6 +950,13 @@ def packSampleApp_cli(app_name=None):
         os.chdir(orig_dir)
         return False
 
+    if checkContains(app_name, "SETBACKGROUNDCOLOR"):
+        replaceUserString(
+            project_root,
+            'config.xml',
+            '</widget>',
+            '    <preference name="BackgroundColor" value="0xFFFF0000" />\n</widget>')
+        createIndexFile(os.path.join(project_root, "www", "index.html"), "setBackgroundColor")
     if checkContains(app_name, "STATUSBAR"):
         replaceUserString(
             project_root,
@@ -980,7 +994,7 @@ def packSampleApp_cli(app_name=None):
     if checkContains(app_name, "REMOTEDEBUGGING"):
         pack_cmd = "cordova build android --debug"
 
-    if not doCMD(pack_cmd, DEFAULT_CMD_TIMEOUT):
+    if not doCMD(pack_cmd, DEFAULT_CMD_TIMEOUT * 5):
         os.chdir(orig_dir)
         return False
 

--- a/usecase/usecase-cordova-android-tests/samples/SetBackgroundColor/REAMDE.md
+++ b/usecase/usecase-cordova-android-tests/samples/SetBackgroundColor/REAMDE.md
@@ -1,0 +1,6 @@
+## Usecase Design
+
+This sample demonstrates Cordova app background color config functionalities, include:
+
+* Set the background color to red
+

--- a/usecase/usecase-cordova-android-tests/samples/SetBackgroundColor/index.html
+++ b/usecase/usecase-cordova-android-tests/samples/SetBackgroundColor/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Zhu, Yongyong <yongyongx.zhu@intel.com>
+
+-->
+
+<meta charset="utf-8" />
+<meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, width=device-width" />
+<link rel="stylesheet" type="text/css" href="../../css/bootstrap.css">
+<link rel="stylesheet" type="text/css" href="../../css/main.css">
+<script src="../../js/jquery-2.1.3.min.js"></script>
+<script src="../../js/bootstrap.min.js"></script>
+<script src="../../js/common.js"></script>
+<script src="../../js/tests.js"></script>
+
+<div id="header">
+  <h3 id="main_page_title"></h3>
+</div>
+<div class="content">
+  <h4>Note</h4>
+  <ol>
+    <li>It's only for Cordova version 4.x</li>
+  </ol>
+  <h4>Test Steps</h4>
+  <ol>
+    <li>Get cordova4.x_sampleapp.zip from internal release link, then unzip it to /tmp/cordova-sampleapp/</li>
+    <li>Install setBackgroundColor.apk</li>
+      <div>
+        $ adb install /tmp/cordova-sampleapp/setBackgroundColor.apk<br/>
+      </div>
+    <li>Launch and Run the app</li>
+    <li>Check if the app page's background color is red</li>
+    <li>Click the "crosswalk" link to navigate "https://crosswalk-project.org" page</li>
+    <li>Check if the app page's background color is red</li>
+    <li>Exit the app</li>
+  </ol>
+</div>
+<div class="footer">
+  <div id="footer"></div>
+</div>
+<div class="modal fade" id="popup_info">
+</div>

--- a/usecase/usecase-cordova-android-tests/steps/SetBackgroundColor/step.js
+++ b/usecase/usecase-cordova-android-tests/steps/SetBackgroundColor/step.js
@@ -1,0 +1,13 @@
+var step = '<font class="fontSize">'
+            +'<p>Purpose:</p>'
+            +'<p>Verify the Cordova app page background color can be configured when build this app</p>'
+            +'<p>Expected Results:</p>'
+            +'<ol>'
+            +'<li>The app can be installed successfully</li>'
+            +'<li>The app can launch and run successfully</li>'
+            +'<li>The app page\'s background color is red</li>'
+            +'<li>Navigate to "https://crosswalk-project.org" page</li>'
+            +'<li>The new page\'s background color is red</li>'
+            +'<li>The app can exit successfully</li>'
+            +'</ol>'
+          +'</font>';

--- a/usecase/usecase-cordova-android-tests/tests.full.xml
+++ b/usecase/usecase-cordova-android-tests/tests.full.xml
@@ -37,6 +37,8 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/Cordova" execution_type="manual" platform="android" priority="P0" status="approved" type="functional_positive" id="RenamePkg" purpose="RenamePkg Test">
       </testcase>
+      <testcase component="Crosswalk Use Cases/Cordova" execution_type="manual" platform="android" priority="P0" status="approved" type="functional_positive" id="SetBackgroundColor" purpose="SetBackgroundColor Test">
+      </testcase>
       <testcase component="Crosswalk Use Cases/Cordova" execution_type="manual" platform="android" priority="P0" status="approved" type="functional_positive" id="XwalkCommandLine" purpose="XwalkCommandLine Test">
       </testcase>
       <testcase component="Crosswalk Use Cases/Cordova" execution_type="manual" platform="android" priority="P0" status="approved" type="functional_positive" id="Remotedebugging" purpose="Remotedebugging Test">

--- a/usecase/usecase-cordova-android-tests/tests.xml
+++ b/usecase/usecase-cordova-android-tests/tests.xml
@@ -37,6 +37,8 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/Cordova" execution_type="manual" id="RenamePkg" purpose="RenamePkg Test">
       </testcase>
+      <testcase component="Crosswalk Use Cases/Cordova" execution_type="manual" id="SetBackgroundColor" purpose="SetBackgroundColor Test">
+      </testcase>
       <testcase component="Crosswalk Use Cases/Cordova" execution_type="manual" id="XwalkCommandLine" purpose="XwalkCommandLine Test">
       </testcase>
       <testcase component="Crosswalk Use Cases/Cordova" execution_type="manual" id="Remotedebugging" purpose="Remotedebugging Test">


### PR DESCRIPTION
- Although the case is pass, the usecase-cordova-android-tests can't be packed with Crosswalk-16.45.421.1 or can't be launched with Crosswalk-17.45.432.0 because of XWALK-5092 and XWALK-5700

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: Crosswalk Project for Android 16.45.421.1
Unit test result summary: pass 1, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-5112