### PR TITLE
[EmbeddingAPI] Add usecase for XWalkUIClient onJavascriptCloseWindow API

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -637,6 +637,15 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".client.XWalkViewWithOnJavascriptCloseWindowAsync"
+            android:label="@string/title_activity_xwalk_view_with_close_window_async"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.UIClient.ResourceClient" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".misc.XWalkViewWithSessionStorageAsync"
             android:label="@string/title_activity_xwalk_view_with_session_storage_async"
             android:parentActivityName=".XWalkEmbeddedAPISample" >

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/window_close_js.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/window_close_js.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+    <title>JavaScript Window Close Example</title>
+</head>
+<script type="text/javascript">
+    function popuponclick()
+    {
+        my_window = window.open("",
+            "mywindow", "status=1,width=350,height=150");
+        my_window.document.write('<h1>The Popup Window</h1>');
+        my_window.document.write('<p><a href="javascript: closepopup()">Close the Popup Window</a></p>');
+    }
+
+    function closepopup()
+    {
+        if(false == my_window.closed)
+        {
+            my_window.close();
+        }
+        else
+        {
+            alert("Window already closed!");
+        }
+    }
+</script>
+<body>
+    <p>
+        <a href="javascript: popuponclick()">Open Popup Window</a>
+    </p>
+</body>
+</html>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_on_javascript_close_window_async.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_on_javascript_close_window_async.xml
@@ -1,0 +1,28 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.asyncsample.client.XWalkViewWithOnJavascriptCloseWindowAsync">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Notify the host application client to close the given XWalkView. If 'onJavascriptModalDialog' is invoked, the received message will be"
+        android:id="@+id/textView" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/message_tv"
+        android:textColor="#00ff00"
+        android:layout_below="@+id/textView"/>
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/message_tv" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
@@ -85,5 +85,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_window_secure_async">XWalkViewWithWindowSecureAsync</string>
     <string name="title_activity_xwalk_view_with_on_js_modal_dialog_async">XWalkViewWithOnJavascriptModalDialogAsync</string>
     <string name="title_activity_xwalk_view_with_session_storage_async">XWalkViewWithSessionStorageAsync</string>
+    <string name="title_activity_xwalk_view_with_close_window_async">XWalkViewWithOnJavascriptCloseWindowAsync</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -647,6 +647,7 @@ This usecase covers following interface and methods:
 
 
 
+
 ### 64. The [XWalkViewWithSessionStorageAsync](misc/XWalkViewWithSessionStorageAsync.java) sample check xwalkview can restore html5 sessionstorage value when screen rotates, include:
 
 * xwalkview can restore html5 sessionstorage value when screen rotates
@@ -664,4 +665,18 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkView interface: load methods
+
 * UIClient interface: onJavascriptModalDialog methods
+
+
+
+### 66. The [XWalkViewWithOnJavascriptCloseWindowAsync](client/XWalkViewWithOnJavascriptCloseWindowAsync.java) sample check XWalkUIClient API onJavascriptCloseWindow method can work, include:
+
+* XWalkUIClient API onJavascriptCloseWindow method can work
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load methods
+
+* UIClient interface: onJavascriptCloseWindow methods
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/client/XWalkViewWithOnJavascriptCloseWindowAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/client/XWalkViewWithOnJavascriptCloseWindowAsync.java
@@ -1,0 +1,80 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.asyncsample.client;
+
+import org.xwalk.embedded.api.asyncsample.R;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkUIClient;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.widget.TextView;
+
+
+public class XWalkViewWithOnJavascriptCloseWindowAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private XWalkInitializer mXWalkInitializer;
+    private TextView mMessage;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        setContentView(R.layout.activity_xwalk_view_with_on_javascript_close_window_async);
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkUIClient API onJavascriptCloseWindow method can work.\n\n")
+        .append("Test  Step:\n")
+        .append("1. Click 'Open Popup Window' link.\n")
+        .append("2. The Popup Window shows.\n")
+        .append("3. Then click 'Close the Popup Window' link.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if the xwalkview testcase window closed.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mMessage = (TextView) findViewById(R.id.message_tv);
+
+        mXWalkView.setUIClient(new XWalkUIClient(mXWalkView) {
+
+            @Override
+            public void onJavascriptCloseWindow(XWalkView view) {
+                // TODO Auto-generated method stub
+                super.onJavascriptCloseWindow(view);
+                mMessage.setText("onJavascriptCloseWindow is invoked");
+            }
+        });
+
+        mXWalkView.load("file:///android_asset/window_close_js.html", null);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -638,6 +638,15 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".client.XWalkViewWithOnJavascriptCloseWindow"
+            android:label="@string/title_activity_xwalk_view_with_close_window"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.UIClient.ResourceClient" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".misc.XWalkViewWithSessionStorage"
             android:label="@string/title_activity_xwalk_view_with_session_storage"
             android:parentActivityName=".XWalkEmbeddedAPISample" >

--- a/usecase/usecase-embedding-android-tests/embeddingapi/assets/window_close_js.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/assets/window_close_js.html
@@ -1,0 +1,31 @@
+<html>
+<head>
+    <title>JavaScript Window Close Example</title>
+</head>
+<script type="text/javascript">
+    function popuponclick()
+    {
+        my_window = window.open("",
+            "mywindow", "status=1,width=350,height=150");
+        my_window.document.write('<h1>The Popup Window</h1>');
+        my_window.document.write('<p><a href="javascript: closepopup()">Close the Popup Window</a></p>');
+    }
+
+    function closepopup()
+    {
+        if(false == my_window.closed)
+        {
+            my_window.close();
+        }
+        else
+        {
+            alert("Window already closed!");
+        }
+    }
+</script>
+<body>
+    <p>
+        <a href="javascript: popuponclick()">Open Popup Window</a>
+    </p>
+</body>
+</html>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_on_javascript_close_window.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_on_javascript_close_window.xml
@@ -1,0 +1,28 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.sample.client.XWalkViewWithOnJavascriptCloseWindow">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Notify the host application client to close the given XWalkView. If 'onJavascriptModalDialog' is invoked, the received message will be"
+        android:id="@+id/textView" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/message_tv"
+        android:textColor="#00ff00"
+        android:layout_below="@+id/textView"/>
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/message_tv" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
@@ -93,5 +93,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_window_secure">XWalkViewWithWindowSecure</string>
     <string name="title_activity_xwalk_view_with_on_js_modal_dialog">XWalkViewWithOnJavascriptModalDialog</string>
     <string name="title_activity_xwalk_view_with_session_storage">XWalkViewWithSessionStorage</string>
+    <string name="title_activity_xwalk_view_with_close_window">XWalkViewWithOnJavascriptCloseWindow</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -664,4 +664,17 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkView interface: load methods
+
 * UIClient interface: onJavascriptModalDialog methods
+
+
+
+### 66. The [XWalkViewWithOnJavascriptCloseWindow](client/XWalkViewWithOnJavascriptCloseWindow.java) sample check XWalkUIClient API onJavascriptCloseWindow method can work, include:
+
+* XWalkUIClient API onJavascriptCloseWindow method can work
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load methods
+
+* UIClient interface: onJavascriptCloseWindow methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/client/XWalkViewWithOnJavascriptCloseWindow.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/client/XWalkViewWithOnJavascriptCloseWindow.java
@@ -1,0 +1,60 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.sample.client;
+
+
+import org.xwalk.embedded.api.sample.R;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkUIClient;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.widget.TextView;
+
+
+public class XWalkViewWithOnJavascriptCloseWindow extends XWalkActivity {
+    private XWalkView mXWalkView;
+    private TextView mMessage;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_xwalk_view_with_on_javascript_close_window);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mMessage = (TextView) findViewById(R.id.message_tv);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkUIClient API onJavascriptCloseWindow method can work.\n\n")
+        .append("Test  Step:\n")
+        .append("1. Click 'Open Popup Window' link.\n")
+        .append("2. The Popup Window shows.\n")
+        .append("3. Then click 'Close the Popup Window' link.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if the xwalkview testcase window closed.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView.setUIClient(new XWalkUIClient(mXWalkView) {
+
+            @Override
+            public void onJavascriptCloseWindow(XWalkView view) {
+                // TODO Auto-generated method stub
+                super.onJavascriptCloseWindow(view);
+                mMessage.setText("onJavascriptCloseWindow is invoked");
+            }
+        });
+
+        mXWalkView.load("file:///android_asset/window_close_js.html", null);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -813,6 +813,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnJavascriptCloseWindow" purpose="XWalkViewWithOnJavascriptCloseWindow Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -1616,6 +1628,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithSessionStorageAsync" purpose="XWalkViewWithSessionStorageAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnJavascriptCloseWindowAsync" purpose="XWalkViewWithOnJavascriptCloseWindowAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -911,6 +911,19 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnJavascriptCloseWindow" platform="android" priority="P0" purpose="XWalkViewWithOnJavascriptCloseWindow Test With XWalkActivity" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -1707,6 +1720,19 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithSessionStorageAsync" platform="android" priority="P0" purpose="XWalkViewWithSessionStorageAsync Test With XWalkInitializer" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnJavascriptCloseWindowAsync" platform="android" priority="P0" purpose="XWalkViewWithOnJavascriptCloseWindowAsync Test With XWalkInitializer" status="approved" type="functional_positive">
         <description>
           <pre_condition />
           <post_condition />


### PR DESCRIPTION
-Add usecase for XWalkUIClient onJavascriptCloseWindow API
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5102