### PR TITLE
[Cordova] Add default crosswalk version test point in CrosswalkVersion usecase

### DIFF
--- a/usecase/usecase-cordova-android-tests/res/comm.py
+++ b/usecase/usecase-cordova-android-tests/res/comm.py
@@ -131,7 +131,9 @@ def create(app_name, pkg_name, tmp_path):
 
 def installWebviewPlugin(xwalk_mode=None, xwalk_version=None):
     print "Install webview plugin----------------> Start"
-    xwalk_mode_cmd = "--variable XWALK_MODE=\"%s\"" % xwalk_mode
+    xwalk_mode_cmd = ""
+    if xwalk_mode:
+        xwalk_mode_cmd = "--variable XWALK_MODE=\"%s\"" % xwalk_mode
     xwalk_version_cmd = ""
     if xwalk_version:
         xwalk_version_cmd = "--variable XWALK_VERSION=\"%s\"" % xwalk_version

--- a/usecase/usecase-cordova-android-tests/samples/CrosswalkVersion/res/test.py
+++ b/usecase/usecase-cordova-android-tests/samples/CrosswalkVersion/res/test.py
@@ -126,6 +126,19 @@ for version_tmp in VERSION_TYPES:
     comm.removeWebviewPlugin()
     index = index + 1
 
+if comm.CROSSWALK_BRANCH != "canary":
+    os.system('cp ../index.html www/index.html')
+    latestVersion = comm.getLatestCrosswalkVersion('stable', '15')
+    os.system('sed -i "s/{expectedVersion}/%s/g" www/index.html' % latestVersion)
+
+    comm.installWebviewPlugin()
+    comm.build(app_name)
+    apk_source = os.path.join(project_path, "platforms", "android", 
+            "build", "outputs", "apk", "android-%s-debug.apk" % pkg_arch_tmp)
+    apk_dest = os.path.join(current_path_tmp, "CrosswalkVersion_%s_%d.apk" % (comm.CROSSWALK_BRANCH, count))
+    comm.doCopy(apk_source, apk_dest)
+    count = count + 1
+
 for i in range(count - 1):
     comm.checkApkExist("../CrosswalkVersion_%s_%d.apk" % (comm.CROSSWALK_BRANCH, (i + 1)))
 


### PR DESCRIPTION
- Fail Analyse: The actual crosswalk is 15.44.384.12 but the expected version is 15.44.384.13

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android 15.44.384.13
Unit test result summary: pass 0, fail 1, block 0
