### PR TITLE
[webapi] Update SIMD tests

### DIFF
--- a/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/ecmascript_simd_tests.js
+++ b/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/ecmascript_simd_tests.js
@@ -31,18 +31,18 @@ test('Float32x4 constructor', function() {
   notEqual(undefined, SIMD.Float32x4(1.0, 2.0, 3.0, 4.0));  // New object.
   var f1 = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
   var f2 = SIMD.Float32x4.check(f1);
-  equal(f1.x, f2.x, "the value of x should equal");
-  equal(f1.y, f2.y, "the value of y should equal");
-  equal(f1.z, f2.z, "the value of z should equal");
-  equal(f1.w, f2.w, "the value of w should equal");
+  equal(SIMD.Float32x4.extractLane(f1, 0), SIMD.Float32x4.extractLane(f2, 0), "the value of x should equal");
+  equal(SIMD.Float32x4.extractLane(f1, 1), SIMD.Float32x4.extractLane(f2, 1), "the value of y should equal");
+  equal(SIMD.Float32x4.extractLane(f1, 2), SIMD.Float32x4.extractLane(f2, 2), "the value of z should equal");
+  equal(SIMD.Float32x4.extractLane(f1, 3), SIMD.Float32x4.extractLane(f2, 3), "the value of w should equal");
 });
 
 test('Float32x4 scalar getters', function() {
   var a = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
-  equal(1.0, a.x);
-  equal(2.0, a.y);
-  equal(3.0, a.z);
-  equal(4.0, a.w);
+  equal(1.0, SIMD.Float32x4.extractLane(a, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(a, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(a, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(a, 3));
 });
 
 test('Float32x4 signMask getter', function() {
@@ -61,54 +61,54 @@ test('Float32x4 vector getters', function() {
   var zzzz = SIMD.Float32x4.swizzle(a, 2, 2, 2, 2);
   var wwww = SIMD.Float32x4.swizzle(a, 3, 3, 3, 3);
   var wzyx = SIMD.Float32x4.swizzle(a, 3, 2, 1, 0);
-  equal(4.0, xxxx.x);
-  equal(4.0, xxxx.y);
-  equal(4.0, xxxx.z);
-  equal(4.0, xxxx.w);
-  equal(3.0, yyyy.x);
-  equal(3.0, yyyy.y);
-  equal(3.0, yyyy.z);
-  equal(3.0, yyyy.w);
-  equal(2.0, zzzz.x);
-  equal(2.0, zzzz.y);
-  equal(2.0, zzzz.z);
-  equal(2.0, zzzz.w);
-  equal(1.0, wwww.x);
-  equal(1.0, wwww.y);
-  equal(1.0, wwww.z);
-  equal(1.0, wwww.w);
-  equal(1.0, wzyx.x);
-  equal(2.0, wzyx.y);
-  equal(3.0, wzyx.z);
-  equal(4.0, wzyx.w);
+  equal(4.0, SIMD.Float32x4.extractLane(xxxx, 0));
+  equal(4.0, SIMD.Float32x4.extractLane(xxxx, 1));
+  equal(4.0, SIMD.Float32x4.extractLane(xxxx, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(xxxx, 3));
+  equal(3.0, SIMD.Float32x4.extractLane(yyyy, 0));
+  equal(3.0, SIMD.Float32x4.extractLane(yyyy, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(yyyy, 2));
+  equal(3.0, SIMD.Float32x4.extractLane(yyyy, 3));
+  equal(2.0, SIMD.Float32x4.extractLane(zzzz, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(zzzz, 1));
+  equal(2.0, SIMD.Float32x4.extractLane(zzzz, 2));
+  equal(2.0, SIMD.Float32x4.extractLane(zzzz, 3));
+  equal(1.0, SIMD.Float32x4.extractLane(wwww, 0));
+  equal(1.0, SIMD.Float32x4.extractLane(wwww, 1));
+  equal(1.0, SIMD.Float32x4.extractLane(wwww, 2));
+  equal(1.0, SIMD.Float32x4.extractLane(wwww, 3));
+  equal(1.0, SIMD.Float32x4.extractLane(wzyx, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(wzyx, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(wzyx, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(wzyx, 3));
 });
 
 test('Float32x4 abs', function() {
   var a = SIMD.Float32x4(-4.0, -3.0, -2.0, -1.0);
   var c = SIMD.Float32x4.abs(a);
-  equal(4.0, c.x);
-  equal(3.0, c.y);
-  equal(2.0, c.z);
-  equal(1.0, c.w);
+  equal(4.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(2.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
   c = SIMD.Float32x4.abs(SIMD.Float32x4(4.0, 3.0, 2.0, 1.0));
-  equal(4.0, c.x);
-  equal(3.0, c.y);
-  equal(2.0, c.z);
-  equal(1.0, c.w);
+  equal(4.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(2.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 neg', function() {
   var a = SIMD.Float32x4(-4.0, -3.0, -2.0, -1.0);
   var c = SIMD.Float32x4.neg(a);
-  equal(4.0, c.x);
-  equal(3.0, c.y);
-  equal(2.0, c.z);
-  equal(1.0, c.w);
+  equal(4.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(2.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
   c = SIMD.Float32x4.neg(SIMD.Float32x4(4.0, 3.0, 2.0, 1.0));
-  equal(-4.0, c.x);
-  equal(-3.0, c.y);
-  equal(-2.0, c.z);
-  equal(-1.0, c.w);
+  equal(-4.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(-3.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(-2.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(-1.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 
@@ -116,40 +116,40 @@ test('Float32x4 add', function() {
   var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
   var b = SIMD.Float32x4(10.0, 20.0, 30.0, 40.0);
   var c = SIMD.Float32x4.add(a, b);
-  equal(14.0, c.x);
-  equal(23.0, c.y);
-  equal(32.0, c.z);
-  equal(41.0, c.w);
+  equal(14.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(23.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(32.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(41.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 sub', function() {
   var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
   var b = SIMD.Float32x4(10.0, 20.0, 30.0, 40.0);
   var c = SIMD.Float32x4.sub(a, b);
-  equal(-6.0, c.x);
-  equal(-17.0, c.y);
-  equal(-28.0, c.z);
-  equal(-39.0, c.w);
+  equal(-6.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(-17.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(-28.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(-39.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 mul', function() {
   var a = SIMD.Float32x4(4.0, 3.0, 2.0, 1.0);
   var b = SIMD.Float32x4(10.0, 20.0, 30.0, 40.0);
   var c = SIMD.Float32x4.mul(a, b);
-  equal(40.0, c.x);
-  equal(60.0, c.y);
-  equal(60.0, c.z);
-  equal(40.0, c.w);
+  equal(40.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(60.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(60.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(40.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 div', function() {
   var a = SIMD.Float32x4(4.0, 9.0, 8.0, 1.0);
   var b = SIMD.Float32x4(2.0, 3.0, 1.0, 0.5);
   var c = SIMD.Float32x4.div(a, b);
-  equal(2.0, c.x);
-  equal(3.0, c.y);
-  equal(8.0, c.z);
-  equal(2.0, c.w);
+  equal(2.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(8.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(2.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 clamp', function() {
@@ -157,66 +157,66 @@ test('Float32x4 clamp', function() {
   var lower = SIMD.Float32x4(2.0, 1.0, 50.0, 0.0);
   var upper = SIMD.Float32x4(2.5, 5.0, 55.0, 1.0);
   var c = SIMD.Float32x4.clamp(a, lower, upper);
-  equal(2.0, c.x);
-  equal(5.0, c.y);
-  equal(50.0, c.z);
-  equal(0.5, c.w);
+  equal(2.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(5.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(50.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(0.5, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 min', function() {
   var a = SIMD.Float32x4(-20.0, 10.0, 30.0, 0.5);
   var lower = SIMD.Float32x4(2.0, 1.0, 50.0, 0.0);
   var c = SIMD.Float32x4.min(a, lower);
-  equal(-20.0, c.x);
-  equal(1.0, c.y);
-  equal(30.0, c.z);
-  equal(0.0, c.w);
+  equal(-20.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(30.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(0.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 max', function() {
   var a = SIMD.Float32x4(-20.0, 10.0, 30.0, 0.5);
   var upper = SIMD.Float32x4(2.5, 5.0, 55.0, 1.0);
   var c = SIMD.Float32x4.max(a, upper);
-  equal(2.5, c.x);
-  equal(10.0, c.y);
-  equal(55.0, c.z);
-  equal(1.0, c.w);
+  equal(2.5, SIMD.Float32x4.extractLane(c, 0));
+  equal(10.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(55.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 reciprocal', function() {
   var a = SIMD.Float32x4(8.0, 4.0, 2.0, -2.0);
   var c = SIMD.Float32x4.reciprocal(a);
-  equal(0.125, c.x);
-  equal(0.250, c.y);
-  equal(0.5, c.z);
-  equal(-0.5, c.w);
+  equal(0.125, SIMD.Float32x4.extractLane(c, 0));
+  equal(0.250, SIMD.Float32x4.extractLane(c, 1));
+  equal(0.5, SIMD.Float32x4.extractLane(c, 2));
+  equal(-0.5, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 reciprocal sqrt', function() {
   var a = SIMD.Float32x4(1.0, 0.25, 0.111111, 0.0625);
   var c = SIMD.Float32x4.reciprocalSqrt(a);
-  almostEqual(1.0, c.x);
-  almostEqual(2.0, c.y);
-  almostEqual(3.0, c.z);
-  almostEqual(4.0, c.w);
+  almostEqual(1.0, SIMD.Float32x4.extractLane(c, 0));
+  almostEqual(2.0, SIMD.Float32x4.extractLane(c, 1));
+  almostEqual(3.0, SIMD.Float32x4.extractLane(c, 2));
+  almostEqual(4.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 scale', function() {
   var a = SIMD.Float32x4(8.0, 4.0, 2.0, -2.0);
   var c = SIMD.Float32x4.scale(a, 0.5);
-  equal(4.0, c.x);
-  equal(2.0, c.y);
-  equal(1.0, c.z);
-  equal(-1.0, c.w);
+  equal(4.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(-1.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 sqrt', function() {
   var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
   var c = SIMD.Float32x4.sqrt(a);
-  equal(4.0, c.x);
-  equal(3.0, c.y);
-  equal(2.0, c.z);
-  equal(1.0, c.w);
+  equal(4.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(3.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(2.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(1.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 shuffleMix', function() {
@@ -225,93 +225,93 @@ test('Float32x4 shuffleMix', function() {
   var xyxy = SIMD.Float32x4.shuffleMix(a, b, SIMD.XYXY);
   var zwzw = SIMD.Float32x4.shuffleMix(a, b, SIMD.ZWZW);
   var xxxx = SIMD.Float32x4.shuffleMix(a, b, SIMD.XXXX);
-  equal(1.0, xyxy.x);
-  equal(2.0, xyxy.y);
-  equal(5.0, xyxy.z);
-  equal(6.0, xyxy.w);
-  equal(3.0, zwzw.x);
-  equal(4.0, zwzw.y);
-  equal(7.0, zwzw.z);
-  equal(8.0, zwzw.w);
-  equal(1.0, xxxx.x);
-  equal(1.0, xxxx.y);
-  equal(5.0, xxxx.z);
-  equal(5.0, xxxx.w);
+  equal(1.0, SIMD.Float32x4.extractLane(xyxy, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(xyxy, 1));
+  equal(5.0, SIMD.Float32x4.extractLane(xyxy, 2));
+  equal(6.0, SIMD.Float32x4.extractLane(xyxy, 3));
+  equal(3.0, SIMD.Float32x4.extractLane(zwzw, 0));
+  equal(4.0, SIMD.Float32x4.extractLane(zwzw, 1));
+  equal(7.0, SIMD.Float32x4.extractLane(zwzw, 2));
+  equal(8.0, SIMD.Float32x4.extractLane(zwzw, 3));
+  equal(1.0, SIMD.Float32x4.extractLane(xxxx, 0));
+  equal(1.0, SIMD.Float32x4.extractLane(xxxx, 1));
+  equal(5.0, SIMD.Float32x4.extractLane(xxxx, 2));
+  equal(5.0, SIMD.Float32x4.extractLane(xxxx, 3));
 });
 
 test('Float32x4 withX', function() {
     var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
-    var c = SIMD.Float32x4.withX(a, 20.0);
-    equal(20.0, c.x);
-    equal(9.0, c.y);
-    equal(4.0, c.z);
-    equal(1.0, c.w);
+    var c = SIMD.Float32x4.replaceLane(a, 0, 20.0);
+    equal(20.0, SIMD.Float32x4.extractLane(c, 0));
+    equal(9.0, SIMD.Float32x4.extractLane(c, 1));
+    equal(4.0, SIMD.Float32x4.extractLane(c, 2));
+    equal(1.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 withY', function() {
     var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
-    var c = SIMD.Float32x4.withY(a, 20.0);
-    equal(16.0, c.x);
-    equal(20.0, c.y);
-    equal(4.0, c.z);
-    equal(1.0, c.w);
+    var c = SIMD.Float32x4.replaceLane(a, 1, 20.0);
+    equal(16.0, SIMD.Float32x4.extractLane(c, 0));
+    equal(20.0, SIMD.Float32x4.extractLane(c, 1));
+    equal(4.0, SIMD.Float32x4.extractLane(c, 2));
+    equal(1.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 withZ', function() {
     var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
-    var c = SIMD.Float32x4.withZ(a, 20.0);
-    equal(16.0, c.x);
-    equal(9.0, c.y);
-    equal(20.0, c.z);
-    equal(1.0, c.w);
+    var c = SIMD.Float32x4.replaceLane(a, 2, 20.0);
+    equal(16.0, SIMD.Float32x4.extractLane(c, 0));
+    equal(9.0, SIMD.Float32x4.extractLane(c, 1));
+    equal(20.0, SIMD.Float32x4.extractLane(c, 2));
+    equal(1.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 withW', function() {
     var a = SIMD.Float32x4(16.0, 9.0, 4.0, 1.0);
-    var c = SIMD.Float32x4.withW(a, 20.0);
-    equal(16.0, c.x);
-    equal(9.0, c.y);
-    equal(4.0, c.z);
-    equal(20.0, c.w);
+    var c = SIMD.Float32x4.replaceLane(a, 3, 20.0);
+    equal(16.0, SIMD.Float32x4.extractLane(c, 0));
+    equal(9.0, SIMD.Float32x4.extractLane(c, 1));
+    equal(4.0, SIMD.Float32x4.extractLane(c, 2));
+    equal(20.0, SIMD.Float32x4.extractLane(c, 3));
 });
 
 test('Float32x4 Int32x4 conversion', function() {
   var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
   var n = SIMD.Float32x4.fromInt32x4Bits(m);
-  equal(1.0, n.x);
-  equal(2.0, n.y);
-  equal(3.0, n.z);
-  equal(4.0, n.w);
+  equal(1.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(3.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(4.0, SIMD.Float32x4.extractLane(n, 3));
   n = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
   m = SIMD.Int32x4.fromFloat32x4Bits(n);
-  equal(0x40A00000, m.x);
-  equal(0x40C00000, m.y);
-  equal(0x40E00000, m.z);
-  equal(0x41000000, m.w);
+  equal(0x40A00000, SIMD.Int32x4.extractLane(m, 0));
+  equal(0x40C00000, SIMD.Int32x4.extractLane(m, 1));
+  equal(0x40E00000, SIMD.Int32x4.extractLane(m, 2));
+  equal(0x41000000, SIMD.Int32x4.extractLane(m, 3));
   // Flip sign using bit-wise operators.
   n = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
   m = SIMD.Int32x4(0x80000000, 0x80000000, 0x80000000, 0x80000000);
   var nMask = SIMD.Int32x4.fromFloat32x4Bits(n);
   nMask = SIMD.Int32x4.xor(nMask, m); // flip sign.
   n = SIMD.Float32x4.fromInt32x4Bits(nMask);
-  equal(-9.0, n.x);
-  equal(-10.0, n.y);
-  equal(-11.0, n.z);
-  equal(-12.0, n.w);
+  equal(-9.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(-10.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(-11.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(-12.0, SIMD.Float32x4.extractLane(n, 3));
   nMask = SIMD.Int32x4.fromFloat32x4Bits(n);
   nMask = SIMD.Int32x4.xor(nMask, m); // flip sign.
   n = SIMD.Float32x4.fromInt32x4Bits(nMask);
-  equal(9.0, n.x);
-  equal(10.0, n.y);
-  equal(11.0, n.z);
-  equal(12.0, n.w);
+  equal(9.0, SIMD.Float32x4.extractLane(n, 0));
+  equal(10.0, SIMD.Float32x4.extractLane(n, 1));
+  equal(11.0, SIMD.Float32x4.extractLane(n, 2));
+  equal(12.0, SIMD.Float32x4.extractLane(n, 3));
   // Should stay unmodified across bit conversions
   m = SIMD.Int32x4(0xFFFFFFFF, 0xFFFF0000, 0x80000000, 0x0);
   var m2 = SIMD.Int32x4.fromFloat32x4Bits(SIMD.Float32x4.fromInt32x4Bits(m));
-  equal(m.x, m2.x);
-  equal(m.y, m2.y);
-  equal(m.z, m2.z);
-  equal(m.w, m2.w);
+  equal(SIMD.Int32x4.extractLane(m, 0), SIMD.Int32x4.extractLane(m2, 0));
+  equal(SIMD.Int32x4.extractLane(m, 1), SIMD.Int32x4.extractLane(m2, 1));
+  equal(SIMD.Int32x4.extractLane(m, 2), SIMD.Int32x4.extractLane(m2, 2));
+  equal(SIMD.Int32x4.extractLane(m, 3), SIMD.Int32x4.extractLane(m2, 3));
 });
 
 test('Float32x4 comparisons', function() {
@@ -319,40 +319,40 @@ test('Float32x4 comparisons', function() {
   var n = SIMD.Float32x4(2.0, 2.0, 0.001, 0.1);
   var cmp;
   cmp = SIMD.Float32x4.lessThan(m, n);
-  equal(-1, cmp.x);
-  equal(0x0, cmp.y);
-  equal(0x0, cmp.z);
-  equal(-1, cmp.w);
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 3));
 
   cmp = SIMD.Float32x4.lessThanOrEqual(m, n);
-  equal(-1, cmp.x);
-  equal(-1, cmp.y);
-  equal(0x0, cmp.z);
-  equal(-1, cmp.w);
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 3));
 
   cmp = SIMD.Float32x4.equal(m, n);
-  equal(0x0, cmp.x);
-  equal(-1, cmp.y);
-  equal(0x0, cmp.z);
-  equal(0x0, cmp.w);
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 
   cmp = SIMD.Float32x4.notEqual(m, n);
-  equal(-1, cmp.x);
-  equal(0x0, cmp.y);
-  equal(-1, cmp.z);
-  equal(-1, cmp.w);
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 3));
 
   cmp = SIMD.Float32x4.greaterThanOrEqual(m, n);
-  equal(0x0, cmp.x);
-  equal(-1, cmp.y);
-  equal(-1, cmp.z);
-  equal(0x0, cmp.w);
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 
   cmp = SIMD.Float32x4.greaterThan(m, n);
-  equal(0x0, cmp.x);
-  equal(0x0, cmp.y);
-  equal(-1, cmp.z);
-  equal(0x0, cmp.w);
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 1));
+  equal(-1, SIMD.Int32x4.extractLane(cmp, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(cmp, 3));
 });
 
 test('Int32x4 select', function() {
@@ -360,46 +360,46 @@ test('Int32x4 select', function() {
   var t = SIMD.Int32x4(1, 2, 3, 4);
   var f = SIMD.Int32x4(5, 6, 7, 8);
   var s = SIMD.Int32x4.select(m, t, f);
-  equal(1, s.x);
-  equal(2, s.y);
-  equal(7, s.z);
-  equal(8, s.w);
+  equal(1, SIMD.Int32x4.extractLane(s, 0));
+  equal(2, SIMD.Int32x4.extractLane(s, 1));
+  equal(7, SIMD.Int32x4.extractLane(s, 2));
+  equal(8, SIMD.Int32x4.extractLane(s, 3));
 });
 
 test('Int32x4 withX', function() {
     var a = SIMD.Int32x4(1, 2, 3, 4);
-    var c = SIMD.Int32x4.withX(a, 20);
-    equal(20, c.x);
-    equal(2, c.y);
-    equal(3, c.z);
-    equal(4, c.w);
+    var c = SIMD.Int32x4.replaceLane(a, 0, 20);
+    equal(20, SIMD.Int32x4.extractLane(c, 0));
+    equal(2, SIMD.Int32x4.extractLane(c, 1));
+    equal(3, SIMD.Int32x4.extractLane(c, 2));
+    equal(4, SIMD.Int32x4.extractLane(c, 3));
 });
 
 test('Int32x4 withY', function() {
     var a = SIMD.Int32x4(1, 2, 3, 4);
-    var c = SIMD.Int32x4.withY(a, 20);
-    equal(1, c.x);
-    equal(20, c.y);
-    equal(3, c.z);
-    equal(4, c.w);
+    var c = SIMD.Int32x4.replaceLane(a, 1, 20);
+    equal(1, SIMD.Int32x4.extractLane(c, 0));
+    equal(20, SIMD.Int32x4.extractLane(c, 1));
+    equal(3, SIMD.Int32x4.extractLane(c, 2));
+    equal(4, SIMD.Int32x4.extractLane(c, 3));
 });
 
 test('Int32x4 withZ', function() {
     var a = SIMD.Int32x4(1, 2, 3, 4);
-    var c = SIMD.Int32x4.withZ(a, 20);
-    equal(1, c.x);
-    equal(2, c.y);
-    equal(20, c.z);
-    equal(4, c.w);
+    var c = SIMD.Int32x4.replaceLane(a, 2, 20);
+    equal(1, SIMD.Int32x4.extractLane(c, 0));
+    equal(2, SIMD.Int32x4.extractLane(c, 1));
+    equal(20, SIMD.Int32x4.extractLane(c, 2));
+    equal(4, SIMD.Int32x4.extractLane(c, 3));
 });
 
 test('Int32x4 withW', function() {
     var a = SIMD.Int32x4(1, 2, 3, 4);
-    var c = SIMD.Int32x4.withW(a, 20);
-    equal(1, c.x);
-    equal(2, c.y);
-    equal(3, c.z);
-    equal(20, c.w);
+    var c = SIMD.Int32x4.replaceLane(a, 3, 20);
+    equal(1, SIMD.Int32x4.extractLane(c, 0));
+    equal(2, SIMD.Int32x4.extractLane(c, 1));
+    equal(3, SIMD.Int32x4.extractLane(c, 2));
+    equal(20, SIMD.Int32x4.extractLane(c, 3));
 });
 
 test('Int32x4 withFlagX', function() {
@@ -414,10 +414,10 @@ test('Int32x4 withFlagX', function() {
     equal(false, c.flagY);
     equal(true, c.flagZ);
     equal(false, c.flagW);
-    equal(0x0, c.x);
-    equal(0x0, c.y);
-    equal(-1, c.z);
-    equal(0x0, c.w);
+    equal(0x0, SIMD.Int32x4.extractLane(c, 0));
+    equal(0x0, SIMD.Int32x4.extractLane(c, 1));
+    equal(-1, SIMD.Int32x4.extractLane(c, 2));
+    equal(0x0, SIMD.Int32x4.extractLane(c, 3));
 });
 
 test('Int32x4 withFlagY', function() {
@@ -432,16 +432,16 @@ test('Int32x4 withFlagY', function() {
     equal(false, c.flagY);
     equal(true, c.flagZ);
     equal(false, c.flagW);
-    equal(-1, c.x);
-    equal(0x0, c.y);
-    equal(-1, c.z);
-    equal(0x0, c.w);
+    equal(-1, SIMD.Int32x4.extractLane(c, 0));
+    equal(0x0, SIMD.Int32x4.extractLane(c, 1));
+    equal(-1, SIMD.Int32x4.extractLane(c, 2));
+    equal(0x0, SIMD.Int32x4.extractLane(c, 3));
 });
 
 test('Int32x4 withFlagZ', function() {
     var a = SIMD.Int32x4.bool(true, false, true, false);
     var c = SIMD.Int32x4.withFlagZ(a, true);
-    equal(-1, c.x);
+    equal(-1, SIMD.Int32x4.extractLane(c, 0));
     equal(true, c.flagX);
     equal(false, c.flagY);
     equal(true, c.flagZ);
@@ -451,10 +451,10 @@ test('Int32x4 withFlagZ', function() {
     equal(false, c.flagY);
     equal(false, c.flagZ);
     equal(false, c.flagW);
-    equal(-1, c.x);
-    equal(0x0, c.y);
-    equal(0x0, c.z);
-    equal(0x0, c.w);
+    equal(-1, SIMD.Int32x4.extractLane(c, 0));
+    equal(0x0, SIMD.Int32x4.extractLane(c, 1));
+    equal(0x0, SIMD.Int32x4.extractLane(c, 2));
+    equal(0x0, SIMD.Int32x4.extractLane(c, 3));
 });
 
 test('Int32x4 withFlagW', function() {
@@ -469,32 +469,32 @@ test('Int32x4 withFlagW', function() {
     equal(false, c.flagY);
     equal(true, c.flagZ);
     equal(false, c.flagW);
-    equal(-1, c.x);
-    equal(0x0, c.y);
-    equal(-1, c.z);
-    equal(0x0, c.w);
+    equal(-1, SIMD.Int32x4.extractLane(c, 0));
+    equal(0x0, SIMD.Int32x4.extractLane(c, 1));
+    equal(-1, SIMD.Int32x4.extractLane(c, 2));
+    equal(0x0, SIMD.Int32x4.extractLane(c, 3));
 });
 
 test('Int32x4 and', function() {
   var m = SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, -1431655766, 0xAAAAAAAA);
   var n = SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
-  equal(-1431655766, m.x);
-  equal(-1431655766, m.y);
-  equal(-1431655766, m.z);
-  equal(-1431655766, m.w);
-  equal(0x55555555, n.x);
-  equal(0x55555555, n.y);
-  equal(0x55555555, n.z);
-  equal(0x55555555, n.w);
+  equal(-1431655766, SIMD.Int32x4.extractLane(m, 0));
+  equal(-1431655766, SIMD.Int32x4.extractLane(m, 1));
+  equal(-1431655766, SIMD.Int32x4.extractLane(m, 2));
+  equal(-1431655766, SIMD.Int32x4.extractLane(m, 3));
+  equal(0x55555555, SIMD.Int32x4.extractLane(n, 0));
+  equal(0x55555555, SIMD.Int32x4.extractLane(n, 1));
+  equal(0x55555555, SIMD.Int32x4.extractLane(n, 2));
+  equal(0x55555555, SIMD.Int32x4.extractLane(n, 3));
   equal(true, n.flagX);
   equal(true, n.flagY);
   equal(true, n.flagZ);
   equal(true, n.flagW);
   var o = SIMD.Int32x4.and(m,n);  // and
-  equal(0x0, o.x);
-  equal(0x0, o.y);
-  equal(0x0, o.z);
-  equal(0x0, o.w);
+  equal(0x0, SIMD.Int32x4.extractLane(o, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(o, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(o, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(o, 3));
   equal(false, o.flagX);
   equal(false, o.flagY);
   equal(false, o.flagZ);
@@ -505,10 +505,10 @@ test('Int32x4 or', function() {
   var m = SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA);
   var n = SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
   var o = SIMD.Int32x4.or(m,n);  // or
-  equal(-1, o.x);
-  equal(-1, o.y);
-  equal(-1, o.z);
-  equal(-1, o.w);
+  equal(-1, SIMD.Int32x4.extractLane(o, 0));
+  equal(-1, SIMD.Int32x4.extractLane(o, 1));
+  equal(-1, SIMD.Int32x4.extractLane(o, 2));
+  equal(-1, SIMD.Int32x4.extractLane(o, 3));
   equal(true, o.flagX);
   equal(true, o.flagY);
   equal(true, o.flagZ);
@@ -518,19 +518,19 @@ test('Int32x4 or', function() {
 test('Int32x4 xor', function() {
   var m = SIMD.Int32x4(0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA);
   var n = SIMD.Int32x4(0x55555555, 0x55555555, 0x55555555, 0x55555555);
-  n = SIMD.Int32x4.withX(n, 0xAAAAAAAA);
-  n = SIMD.Int32x4.withY(n, 0xAAAAAAAA);
-  n = SIMD.Int32x4.withZ(n, 0xAAAAAAAA);
-  n = SIMD.Int32x4.withW(n, 0xAAAAAAAA);
-  equal(-1431655766, n.x);
-  equal(-1431655766, n.y);
-  equal(-1431655766, n.z);
-  equal(-1431655766, n.w);
+  n = SIMD.Int32x4.replaceLane(n, 0, 0xAAAAAAAA);
+  n = SIMD.Int32x4.replaceLane(n, 1, 0xAAAAAAAA);
+  n = SIMD.Int32x4.replaceLane(n, 2, 0xAAAAAAAA);
+  n = SIMD.Int32x4.replaceLane(n, 3, 0xAAAAAAAA);
+  equal(-1431655766, SIMD.Int32x4.extractLane(n, 0));
+  equal(-1431655766, SIMD.Int32x4.extractLane(n, 1));
+  equal(-1431655766, SIMD.Int32x4.extractLane(n, 2));
+  equal(-1431655766, SIMD.Int32x4.extractLane(n, 3));
   var o = SIMD.Int32x4.xor(m,n);  // xor
-  equal(0x0, o.x);
-  equal(0x0, o.y);
-  equal(0x0, o.z);
-  equal(0x0, o.w);
+  equal(0x0, SIMD.Int32x4.extractLane(o, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(o, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(o, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(o, 3));
   equal(false, o.flagX);
   equal(false, o.flagY);
   equal(false, o.flagZ);
@@ -542,14 +542,14 @@ test('Int32x4 neg', function() {
   var n = SIMD.Int32x4(-1, -2, -3, -4);
   m = SIMD.Int32x4.neg(m);
   n = SIMD.Int32x4.neg(n);
-  equal(-16, m.x);
-  equal(-32, m.y);
-  equal(-64, m.z);
-  equal(-128, m.w);
-  equal(1, n.x);
-  equal(2, n.y);
-  equal(3, n.z);
-  equal(4, n.w);
+  equal(-16, SIMD.Int32x4.extractLane(m, 0));
+  equal(-32, SIMD.Int32x4.extractLane(m, 1));
+  equal(-64, SIMD.Int32x4.extractLane(m, 2));
+  equal(-128, SIMD.Int32x4.extractLane(m, 3));
+  equal(1, SIMD.Int32x4.extractLane(n, 0));
+  equal(2, SIMD.Int32x4.extractLane(n, 1));
+  equal(3, SIMD.Int32x4.extractLane(n, 2));
+  equal(4, SIMD.Int32x4.extractLane(n, 3));
 });
 
 test('Int32x4 signMask getter', function() {
@@ -566,30 +566,30 @@ test('Int32x4 add', function() {
   var a = SIMD.Int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x7fffffff, 0x0);
   var b = SIMD.Int32x4(0x1, 0xFFFFFFFF, 0x1, 0xFFFFFFFF);
   var c = SIMD.Int32x4.add(a, b);
-  equal(0x0, c.x);
-  equal(-2, c.y);
-  equal(-0x80000000, c.z);
-  equal(-1, c.w);
+  equal(0x0, SIMD.Int32x4.extractLane(c, 0));
+  equal(-2, SIMD.Int32x4.extractLane(c, 1));
+  equal(-0x80000000, SIMD.Int32x4.extractLane(c, 2));
+  equal(-1, SIMD.Int32x4.extractLane(c, 3));
 });
 
 test('Int32x4 sub', function() {
   var a = SIMD.Int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x80000000, 0x0);
   var b = SIMD.Int32x4(0x1, 0xFFFFFFFF, 0x1, 0xFFFFFFFF);
   var c = SIMD.Int32x4.sub(a, b);
-  equal(-2, c.x);
-  equal(0x0, c.y);
-  equal(0x7FFFFFFF, c.z);
-  equal(0x1, c.w);
+  equal(-2, SIMD.Int32x4.extractLane(c, 0));
+  equal(0x0, SIMD.Int32x4.extractLane(c, 1));
+  equal(0x7FFFFFFF, SIMD.Int32x4.extractLane(c, 2));
+  equal(0x1, SIMD.Int32x4.extractLane(c, 3));
 });
 
 test('Int32x4 mul', function() {
   var a = SIMD.Int32x4(0xFFFFFFFF, 0xFFFFFFFF, 0x80000000, 0x0);
   var b = SIMD.Int32x4(0x1, 0xFFFFFFFF, 0x80000000, 0xFFFFFFFF);
   var c = SIMD.Int32x4.mul(a, b);
-  equal(-1, c.x);
-  equal(0x1, c.y);
-  equal(0x0, c.z);
-  equal(0x0, c.w);
+  equal(-1, SIMD.Int32x4.extractLane(c, 0));
+  equal(0x1, SIMD.Int32x4.extractLane(c, 1));
+  equal(0x0, SIMD.Int32x4.extractLane(c, 2));
+  equal(0x0, SIMD.Int32x4.extractLane(c, 3));
 });
 
 test('Float32x4Array simple', function() {
@@ -878,75 +878,75 @@ test('Int32x4 shiftLeftByScalar', function() {
   var a = SIMD.Int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
   var b;
   b = SIMD.Int32x4.shiftLeftByScalar(a, 1);
-  equal(b.x, 0xfffffffe|0);
-  equal(b.y, 0xfffffffe|0);
-  equal(b.z, 0x00000002);
-  equal(b.w, 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xfffffffe|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0xfffffffe|0);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000002);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
   b = SIMD.Int32x4.shiftLeftByScalar(a, 2);
-  equal(b.x, 0xfffffffc|0);
-  equal(b.y, 0xfffffffc|0);
-  equal(b.z, 0x00000004);
-  equal(b.w, 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xfffffffc|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0xfffffffc|0);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000004);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
   b = SIMD.Int32x4.shiftLeftByScalar(a, 30);
-  equal(b.x, 0xc0000000|0);
-  equal(b.y, 0xc0000000|0);
-  equal(b.z, 0x40000000);
-  equal(b.w, 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xc0000000|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0xc0000000|0);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x40000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
   b = SIMD.Int32x4.shiftLeftByScalar(a, 31);
-  equal(b.x, 0x80000000|0);
-  equal(b.y, 0x80000000|0);
-  equal(b.z, 0x80000000|0);
-  equal(b.w, 0x0);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x80000000|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x80000000|0);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x80000000|0);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x0);
 });
 
 test('Int32x4 shiftRightLogicalByScalar', function() {
   var a = SIMD.Int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
   var b;
   b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 1);
-  equal(b.x, 0x7fffffff);
-  equal(b.y, 0x3fffffff);
-  equal(b.z, 0x00000000);
-  equal(b.w, 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x7fffffff);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x3fffffff);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
   b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 2);
-  equal(b.x, 0x3fffffff);
-  equal(b.y, 0x1fffffff);
-  equal(b.z, 0x00000000);
-  equal(b.w, 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x3fffffff);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x1fffffff);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
   b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 30);
-  equal(b.x, 0x00000003);
-  equal(b.y, 0x00000001);
-  equal(b.z, 0x00000000);
-  equal(b.w, 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x00000003);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000001);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
   b = SIMD.Int32x4.shiftRightLogicalByScalar(a, 31);
-  equal(b.x, 0x00000001);
-  equal(b.y, 0x00000000);
-  equal(b.z, 0x00000000);
-  equal(b.w, 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0x00000001);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
 });
 
 test('Int32x4 shiftRightArithmeticByScalar', function() {
   var a = SIMD.Int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
   var b;
   b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 1);
-  equal(b.x, 0xffffffff|0);
-  equal(b.y, 0x3fffffff);
-  equal(b.z, 0x00000000);
-  equal(b.w, 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x3fffffff);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
   b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 2);
-  equal(b.x, 0xffffffff|0);
-  equal(b.y, 0x1fffffff);
-  equal(b.z, 0x00000000);
-  equal(b.w, 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x1fffffff);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
   b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 30);
-  equal(b.x, 0xffffffff|0);
-  equal(b.y, 0x00000001);
-  equal(b.z, 0x00000000);
-  equal(b.w, 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000001);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
   b = SIMD.Int32x4.shiftRightArithmeticByScalar(a, 31);
-  equal(b.x, 0xffffffff|0);
-  equal(b.y, 0x00000000);
-  equal(b.z, 0x00000000);
-  equal(b.w, 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 0), 0xffffffff|0);
+  equal(SIMD.Int32x4.extractLane(b, 1), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 2), 0x00000000);
+  equal(SIMD.Int32x4.extractLane(b, 3), 0x00000000);
 });
 
 test('Float32x4 shuffle', function() {
@@ -955,33 +955,33 @@ test('Float32x4 shuffle', function() {
   var xyxy = SIMD.Float32x4.shuffle(a, b, 0, 1, 4, 5);
   var zwzw = SIMD.Float32x4.shuffle(a, b, 2, 3, 6, 7);
   var xxxx = SIMD.Float32x4.shuffle(a, b, 0, 0, 4, 4);
-  equal(1.0, xyxy.x);
-  equal(2.0, xyxy.y);
-  equal(5.0, xyxy.z);
-  equal(6.0, xyxy.w);
-  equal(3.0, zwzw.x);
-  equal(4.0, zwzw.y);
-  equal(7.0, zwzw.z);
-  equal(8.0, zwzw.w);
-  equal(1.0, xxxx.x);
-  equal(1.0, xxxx.y);
-  equal(5.0, xxxx.z);
-  equal(5.0, xxxx.w);
+  equal(1.0, SIMD.Float32x4.extractLane(xyxy, 0));
+  equal(2.0, SIMD.Float32x4.extractLane(xyxy, 1));
+  equal(5.0, SIMD.Float32x4.extractLane(xyxy, 2));
+  equal(6.0, SIMD.Float32x4.extractLane(xyxy, 3));
+  equal(3.0, SIMD.Float32x4.extractLane(zwzw, 0));
+  equal(4.0, SIMD.Float32x4.extractLane(zwzw, 1));
+  equal(7.0, SIMD.Float32x4.extractLane(zwzw, 2));
+  equal(8.0, SIMD.Float32x4.extractLane(zwzw, 3));
+  equal(1.0, SIMD.Float32x4.extractLane(xxxx, 0));
+  equal(1.0, SIMD.Float32x4.extractLane(xxxx, 1));
+  equal(5.0, SIMD.Float32x4.extractLane(xxxx, 2));
+  equal(5.0, SIMD.Float32x4.extractLane(xxxx, 3));
   var c = SIMD.Float32x4.shuffle(a, b, 0, 4, 5, 1);
   var d = SIMD.Float32x4.shuffle(a, b, 2, 6, 3, 7);
   var e = SIMD.Float32x4.shuffle(a, b, 0, 4, 0, 4);
-  equal(1.0, c.x);
-  equal(5.0, c.y);
-  equal(6.0, c.z);
-  equal(2.0, c.w);
-  equal(3.0, d.x);
-  equal(7.0, d.y);
-  equal(4.0, d.z);
-  equal(8.0, d.w);
-  equal(1.0, e.x);
-  equal(5.0, e.y);
-  equal(1.0, e.z);
-  equal(5.0, e.w);
+  equal(1.0, SIMD.Float32x4.extractLane(c, 0));
+  equal(5.0, SIMD.Float32x4.extractLane(c, 1));
+  equal(6.0, SIMD.Float32x4.extractLane(c, 2));
+  equal(2.0, SIMD.Float32x4.extractLane(c, 3));
+  equal(3.0, SIMD.Float32x4.extractLane(d, 0));
+  equal(7.0, SIMD.Float32x4.extractLane(d, 1));
+  equal(4.0, SIMD.Float32x4.extractLane(d, 2));
+  equal(8.0, SIMD.Float32x4.extractLane(d, 3));
+  equal(1.0, SIMD.Float32x4.extractLane(e, 0));
+  equal(5.0, SIMD.Float32x4.extractLane(e, 1));
+  equal(1.0, SIMD.Float32x4.extractLane(e, 2));
+  equal(5.0, SIMD.Float32x4.extractLane(e, 3));
 });
 
 test('Float64x2 swizzle', function() {
@@ -990,14 +990,14 @@ test('Float64x2 swizzle', function() {
   var xy = SIMD.Float64x2.swizzle(a, 0, 1);
   var yx = SIMD.Float64x2.swizzle(a, 1, 0);
   var yy = SIMD.Float64x2.swizzle(a, 1, 1);
-  equal(1.0, xx.x);
-  equal(1.0, xx.y);
-  equal(1.0, xy.x);
-  equal(2.0, xy.y);
-  equal(2.0, yx.x);
-  equal(1.0, yx.y);
-  equal(2.0, yy.x);
-  equal(2.0, yy.y);
+  equal(1.0, SIMD.Float64x2.extractLane(xx, 0));
+  equal(1.0, SIMD.Float64x2.extractLane(xx, 1));
+  equal(1.0, SIMD.Float64x2.extractLane(xy, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(xy, 1));
+  equal(2.0, SIMD.Float64x2.extractLane(yx, 0));
+  equal(1.0, SIMD.Float64x2.extractLane(yx, 1));
+  equal(2.0, SIMD.Float64x2.extractLane(yy, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(yy, 1));
 });
 
 test('Float64x2 shuffle', function() {
@@ -1007,26 +1007,26 @@ test('Float64x2 shuffle', function() {
   var xy = SIMD.Float64x2.shuffle(a, b, 0, 3);
   var yx = SIMD.Float64x2.shuffle(a, b, 1, 0);
   var yy = SIMD.Float64x2.shuffle(a, b, 1, 3);
-  equal(1.0, xx.x);
-  equal(3.0, xx.y);
-  equal(1.0, xy.x);
-  equal(4.0, xy.y);
-  equal(2.0, yx.x);
-  equal(1.0, yx.y);
-  equal(2.0, yy.x);
-  equal(4.0, yy.y);
+  equal(1.0, SIMD.Float64x2.extractLane(xx, 0));
+  equal(3.0, SIMD.Float64x2.extractLane(xx, 1));
+  equal(1.0, SIMD.Float64x2.extractLane(xy, 0));
+  equal(4.0, SIMD.Float64x2.extractLane(xy, 1));
+  equal(2.0, SIMD.Float64x2.extractLane(yx, 0));
+  equal(1.0, SIMD.Float64x2.extractLane(yx, 1));
+  equal(2.0, SIMD.Float64x2.extractLane(yy, 0));
+  equal(4.0, SIMD.Float64x2.extractLane(yy, 1));
   var c = SIMD.Float64x2.shuffle(a, b, 1, 0);
   var d = SIMD.Float64x2.shuffle(a, b, 3, 2);
   var e = SIMD.Float64x2.shuffle(a, b, 0, 1);
   var f = SIMD.Float64x2.shuffle(a, b, 0, 2);
-  equal(2.0, c.x);
-  equal(1.0, c.y);
-  equal(4.0, d.x);
-  equal(3.0, d.y);
-  equal(1.0, e.x);
-  equal(2.0, e.y);
-  equal(1.0, f.x);
-  equal(3.0, f.y);
+  equal(2.0, SIMD.Float64x2.extractLane(c, 0));
+  equal(1.0, SIMD.Float64x2.extractLane(c, 1));
+  equal(4.0, SIMD.Float64x2.extractLane(d, 0));
+  equal(3.0, SIMD.Float64x2.extractLane(d, 1));
+  equal(1.0, SIMD.Float64x2.extractLane(e, 0));
+  equal(2.0, SIMD.Float64x2.extractLane(e, 1));
+  equal(1.0, SIMD.Float64x2.extractLane(f, 0));
+  equal(3.0, SIMD.Float64x2.extractLane(f, 1));
 });
 
 test('Int32x4 shuffle', function() {
@@ -1035,33 +1035,33 @@ test('Int32x4 shuffle', function() {
   var xyxy = SIMD.Int32x4.shuffle(a, b, 0, 1, 4, 5);
   var zwzw = SIMD.Int32x4.shuffle(a, b, 2, 3, 6, 7);
   var xxxx = SIMD.Int32x4.shuffle(a, b, 0, 0, 4, 4);
-  equal(1, xyxy.x);
-  equal(2, xyxy.y);
-  equal(5, xyxy.z);
-  equal(6, xyxy.w);
-  equal(3, zwzw.x);
-  equal(4, zwzw.y);
-  equal(7, zwzw.z);
-  equal(8, zwzw.w);
-  equal(1, xxxx.x);
-  equal(1, xxxx.y);
-  equal(5, xxxx.z);
-  equal(5, xxxx.w);
+  equal(1, SIMD.Int32x4.extractLane(xyxy, 0));
+  equal(2, SIMD.Int32x4.extractLane(xyxy, 1));
+  equal(5, SIMD.Int32x4.extractLane(xyxy, 2));
+  equal(6, SIMD.Int32x4.extractLane(xyxy, 3));
+  equal(3, SIMD.Int32x4.extractLane(zwzw, 0));
+  equal(4, SIMD.Int32x4.extractLane(zwzw, 1));
+  equal(7, SIMD.Int32x4.extractLane(zwzw, 2));
+  equal(8, SIMD.Int32x4.extractLane(zwzw, 3));
+  equal(1, SIMD.Int32x4.extractLane(xxxx, 0));
+  equal(1, SIMD.Int32x4.extractLane(xxxx, 1));
+  equal(5, SIMD.Int32x4.extractLane(xxxx, 2));
+  equal(5, SIMD.Int32x4.extractLane(xxxx, 3));
   var c = SIMD.Int32x4.shuffle(a, b, 0, 4, 5, 1);
   var d = SIMD.Int32x4.shuffle(a, b, 2, 6, 3, 7);
   var e = SIMD.Int32x4.shuffle(a, b, 0, 4, 0, 4);
-  equal(1, c.x);
-  equal(5, c.y);
-  equal(6, c.z);
-  equal(2, c.w);
-  equal(3, d.x);
-  equal(7, d.y);
-  equal(4, d.z);
-  equal(8, d.w);
-  equal(1, e.x);
-  equal(5, e.y);
-  equal(1, e.z);
-  equal(5, e.w);
+  equal(1, SIMD.Int32x4.extractLane(c, 0));
+  equal(5, SIMD.Int32x4.extractLane(c, 1));
+  equal(6, SIMD.Int32x4.extractLane(c, 2));
+  equal(2, SIMD.Int32x4.extractLane(c, 3));
+  equal(3, SIMD.Int32x4.extractLane(d, 0));
+  equal(7, SIMD.Int32x4.extractLane(d, 1));
+  equal(4, SIMD.Int32x4.extractLane(d, 2));
+  equal(8, SIMD.Int32x4.extractLane(d, 3));
+  equal(1, SIMD.Int32x4.extractLane(e, 0));
+  equal(5, SIMD.Int32x4.extractLane(e, 1));
+  equal(1, SIMD.Int32x4.extractLane(e, 2));
+  equal(5, SIMD.Int32x4.extractLane(e, 3));
 });
 
 test('Int32x4 vector getters', function() {
@@ -1071,24 +1071,24 @@ test('Int32x4 vector getters', function() {
   var zzzz = SIMD.Int32x4.swizzle(a, 2, 2, 2, 2);
   var wwww = SIMD.Int32x4.swizzle(a, 3, 3, 3, 3);
   var wzyx = SIMD.Int32x4.swizzle(a, 3, 2, 1, 0);
-  equal(4, xxxx.x);
-  equal(4, xxxx.y);
-  equal(4, xxxx.z);
-  equal(4, xxxx.w);
-  equal(3, yyyy.x);
-  equal(3, yyyy.y);
-  equal(3, yyyy.z);
-  equal(3, yyyy.w);
-  equal(2, zzzz.x);
-  equal(2, zzzz.y);
-  equal(2, zzzz.z);
-  equal(2, zzzz.w);
-  equal(1, wwww.x);
-  equal(1, wwww.y);
-  equal(1, wwww.z);
-  equal(1, wwww.w);
-  equal(1, wzyx.x);
-  equal(2, wzyx.y);
-  equal(3, wzyx.z);
-  equal(4, wzyx.w);
+  equal(4, SIMD.Int32x4.extractLane(xxxx, 0));
+  equal(4, SIMD.Int32x4.extractLane(xxxx, 1));
+  equal(4, SIMD.Int32x4.extractLane(xxxx, 2));
+  equal(4, SIMD.Int32x4.extractLane(xxxx, 3));
+  equal(3, SIMD.Int32x4.extractLane(yyyy, 0));
+  equal(3, SIMD.Int32x4.extractLane(yyyy, 1));
+  equal(3, SIMD.Int32x4.extractLane(yyyy, 2));
+  equal(3, SIMD.Int32x4.extractLane(yyyy, 3));
+  equal(2, SIMD.Int32x4.extractLane(zzzz, 0));
+  equal(2, SIMD.Int32x4.extractLane(zzzz, 1));
+  equal(2, SIMD.Int32x4.extractLane(zzzz, 2));
+  equal(2, SIMD.Int32x4.extractLane(zzzz, 3));
+  equal(1, SIMD.Int32x4.extractLane(wwww, 0));
+  equal(1, SIMD.Int32x4.extractLane(wwww, 1));
+  equal(1, SIMD.Int32x4.extractLane(wwww, 2));
+  equal(1, SIMD.Int32x4.extractLane(wwww, 3));
+  equal(1, SIMD.Int32x4.extractLane(wzyx, 0));
+  equal(2, SIMD.Int32x4.extractLane(wzyx, 1));
+  equal(3, SIMD.Int32x4.extractLane(wzyx, 2));
+  equal(4, SIMD.Int32x4.extractLane(wzyx, 3));
 });

--- a/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html
+++ b/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/load_stroe_test.html
@@ -47,10 +47,10 @@ test('Float32x4 load', function() {
   }
   for (var i = 0; i < a.length - 3; i++) {
     var v = SIMD.Float32x4.load(a, i);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(i+2, v.z);
-    equal(i+3, v.w);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Float32x4.extractLane(v, 2));
+    equal(i+3, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
@@ -63,10 +63,10 @@ test('Float32x4 overaligned load', function() {
   }
   for (var i = 0; i < a.length - 3; i += 2) {
     var v = SIMD.Float32x4.load(af, i / 2);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(i+2, v.z);
-    equal(i+3, v.w);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Float32x4.extractLane(v, 2));
+    equal(i+3, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
@@ -85,10 +85,10 @@ test('Float32x4 unaligned load', function() {
   // Load the values unaligned.
   for (var i = 0; i < a.length - 3; i++) {
     var v = SIMD.Float32x4.load(b, i * 4 + 1);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(i+2, v.z);
-    equal(i+3, v.w);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Float32x4.extractLane(v, 2));
+    equal(i+3, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
@@ -99,10 +99,10 @@ test('Float32x4 loadX', function() {
   }
   for (var i = 0; i < a.length; i++) {
     var v = SIMD.Float32x4.loadX(a, i);
-    equal(i, v.x);
-    equal(0.0, v.y);
-    equal(0.0, v.z);
-    equal(0.0, v.w);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 1));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 2));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
@@ -115,10 +115,10 @@ test('Float32x4 overaligned loadX', function() {
   }
   for (var i = 0; i < a.length; i += 2) {
     var v = SIMD.Float32x4.loadX(af, i / 2);
-    equal(i, v.x);
-    equal(0.0, v.y);
-    equal(0.0, v.z);
-    equal(0.0, v.w);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 1));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 2));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
@@ -136,10 +136,10 @@ test('Float32x4 unaligned loadX', function() {
   // Load the values unaligned.
   for (var i = 0; i < a.length; i++) {
     var v = SIMD.Float32x4.loadX(b, i * 4 + 1);
-    equal(i, v.x);
-    equal(0.0, v.y);
-    equal(0.0, v.z);
-    equal(0.0, v.w);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 1));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 2));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
@@ -150,10 +150,10 @@ test('Float32x4 loadXY', function() {
   }
   for (var i = 0; i < a.length - 1; i++) {
     var v = SIMD.Float32x4.loadXY(a, i);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(0.0, v.z);
-    equal(0.0, v.w);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 2));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
@@ -166,10 +166,10 @@ test('Float32x4 overaligned loadXY', function() {
   }
   for (var i = 0; i < a.length - 1; i += 2) {
   var v = SIMD.Float32x4.loadXY(af, i / 2);
-  equal(i, v.x);
-  equal(i+1, v.y);
-  equal(0.0, v.z);
-  equal(0.0, v.w);
+  equal(i, SIMD.Float32x4.extractLane(v, 0));
+  equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+  equal(0.0, SIMD.Float32x4.extractLane(v, 2));
+  equal(0.0, SIMD.Float32x4.extractLane(v, 3));
 }
 });
 
@@ -187,10 +187,10 @@ test('Float32x4 unaligned loadXY', function() {
   // Load the values unaligned.
   for (var i = 0; i < a.length - 1; i++) {
     var v = SIMD.Float32x4.loadXY(b, i * 4 + 1);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(0.0, v.z);
-    equal(0.0, v.w);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 2));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
@@ -201,10 +201,10 @@ test('Float32x4 loadXYZ', function() {
   }
   for (var i = 0; i < a.length - 2; i++) {
     var v = SIMD.Float32x4.loadXYZ(a, i);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(i+2, v.z);
-    equal(0.0, v.w);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Float32x4.extractLane(v, 2));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
@@ -217,10 +217,10 @@ test('Float32x4 overaligned loadXYZ', function() {
   }
   for (var i = 0; i < a.length - 2; i += 2) {
     var v = SIMD.Float32x4.loadXYZ(af, i / 2);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(i+2, v.z);
-    equal(0.0, v.w);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Float32x4.extractLane(v, 2));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
@@ -238,10 +238,10 @@ test('Float32x4 unaligned loadXYZ', function() {
   // Load the values unaligned.
   for (var i = 0; i < a.length - 2; i++) {
     var v = SIMD.Float32x4.loadXYZ(b, i * 4 + 1);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(i+2, v.z);
-    equal(0.0, v.w);
+    equal(i, SIMD.Float32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Float32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Float32x4.extractLane(v, 2));
+    equal(0.0, SIMD.Float32x4.extractLane(v, 3));
   }
 });
 
@@ -568,8 +568,8 @@ test('Float64x2 load', function() {
   }
   for (var i = 0; i < a.length - 1; i++) {
     var v = SIMD.Float64x2.load(a, i);
-    equal(i, v.x);
-    equal(i+1, v.y);
+    equal(i, SIMD.Float64x2.extractLane(v, 0));
+    equal(i+1, SIMD.Float64x2.extractLane(v, 1));
   }
 });
 
@@ -587,8 +587,8 @@ test('Float64x2 unaligned load', function() {
   // Load the values unaligned.
   for (var i = 0; i < a.length - 1; i++) {
     var v = SIMD.Float64x2.load(b, i * 8 + 1);
-    equal(i, v.x);
-    equal(i+1, v.y);
+    equal(i, SIMD.Float64x2.extractLane(v, 0));
+    equal(i+1, SIMD.Float64x2.extractLane(v, 1));
   }
 });
 
@@ -599,8 +599,8 @@ test('Float64x2 loadX', function() {
   }
   for (var i = 0; i < a.length; i++) {
     var v = SIMD.Float64x2.loadX(a, i);
-    equal(i, v.x);
-    equal(0.0, v.y);
+    equal(i, SIMD.Float64x2.extractLane(v, 0));
+    equal(0.0, SIMD.Float64x2.extractLane(v, 1));
   }
 });
 
@@ -618,8 +618,8 @@ test('Float64x2 unaligned loadX', function() {
   // Copy the values unaligned.
   for (var i = 0; i < a.length; i++) {
     var v = SIMD.Float64x2.loadX(b, i * 8 + 1);
-    equal(i, v.x);
-    equal(0.0, v.y);
+    equal(i, SIMD.Float64x2.extractLane(v, 0));
+    equal(0.0, SIMD.Float64x2.extractLane(v, 1));
   }
 });
 
@@ -758,10 +758,10 @@ test('Int32x4 load', function() {
   }
   for (var i = 0; i < a.length - 3; i++) {
     var v = SIMD.Int32x4.load(a, i);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(i+2, v.z);
-    equal(i+3, v.w);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(v, 2));
+    equal(i+3, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
@@ -774,10 +774,10 @@ test('Int32x4 overaligned load', function() {
   }
   for (var i = 0; i < a.length - 3; i += 2) {
     var v = SIMD.Int32x4.load(af, i / 2);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(i+2, v.z);
-    equal(i+3, v.w);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(v, 2));
+    equal(i+3, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
@@ -795,10 +795,10 @@ test('Int32x4 unaligned load', function() {
   // Load the values unaligned.
   for (var i = 0; i < a.length - 3; i++) {
     var v = SIMD.Int32x4.load(b, i * 4 + 1);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(i+2, v.z);
-    equal(i+3, v.w);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(v, 2));
+    equal(i+3, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
@@ -809,10 +809,10 @@ test('Int32x4 loadX', function() {
   }
   for (var i = 0; i < a.length ; i++) {
     var v = SIMD.Int32x4.loadX(a, i);
-    equal(i, v.x);
-    equal(0, v.y);
-    equal(0, v.z);
-    equal(0, v.w);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(0, SIMD.Int32x4.extractLane(v, 1));
+    equal(0, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
@@ -825,10 +825,10 @@ test('Int32x4 overaligned loadX', function() {
   }
   for (var i = 0; i < a.length; i++) {
     var v = SIMD.Int32x4.loadX(af, i);
-    equal(i, v.x);
-    equal(0, v.y);
-    equal(0, v.z);
-    equal(0, v.w);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(0, SIMD.Int32x4.extractLane(v, 1));
+    equal(0, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
@@ -846,10 +846,10 @@ test('Int32x4 unaligned loadX', function() {
   // Load the values unaligned.
   for (var i = 0; i < a.length ; i++) {
     var v = SIMD.Int32x4.loadX(b, i * 4 + 1);
-    equal(i, v.x);
-    equal(0, v.y);
-    equal(0, v.z);
-    equal(0, v.w);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(0, SIMD.Int32x4.extractLane(v, 1));
+    equal(0, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
@@ -860,10 +860,10 @@ test('Int32x4 loadXY', function() {
   }
   for (var i = 0; i < a.length - 1; i++) {
     var v = SIMD.Int32x4.loadXY(a, i);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(0, v.z);
-    equal(0, v.w);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(0, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
@@ -876,10 +876,10 @@ test('Int32x4 overaligned loadXY', function() {
   }
   for (var i = 0; i < a.length - 1; i += 2) {
     var v = SIMD.Int32x4.loadXY(af, i / 2);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(0, v.z);
-    equal(0, v.w);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(0, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
@@ -897,10 +897,10 @@ test('Int32x4 unaligned loadXY', function() {
   // Load the values unaligned.
   for (var i = 0; i < a.length - 1; i++) {
     var v = SIMD.Int32x4.loadXY(b, i * 4 + 1);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(0, v.z);
-    equal(0, v.w);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(0, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
@@ -911,10 +911,10 @@ test('Int32x4 loadXYZ', function() {
   }
   for (var i = 0; i < a.length - 2; i++) {
     var v = SIMD.Int32x4.loadXYZ(a, i);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(i+2, v.z);
-    equal(0, v.w);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
@@ -927,10 +927,10 @@ test('Int32x4 overaligned loadXYZ', function() {
   }
   for (var i = 0; i < a.length - 2; i += 2) {
     var v = SIMD.Int32x4.loadXYZ(af, i / 2);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(i+2, v.z);
-    equal(0, v.w);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 
@@ -949,10 +949,10 @@ test('Int32x4 unaligned loadXYZ', function() {
   // Load the values unaligned.
   for (var i = 0; i < a.length - 2; i++) {
     var v = SIMD.Int32x4.loadXYZ(b, i * 4 + 1);
-    equal(i, v.x);
-    equal(i+1, v.y);
-    equal(i+2, v.z);
-    equal(0, v.w);
+    equal(i, SIMD.Int32x4.extractLane(v, 0));
+    equal(i+1, SIMD.Int32x4.extractLane(v, 1));
+    equal(i+2, SIMD.Int32x4.extractLane(v, 2));
+    equal(0, SIMD.Int32x4.extractLane(v, 3));
   }
 });
 test('Int32x4 store', function() {

--- a/webapi/webapi-simd-nonw3c-tests/simd/float32x4.html
+++ b/webapi/webapi-simd-nonw3c-tests/simd/float32x4.html
@@ -42,58 +42,58 @@ Authors:
 
 test("Check if the zero function of Float32x4 can change the parameter to 0.0", function() {
   var z1 = SIMD.Float32x4.zero();
-  equal(0.0, z1.x, "the value of z1.x should be 0.0");
-  equal(0.0, z1.y, "the value of z1.y should be 0.0");
-  equal(0.0, z1.z, "the value of z1.z should be 0.0");
-  equal(0.0, z1.w, "the value of z1.w should be 0.0");
+  equal(0.0, SIMD.Float32x4.extractLane(z1, 0), "the value of z1.x should be 0.0");
+  equal(0.0, SIMD.Float32x4.extractLane(z1, 1), "the value of z1.y should be 0.0");
+  equal(0.0, SIMD.Float32x4.extractLane(z1, 2), "the value of z1.z should be 0.0");
+  equal(0.0, SIMD.Float32x4.extractLane(z1, 3), "the value of z1.w should be 0.0");
 });
 
 test("Check if the splat function of Float32x4 can change the parameter to specified value", function () {
   var z2 = SIMD.Float32x4.splat(5.0);
-  equal(5.0, z2.x, "the value of z2.x should be 5.0");
-  equal(5.0, z2.y, "the value of z2.y should be 5.0");
-  equal(5.0, z2.z, "the value of z2.z should be 5.0");
-  equal(5.0, z2.w, "the value of z2.w should be 5.0");
+  equal(5.0, SIMD.Float32x4.extractLane(z2, 0), "the value of z2.x should be 5.0");
+  equal(5.0, SIMD.Float32x4.extractLane(z2, 1), "the value of z2.y should be 5.0");
+  equal(5.0, SIMD.Float32x4.extractLane(z2, 2), "the value of z2.z should be 5.0");
+  equal(5.0, SIMD.Float32x4.extractLane(z2, 3), "the value of z2.w should be 5.0");
 });
 
 test("Check if the fromFloat64x2 method of Float32x4 is valid", function () {
   var m = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
   var nMask = SIMD.Float64x2.fromFloat32x4(m);
   var n = SIMD.Float32x4.fromFloat64x2(nMask);
-  equal(9.0, n.x, "the value of n.x should be 9.0");
-  equal(10.0, n.y, "the value of n.y should be 10.0");
-  equal(0, n.z, "the value of n.z should be 0");
-  equal(0, n.w, "the value of n.w should be 0");
+  equal(9.0, SIMD.Float32x4.extractLane(n, 0), "the value of n.x should be 9.0");
+  equal(10.0, SIMD.Float32x4.extractLane(n, 1), "the value of n.y should be 10.0");
+  equal(0, SIMD.Float32x4.extractLane(n, 2), "the value of n.z should be 0");
+  equal(0, SIMD.Float32x4.extractLane(n, 3), "the value of n.w should be 0");
 });
 
 test("Check if the fromFloat64x2Bits method of Float32x4 is valid", function () {
   var m = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
   var nMask = SIMD.Float64x2.fromFloat32x4Bits(m);
   var n = SIMD.Float32x4.fromFloat64x2Bits(nMask);
-  equal(9.0, n.x, "the value of n.x should be 9.0");
-  equal(10.0, n.y, "the value of n.y should be 10.0");
-  equal(11.0, n.z, "the value of n.z should be 11.0");
-  equal(12.0, n.w, "the value of n.w should be 12.0");
+  equal(9.0, SIMD.Float32x4.extractLane(n, 0), "the value of n.x should be 9.0");
+  equal(10.0, SIMD.Float32x4.extractLane(n, 1), "the value of n.y should be 10.0");
+  equal(11.0, SIMD.Float32x4.extractLane(n, 2), "the value of n.z should be 11.0");
+  equal(12.0, SIMD.Float32x4.extractLane(n, 3), "the value of n.w should be 12.0");
 });
 
 test("Check if the fromInt32x4 method of Float32x4 is valid", function () {
   var m = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
   var nMask = SIMD.Int32x4.fromFloat32x4(m);
   var n = SIMD.Float32x4.fromInt32x4(nMask);
-  equal(9.0, n.x, "the value of n.x should be 9.0");
-  equal(10.0, n.y, "the value of n.y should be 10.0");
-  equal(11.0, n.z, "the value of n.z should be 11.0");
-  equal(12.0, n.w, "the value of n.w should be 12.0");
+  equal(9.0, SIMD.Float32x4.extractLane(n, 0), "the value of n.x should be 9.0");
+  equal(10.0, SIMD.Float32x4.extractLane(n, 1), "the value of n.y should be 10.0");
+  equal(11.0, SIMD.Float32x4.extractLane(n, 2), "the value of n.z should be 11.0");
+  equal(12.0, SIMD.Float32x4.extractLane(n, 3), "the value of n.w should be 12.0");
 });
 
 test("Check if the fromInt32x4Bits method of Float32x4 is valid", function () {
   var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
   var nMask = SIMD.Float32x4.fromInt32x4Bits(m);
   var n = SIMD.Int32x4.fromFloat32x4Bits(nMask);
-  equal(0x3F800000, n.x, "the value of n.x should be 0x3F800000");
-  equal(0x40000000, n.y, "the value of n.y should be 0x40000000");
-  equal(0x40400000, n.z, "the value of n.z should be 0x40400000");
-  equal(0x40800000, n.w, "the value of n.w should be 0x40800000");
+  equal(0x3F800000, SIMD.Int32x4.extractLane(n, 0), "the value of n.x should be 0x3F800000");
+  equal(0x40000000, SIMD.Int32x4.extractLane(n, 1), "the value of n.y should be 0x40000000");
+  equal(0x40400000, SIMD.Int32x4.extractLane(n, 2), "the value of n.z should be 0x40400000");
+  equal(0x40800000, SIMD.Int32x4.extractLane(n, 3), "the value of n.w should be 0x40800000");
 });
 
 test("Check if the select method of Float32x4 is valid", function () {
@@ -101,10 +101,10 @@ test("Check if the select method of Float32x4 is valid", function () {
   var t = SIMD.Float32x4(1.0, 2.0, 3.0, 4.0);
   var f = SIMD.Float32x4(5.0, 6.0, 7.0, 8.0);
   var s = SIMD.Float32x4.select(m, t, f);
-  equal(1.0, s.x, "the value of s.x should be 1.0");
-  equal(2.0, s.y, "the value of s.y should be 2.0");
-  equal(7.0, s.z, "the value of s.z should be 7.0");
-  equal(8.0, s.w, "the value of s.w should be 8.0");
+  equal(1.0, SIMD.Float32x4.extractLane(s, 0), "the value of s.x should be 1.0");
+  equal(2.0, SIMD.Float32x4.extractLane(s, 1), "the value of s.y should be 2.0");
+  equal(7.0, SIMD.Float32x4.extractLane(s, 2), "the value of s.z should be 7.0");
+  equal(8.0, SIMD.Float32x4.extractLane(s, 3), "the value of s.w should be 8.0");
 });
 
 test('Float32x4 store smi check', function() {

--- a/webapi/webapi-simd-nonw3c-tests/simd/float64x2.html
+++ b/webapi/webapi-simd-nonw3c-tests/simd/float64x2.html
@@ -45,106 +45,106 @@ test("Check if Float64x2 object can be creat successful", function () {
   notEqual(undefined, SIMD.Float64x2(1, 2), "the Float64x2 object should not be undefined");
   var f1 = SIMD.Float64x2(1.0, 2.0);
   var f2 = SIMD.Float64x2.check(f1);
-  equal(f1.x, f2.x, "the value of x should equal");
-  equal(f1.y, f2.y, "the value of y should equal");
+  equal(SIMD.Float64x2.extractLane(f1, 0), SIMD.Float64x2.extractLane(f2, 0), "the value of x should equal");
+  equal(SIMD.Float64x2.extractLane(f1, 1), SIMD.Float64x2.extractLane(f2, 1), "the value of y should equal");
 });
 
 test("Check if the zero function of Float64x2 can change the parameter to 0.0", function () {
   var z1 = SIMD.Float64x2.zero();
-  equal(0.0, z1.x, "the value of z1.x should be 0.0");
-  equal(0.0, z1.y, "the value of z1.y should be 0.0");
+  equal(0.0, SIMD.Float64x2.extractLane(z1, 0), "the value of z1.x should be 0.0");
+  equal(0.0, SIMD.Float64x2.extractLane(z1, 1), "the value of z1.y should be 0.0");
 });
 
 test("Check if the splat function of Float64x2 can change the parameter to specified value", function () {
   var z2 = SIMD.Float64x2.splat(5.0);
-  equal(5.0, z2.x, "the value of z2.x should be 5.0");
-  equal(5.0, z2.y, "the value of z2.y should be 5.0");
+  equal(5.0, SIMD.Float64x2.extractLane(z2, 0), "the value of z2.x should be 5.0");
+  equal(5.0, SIMD.Float64x2.extractLane(z2, 1), "the value of z2.y should be 5.0");
 });
 
 test("Check if the fromFloat32x4Bits method of Float64x2 is valid", function () {
   var m = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
   var nMask = SIMD.Float64x2.fromFloat32x4Bits(m);
   var n = SIMD.Float32x4.fromFloat64x2Bits(nMask);
-  equal(9.0, n.x, "the value of n.x should be 9.0");
-  equal(10.0, n.y, "the value of n.y should be 10.0");
-  equal(11.0, n.z, "the value of n.z should be 11.0");
-  equal(12.0, n.w, "the value of n.w should be 12.0");
+  equal(9.0, SIMD.Float32x4.extractLane(n, 0), "the value of n.x should be 9.0");
+  equal(10.0, SIMD.Float32x4.extractLane(n, 1), "the value of n.y should be 10.0");
+  equal(11.0, SIMD.Float32x4.extractLane(n, 2), "the value of n.z should be 11.0");
+  equal(12.0, SIMD.Float32x4.extractLane(n, 3), "the value of n.w should be 12.0");
 });
 
 test("Check if the fromInt32x4Bits method of Float64x2 is valid", function () {
   var m = SIMD.Int32x4(9, 10, 11, 12);
   var nMask = SIMD.Float64x2.fromInt32x4Bits(m);
   var n = SIMD.Int32x4.fromFloat64x2Bits(nMask);
-  equal(9, n.x, "the value of n.x should be 9");
-  equal(10, n.y, "the value of n.y should be 10");
-  equal(11, n.z, "the value of n.z should be 11");
-  equal(12, n.w, "the value of n.w should be 12");
+  equal(9, SIMD.Int32x4.extractLane(n, 0), "the value of n.x should be 9");
+  equal(10, SIMD.Int32x4.extractLane(n, 1), "the value of n.y should be 10");
+  equal(11, SIMD.Int32x4.extractLane(n, 2), "the value of n.z should be 11");
+  equal(12, SIMD.Int32x4.extractLane(n, 3), "the value of n.w should be 12");
 });
 
 test("Check if the fromInt32x4 method of Float64x2 is valid", function () {
   var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
   var nMask = SIMD.Float64x2.fromInt32x4(m);
   var n = SIMD.Int32x4.fromFloat64x2(nMask);
-  equal(0x3F800000, n.x, "the value of n.x should be 0x3F800000");
-  equal(0x40000000, n.y, "the value of n.y should be 0x40000000");
-  equal(0, n.z, "the value of n.z should be 0");
-  equal(0, n.w, "the value of n.w should be 0");
+  equal(0x3F800000, SIMD.Int32x4.extractLane(n, 0), "the value of n.x should be 0x3F800000");
+  equal(0x40000000, SIMD.Int32x4.extractLane(n, 1), "the value of n.y should be 0x40000000");
+  equal(0, SIMD.Int32x4.extractLane(n, 2), "the value of n.z should be 0");
+  equal(0, SIMD.Int32x4.extractLane(n, 3), "the value of n.w should be 0");
 });
 
 test("Check if the fromFloat32x4 method of Float64x2 is valid", function () {
   var m = SIMD.Float32x4(9.0, 10.0, 11.0, 12.0);
   var nMask = SIMD.Float64x2.fromFloat32x4(m);
   var n = SIMD.Float32x4.fromFloat64x2(nMask);
-  equal(9.0, n.x, "the value of n.x should be 9.0");
-  equal(10.0, n.y, "the value of n.y should be 10.0");
-  equal(0, n.z, "the value of n.z should be 0");
-  equal(0, n.w, "the value of n.w should be 0");
+  equal(9.0, SIMD.Float32x4.extractLane(n, 0), "the value of n.x should be 9.0");
+  equal(10.0, SIMD.Float32x4.extractLane(n, 1), "the value of n.y should be 10.0");
+  equal(0, SIMD.Float32x4.extractLane(n, 2), "the value of n.z should be 0");
+  equal(0, SIMD.Float32x4.extractLane(n, 3), "the value of n.w should be 0");
 });
 
 test("Check if the abs method of Float64x2 is valid", function () {
   var a = SIMD.Float64x2(-4.0, -3.0);
   var c = SIMD.Float64x2.abs(a);
-  equal(4.0, c.x, "the value of c.x should be 4.0");
-  equal(3.0, c.y, "the value of c.y should be 3.0");
+  equal(4.0, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be 4.0");
+  equal(3.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 3.0");
 });
 
 test("Check if the neg method of Float64x2 is valid", function () {
   var a = SIMD.Float64x2(-4.0, -3.0, -2.0, -1.0);
   var c = SIMD.Float64x2.neg(a);
-  equal(4.0, c.x, "the value of c.x should be 4.0");
-  equal(3.0, c.y, "the value of c.y should be 3.0");
+  equal(4.0, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be 4.0");
+  equal(3.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 3.0");
 });
 
 test("Check if the add method of Float64x2 is valid", function () {
   var a = SIMD.Float64x2(4.0, 3.0);
   var b = SIMD.Float64x2(10.0, 20.0);
   var c = SIMD.Float64x2.add(a, b);
-  equal(14.0, c.x, "the value of c.x should be 14.0");
-  equal(23.0, c.y, "the value of c.y should be 23.0");
+  equal(14.0, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be 14.0");
+  equal(23.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 23.0");
 });
 
 test("Check if the sub method is valid", function () {
   var a = SIMD.Float64x2(4.0, 3.0);
   var b = SIMD.Float64x2(10.0, 20.0);
   var c = SIMD.Float64x2.sub(a, b);
-  equal(-6.0, c.x, "the value of c.x should be -6.0");
-  equal(-17.0, c.y, "the value of c.y should be -17.0");
+  equal(-6.0, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be -6.0");
+  equal(-17.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be -17.0");
 });
 
 test("Check if the mul method of Float64x2 is valid", function () {
   var a = SIMD.Float64x2(4.0, 3.0);
   var b = SIMD.Float64x2(10.0, 20.0);
   var c = SIMD.Float64x2.mul(a, b);
-  equal(40.0, c.x, "the value of c.x should be 40.0");
-  equal(60.0, c.y, "the value of c.y should be 60.0");
+  equal(40.0, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be 40.0");
+  equal(60.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 60.0");
 });
 
 test("Check if the div method is valid", function () {
   var a = SIMD.Float64x2(4.0, 9.0);
   var b = SIMD.Float64x2(2.0, 3.0);
   var c = SIMD.Float64x2.div(a, b);
-  equal(2.0, c.x, "the value of c.x should be 2.0");
-  equal(3.0, c.y, "the value of c.y should be 3.0");
+  equal(2.0, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be 2.0");
+  equal(3.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 3.0");
 });
 
 test("Check if the clamp method of Float64x2 is valid", function () {
@@ -152,59 +152,59 @@ test("Check if the clamp method of Float64x2 is valid", function () {
   var lower = SIMD.Float64x2(2.0, 1.0);
   var upper = SIMD.Float64x2(2.5, 5.0);
   var c = SIMD.Float64x2.clamp(a, lower, upper);
-  equal(2.0, c.x, "the value of c.x should be 2.0");
-  equal(5.0, c.y, "the value of c.y should be 5.0");
+  equal(2.0, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be 2.0");
+  equal(5.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 5.0");
 });
 
 test("Check if the min method of Float64x2 is valid", function () {
   var a = SIMD.Float64x2(-20.0, 10.0, 30.0, 0.5);
   var lower = SIMD.Float64x2(2.0, 1.0, 50.0, 0.0);
   var c = SIMD.Float64x2.min(a, lower);
-  equal(-20.0, c.x, "the value of c.x should be -20.0");
-  equal(1.0, c.y, "the value of c.y should be 1.0");
+  equal(-20.0, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be -20.0");
+  equal(1.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 1.0");
 });
 
 test("Check if the max method of Float64x2 is valid", function () {
   var a = SIMD.Float64x2(-20.0, 10.0);
   var upper = SIMD.Float64x2(2.5, 5.0);
   var c = SIMD.Float64x2.max(a, upper);
-  equal(2.5, c.x, "the value of c.x should be 2.5");
-  equal(10.0, c.y, "the value of c.y should be 10.0");
+  equal(2.5, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be 2.5");
+  equal(10.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 10.0");
 });
 
 test("Check if the reciprocal method of Float64x2 is valid", function () {
   var a = SIMD.Float64x2(8.0, 4.0);
   var c = SIMD.Float64x2.reciprocal(a);
-  equal(0.125, c.x, "the value of c.x should be 0.125");
-  equal(0.250, c.y, "the value of c.y should be 0.250");
+  equal(0.125, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be 0.125");
+  equal(0.250, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 0.250");
 });
 
 test("Check if the reciprocalSqrt method of Float64x2 is valid", function () {
   var a = SIMD.Float64x2(1.0, 0.25);
   var c = SIMD.Float64x2.reciprocalSqrt(a);
-  equal(1.0, c.x, "the value of c.x should be 1.0");
-  equal(2.0, c.y, "the value of c.y should be 2.0");
+  equal(1.0, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be 1.0");
+  equal(2.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 2.0");
 });
 
 test("Check if the scale method of Float64x2 is valid", function () {
   var a = SIMD.Float64x2(8.0, 4.0, 2.0, -2.0);
   var c = SIMD.Float64x2.scale(a, 0.5);
-  equal(4.0, c.x, "the value of c.x should be 1.0");
-  equal(2.0, c.y, "the value of c.y should be 2.0");
+  equal(4.0, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be 1.0");
+  equal(2.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 2.0");
 });
 
 test("Check if the sqrt method of Float64x2 is valid", function () {
   var a = SIMD.Float64x2(16.0, 9.0);
   var c = SIMD.Float64x2.sqrt(a);
-  equal(4.0, c.x, "the value of c.x should be 4.0");
-  equal(3.0, c.y, "the value of c.y should be 3.0");
+  equal(4.0, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be 4.0");
+  equal(3.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 3.0");
 });
 
 test("Check if the shuffle  method of Float64x2 is valid", function () {
   var a = SIMD.Float64x2(4.0, 3.0);
   var xxxx = SIMD.Float64x2.shuffle(a, SIMD.XXXX);
-  equal(4.0, xxxx.x, "the value of xxxx.x should be 4.0");
-  equal(4.0, xxxx.y, "the value of xxxx.y should be 4.0");
+  equal(4.0, SIMD.Float64x2.extractLane(xxxx, 0), "the value of xxxx.x should be 4.0");
+  equal(4.0, SIMD.Float64x2.extractLane(xxxx, 1), "the value of xxxx.y should be 4.0");
 });
 
 test("Check if the shuffleMix  method of Float64x2 is valid", function () {
@@ -213,26 +213,26 @@ test("Check if the shuffleMix  method of Float64x2 is valid", function () {
   var xyxy = SIMD.Float64x2.shuffleMix(a, b, SIMD.XYXY);
   var zwzw = SIMD.Float64x2.shuffleMix(a, b, SIMD.ZWZW);
   var xxxx = SIMD.Float64x2.shuffleMix(a, b, SIMD.XXXX);
-  equal(1.0, xyxy.x, "the value of xyxy.x should be 1.0");
-  equal(5.0, xyxy.y, "the value of xyxy.y should be 5.0");
-  equal(1.0, zwzw.x, "the value of zwzw.x should be 1.0");
-  equal(6.0, zwzw.y, "the value of zwzw.y should be 6.0");
-  equal(1.0, xxxx.x, "the value of xxxx.x should be 1.0");
-  equal(5.0, xxxx.y, "the value of xxxx.y should be 5.0");
+  equal(1.0, SIMD.Float64x2.extractLane(xyxy, 0), "the value of xyxy.x should be 1.0");
+  equal(5.0, SIMD.Float64x2.extractLane(xyxy, 1), "the value of xyxy.y should be 5.0");
+  equal(1.0, SIMD.Float64x2.extractLane(zwzw, 0), "the value of zwzw.x should be 1.0");
+  equal(6.0, SIMD.Float64x2.extractLane(zwzw, 1), "the value of zwzw.y should be 6.0");
+  equal(1.0, SIMD.Float64x2.extractLane(xxxx, 0), "the value of xxxx.x should be 1.0");
+  equal(5.0, SIMD.Float64x2.extractLane(xxxx, 1), "the value of xxxx.y should be 5.0");
 });
 
 test("Check if the withX method of Float64x2 is valid", function () {
   var a = SIMD.Float64x2(16.0, 9.0);
-  var c = SIMD.Float64x2.withX(a, 20.0);
-  equal(20.0, c.x, "the value of c.x should be 20.0");
-  equal(9.0, c.y, "the value of c.y should be 9.0");
+  var c = SIMD.Float64x2.replaceLane(a, 0, 20.0);
+  equal(20.0, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be 20.0");
+  equal(9.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 9.0");
 });
 
 test("Check if the withY method of Float64x2 is valid", function () {
   var a = SIMD.Float64x2(16.0, 9.0);
-  var c = SIMD.Float64x2.withY(a, 20.0);
-  equal(16.0, c.x, "the value of c.x should be 16.0");
-  equal(20.0, c.y, "the value of c.y should be 20.0");
+  var c = SIMD.Float64x2.replaceLane(a, 1, 20.0);
+  equal(16.0, SIMD.Float64x2.extractLane(c, 0), "the value of c.x should be 16.0");
+  equal(20.0, SIMD.Float64x2.extractLane(c, 1), "the value of c.y should be 20.0");
 });
 
 test("Check if the lessThan method of Float64x2 is valid", function () {
@@ -240,10 +240,10 @@ test("Check if the lessThan method of Float64x2 is valid", function () {
   var n = SIMD.Float64x2(2.0, 2.0);
   var cmp;
   cmp = SIMD.Float64x2.lessThan(m, n);
-  equal(-1, cmp.x, "the value of cmp.x should be -1");
-  equal(-1, cmp.y, "the value of cmp.y should be -1");
-  equal(0, cmp.z, "the value of cmp.z should be 0");
-  equal(0, cmp.w, "the value of cmp.w should be 0");
+  equal(-1, SIMD.Float64x2.extractLane(cmp, 0), "the value of cmp.x should be -1");
+  equal(-1, SIMD.Float64x2.extractLane(cmp, 1), "the value of cmp.y should be -1");
+  equal(0, SIMD.Float64x2.extractLane(cmp, 2), "the value of cmp.z should be 0");
+  equal(0, SIMD.Float64x2.extractLane(cmp, 3), "the value of cmp.w should be 0");
 });
 
 test("Check if the lessThanOrEqual method of Float64x2 is valid", function () {
@@ -251,10 +251,10 @@ test("Check if the lessThanOrEqual method of Float64x2 is valid", function () {
   var n = SIMD.Float64x2(2.0, 2.0);
   var cmp;
   cmp = SIMD.Float64x2.lessThanOrEqual(m, n);
-  equal(-1, cmp.x, "the value of cmp.x should be -1");
-  equal(-1, cmp.y, "the value of cmp.y should be -1");
-  equal(-1, cmp.z, "the value of cmp.z should be -1");
-  equal(-1, cmp.w, "the value of cmp.w should be -1");
+  equal(-1, SIMD.Float64x2.extractLane(cmp, 0), "the value of cmp.x should be -1");
+  equal(-1, SIMD.Float64x2.extractLane(cmp, 1), "the value of cmp.y should be -1");
+  equal(-1, SIMD.Float64x2.extractLane(cmp, 2), "the value of cmp.z should be -1");
+  equal(-1, SIMD.Float64x2.extractLane(cmp, 3), "the value of cmp.w should be -1");
 });
 
 test("Check if the equal method of Float64x2 is valid", function () {
@@ -262,10 +262,10 @@ test("Check if the equal method of Float64x2 is valid", function () {
   var n = SIMD.Float64x2(2.0, 2.0);
   var cmp;
   cmp = SIMD.Float64x2.equal(m, n);
-  equal(0, cmp.x, "the value of cmp.x should be 0");
-  equal(0, cmp.y, "the value of cmp.y should be 0");
-  equal(-1, cmp.z, "the value of cmp.z should be -1");
-  equal(-1, cmp.w, "the value of cmp.w should be -1");
+  equal(0, SIMD.Float64x2.extractLane(cmp, 0), "the value of cmp.x should be 0");
+  equal(0, SIMD.Float64x2.extractLane(cmp, 1), "the value of cmp.y should be 0");
+  equal(-1, SIMD.Float64x2.extractLane(cmp, 2), "the value of cmp.z should be -1");
+  equal(-1, SIMD.Float64x2.extractLane(cmp, 3), "the value of cmp.w should be -1");
 });
 
 test("Check if the notEqual method of Float64x2 is valid", function () {
@@ -273,10 +273,10 @@ test("Check if the notEqual method of Float64x2 is valid", function () {
   var n = SIMD.Float64x2(2.0, 2.0);
   var cmp;
   cmp = SIMD.Float64x2.notEqual(m, n);
-  equal(-1, cmp.x, "the value of cmp.x should be -1");
-  equal(-1, cmp.y, "the value of cmp.y should be -1");
-  equal(0, cmp.z, "the value of cmp.z should be 0");
-  equal(0, cmp.w, "the value of cmp.w should be 0");
+  equal(-1, SIMD.Float64x2.extractLane(cmp, 0), "the value of cmp.x should be -1");
+  equal(-1, SIMD.Float64x2.extractLane(cmp, 1), "the value of cmp.y should be -1");
+  equal(0, SIMD.Float64x2.extractLane(cmp, 2), "the value of cmp.z should be 0");
+  equal(0, SIMD.Float64x2.extractLane(cmp, 3), "the value of cmp.w should be 0");
 });
 
 test("Check if the greaterThanOrEqual  method of Float64x2 is valid", function () {
@@ -284,10 +284,10 @@ test("Check if the greaterThanOrEqual  method of Float64x2 is valid", function (
   var n = SIMD.Float64x2(2.0, 2.0);
   var cmp;
   cmp = SIMD.Float64x2.greaterThanOrEqual (m, n);
-  equal(0, cmp.x, "the value of cmp.x should be 0");
-  equal(0, cmp.y, "the value of cmp.y should be 0");
-  equal(-1, cmp.z, "the value of cmp.z should be -1");
-  equal(-1, cmp.w, "the value of cmp.w should be -1");
+  equal(0, SIMD.Float64x2.extractLane(cmp, 0), "the value of cmp.x should be 0");
+  equal(0, SIMD.Float64x2.extractLane(cmp, 1), "the value of cmp.y should be 0");
+  equal(-1, SIMD.Float64x2.extractLane(cmp, 2), "the value of cmp.z should be -1");
+  equal(-1, SIMD.Float64x2.extractLane(cmp, 3), "the value of cmp.w should be -1");
 });
 
 test("Check if the greaterThan  method of Float64x2 is valid", function () {
@@ -295,10 +295,10 @@ test("Check if the greaterThan  method of Float64x2 is valid", function () {
   var n = SIMD.Float64x2(2.0, 2.0);
   var cmp;
   cmp = SIMD.Float64x2.greaterThan (m, n);
-  equal(0, cmp.x, "the value of cmp.x should be 0");
-  equal(0, cmp.y, "the value of cmp.y should be 0");
-  equal(0, cmp.z, "the value of cmp.z should be 0");
-  equal(0, cmp.w, "the value of cmp.w should be 0");
+  equal(0, SIMD.Float64x2.extractLane(cmp, 0), "the value of cmp.x should be 0");
+  equal(0, SIMD.Float64x2.extractLane(cmp, 1), "the value of cmp.y should be 0");
+  equal(0, SIMD.Float64x2.extractLane(cmp, 2), "the value of cmp.z should be 0");
+  equal(0, SIMD.Float64x2.extractLane(cmp, 3), "the value of cmp.w should be 0");
 });
 
 test("Check if the select method of Float64x2 is valid", function () {
@@ -306,16 +306,16 @@ test("Check if the select method of Float64x2 is valid", function () {
   var t = SIMD.Float64x2(1.0, 2.0);
   var f = SIMD.Float64x2(5.0, 6.0);
   var s = SIMD.Float64x2.select(m, t, f);
-  equal(1.0, s.x, "the value of s.x should be 1");
-  equal(6.0, s.y, "the value of s.y should be 6");
+  equal(1.0, SIMD.Float64x2.extractLane(s, 0), "the value of s.x should be 1");
+  equal(6.0, SIMD.Float64x2.extractLane(s, 1), "the value of s.y should be 6");
 });
 
 test("Check if the bitsToInt32x4 method of Float64x2 is valid", function () {
   var t = SIMD.Float64x2(1.0, 2.0);
   var a = SIMD.Float64x2.bitsToInt32x4(t);
   var s = SIMD.Int32x4.bitsToFloat64x2(a);
-  equal(1, s.x, "the value of s.x should be 1");
-  equal(2, s.y, "the value of s.y should be 2");
+  equal(1, SIMD.Float64x2.extractLane(s, 0), "the value of s.x should be 1");
+  equal(2, SIMD.Float64x2.extractLane(s, 1), "the value of s.y should be 2");
 });
 
 </script>

--- a/webapi/webapi-simd-nonw3c-tests/simd/int32x4.html
+++ b/webapi/webapi-simd-nonw3c-tests/simd/int32x4.html
@@ -45,54 +45,54 @@ test("Check if Int32x4 object can be creat successful", function () {
   notEqual(undefined, SIMD.Int32x4(1, 2, 3, 4), "the Int32x4 object should not be undefined");
   var f1 = SIMD.Int32x4(1, 2, 3, 4);
   var f2 = SIMD.Int32x4.check(f1);
-  equal(f1.x, f2.x, "the value of x should equal");
-  equal(f1.y, f2.y, "the value of y should equal");
-  equal(f1.z, f2.z, "the value of z should equal");
-  equal(f1.w, f2.w, "the value of w should equal");
+  equal(SIMD.Int32x4.extractLane(f1, 0), SIMD.Int32x4.extractLane(f2, 0), "the value of x should equal");
+  equal(SIMD.Int32x4.extractLane(f1, 1), SIMD.Int32x4.extractLane(f2, 1), "the value of y should equal");
+  equal(SIMD.Int32x4.extractLane(f1, 2), SIMD.Int32x4.extractLane(f2, 2), "the value of z should equal");
+  equal(SIMD.Int32x4.extractLane(f1, 3), SIMD.Int32x4.extractLane(f2, 3), "the value of w should equal");
 });
 
 test("Check if the x value of Int32x4 object can be got", function () {
   var u11 = SIMD.Int32x4(1, 2, 3, 4);
-  equal(1, u11.x, "the value of u11.x should be 1");
+  equal(1, SIMD.Int32x4.extractLane(u11, 0), "the value of u11.x should be 1");
   var u21 = new SIMD.Int32x4(1, 2, 3, 4);
-  equal(1, u21.x, "the value of u21.x should be 1");
+  equal(1, SIMD.Int32x4.extractLane(u21, 0), "the value of u21.x should be 1");
 });
 
 test("Check if the z value of Int32x4 object can be got", function () {
   var u12 = SIMD.Int32x4(1, 2, 3, 4);
-  equal(2, u12.y, "the value of u12.y should be 2");
+  equal(2, SIMD.Int32x4.extractLane(u12, 1), "the value of u12.y should be 2");
   var u22 = new SIMD.Int32x4(1, 2, 3, 4);
-  equal(2, u22.y, "the value of u22.y should be 2");
+  equal(2, SIMD.Int32x4.extractLane(u22, 1), "the value of u22.y should be 2");
 });
 
 test("Check if the w value of Int32x4 object can be got", function () {
   var u13 = SIMD.Int32x4(1, 2, 3, 4);
-  equal(3, u13.z, "the value of u13.z should be 3");
+  equal(3, SIMD.Int32x4.extractLane(u13, 2), "the value of u13.z should be 3");
   var u23 = new SIMD.Int32x4(1, 2, 3, 4);
-  equal(3, u23.z, "the value of u23.z should be 3");
+  equal(3, SIMD.Int32x4.extractLane(u23, 2), "the value of u23.z should be 3");
 });
 
 test("Check if the y value of Int32x4 object can be got", function () {
   var u14 = SIMD.Int32x4(1, 2, 3, 4);
-  equal(4, u14.w, "the value of u14.w should be 4");
+  equal(4, SIMD.Int32x4.extractLane(u14, 3), "the value of u14.w should be 4");
   var u24 = new SIMD.Int32x4(1, 2, 3, 4);
-  equal(4, u24.w, "the value of u24.w should be 4");
+  equal(4, SIMD.Int32x4.extractLane(u24, 3), "the value of u24.w should be 4");
 });
 
 test("Check if the bool function of Int32x4 can change the object to (-1, 0, -1, 0)", function () {
   var u3 = SIMD.Int32x4.bool(true, false, true, false);
-  equal(-1, u3.x, "the value of u3.x should be -1");
-  equal(0, u3.y, "the value of u3.y should be 0");
-  equal(-1, u3.z, "the value of u3.z should be -1");
-  equal(0, u3.w, "the value of u3.w should be 0");
+  equal(-1, SIMD.Int32x4.extractLane(u3, 0), "the value of u3.x should be -1");
+  equal(0, SIMD.Int32x4.extractLane(u3, 1), "the value of u3.y should be 0");
+  equal(-1, SIMD.Int32x4.extractLane(u3, 2), "the value of u3.z should be -1");
+  equal(0, SIMD.Int32x4.extractLane(u3, 3), "the value of u3.w should be 0");
 });
 
 test("Check if the splat function of Int32x4can change the parameter to specified value", function () {
   var u4 = SIMD.Int32x4.splat(4);
-  equal(4, u4.x, "the value of u4.x should be 4");
-  equal(4, u4.y, "the value of u4.y should be 4");
-  equal(4, u4.z, "the value of u4.z should be 4");
-  equal(4, u4.w, "the value of u4.w should be 4");
+  equal(4, SIMD.Int32x4.extractLane(u4, 0), "the value of u4.x should be 4");
+  equal(4, SIMD.Int32x4.extractLane(u4, 1), "the value of u4.y should be 4");
+  equal(4, SIMD.Int32x4.extractLane(u4, 2), "the value of u4.z should be 4");
+  equal(4, SIMD.Int32x4.extractLane(u4, 3), "the value of u4.w should be 4");
 });
 
 test("Check if the flagX of Int32x4 object can be got and type of boolean", function () {
@@ -127,39 +127,39 @@ test("Check if the fromFloat64x2 method of Int32x4 is valid", function () {
   var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
   var nMask = SIMD.Float64x2.fromInt32x4(m);
   var n = SIMD.Int32x4.fromFloat64x2(nMask);
-  equal(0x3F800000, n.x, "the value of n.x should be 0x3F800000");
-  equal(0x40000000, n.y, "the value of n.y should be 0x40000000");
-  equal(0, n.z, "the value of n.z should be 0");
-  equal(0, n.w, "the value of n.w should be 0");
+  equal(0x3F800000, SIMD.Int32x4.extractLane(n, 0), "the value of n.x should be 0x3F800000");
+  equal(0x40000000, SIMD.Int32x4.extractLane(n, 1), "the value of n.y should be 0x40000000");
+  equal(0, SIMD.Int32x4.extractLane(n, 2), "the value of n.z should be 0");
+  equal(0, SIMD.Int32x4.extractLane(n, 3), "the value of n.w should be 0");
 });
 
 test("Check if the fromFloat64x2Bits method of Int32x4 is valid", function () {
   var m = SIMD.Int32x4(9, 10, 11, 12);
   var nMask = SIMD.Float64x2.fromInt32x4Bits(m);
   var n = SIMD.Int32x4.fromFloat64x2Bits(nMask);
-  equal(9, n.x, "the value of n.x should be 9");
-  equal(10, n.y, "the value of n.y should be 10");
-  equal(11, n.z, "the value of n.z should be 11");
-  equal(12, n.w, "the value of n.w should be 12");
+  equal(9, SIMD.Int32x4.extractLane(n, 0), "the value of n.x should be 9");
+  equal(10, SIMD.Int32x4.extractLane(n, 1), "the value of n.y should be 10");
+  equal(11, SIMD.Int32x4.extractLane(n, 2), "the value of n.z should be 11");
+  equal(12, SIMD.Int32x4.extractLane(n, 3), "the value of n.w should be 12");
 });
 
 test("Check if the fromFloat32x4 method of Int32x4 is valid", function () {
   var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
   var nMask = SIMD.Float32x4.fromInt32x4(m);
   var n = SIMD.Int32x4.fromFloat32x4(nMask);
-  equal(0x3F800000, n.x, "the value of n.x should be 0x3F800000");
-  equal(0x40000000, n.y, "the value of n.y should be 0x40000000");
-  equal(0x40400000, n.z, "the value of n.z should be 0");
-  equal(0x40800000, n.w, "the value of n.w should be 0");
+  equal(0x3F800000, SIMD.Int32x4.extractLane(n, 0), "the value of n.x should be 0x3F800000");
+  equal(0x40000000, SIMD.Int32x4.extractLane(n, 1), "the value of n.y should be 0x40000000");
+  equal(0x40400000, SIMD.Int32x4.extractLane(n, 2), "the value of n.z should be 0");
+  equal(0x40800000, SIMD.Int32x4.extractLane(n, 3), "the value of n.w should be 0");
 });
 
 test("Check if the fromFloat32x4Bits method of Int32x4 is valid", function () {
   var m = SIMD.Int32x4(0x3F800000, 0x40000000, 0x40400000, 0x40800000);
   var nMask = SIMD.Float32x4.fromInt32x4Bits(m);
   var n = SIMD.Int32x4.fromFloat32x4Bits(nMask);
-  equal(0x3F800000, n.x, "the value of n.x should be 0x3F800000");
-  equal(0x40000000, n.y, "the value of n.y should be 0x40000000");
-  equal(0x40400000, n.z, "the value of n.z should be 0");
-  equal(0x40800000, n.w, "the value of n.w should be 0");
+  equal(0x3F800000, SIMD.Int32x4.extractLane(n, 0), "the value of n.x should be 0x3F800000");
+  equal(0x40000000, SIMD.Int32x4.extractLane(n, 1), "the value of n.y should be 0x40000000");
+  equal(0x40400000, SIMD.Int32x4.extractLane(n, 2), "the value of n.z should be 0");
+  equal(0x40800000, SIMD.Int32x4.extractLane(n, 3), "the value of n.w should be 0");
 });
 </script>


### PR DESCRIPTION
Crosswalk have added extractLane and replaceLane for SIMD.Float32x4, SIMD.Int32x4
(https://github.com/crosswalk-project/v8-crosswalk/pull/118), so there are some changes
for SIMD.
 -  m.x/y/z/w are changed to SIMD.XXXX.extractLane(m, 0/1/2/3)
 -  m.withX/Y/Z/W are changed to SIMD.XXXX.replaceLane(m, 0/1/2/3, value)

Impacted TCs num(approved): New 0, Update 1069, Delete 0
Unit test Platform: Crosswalk Project for Android 17.45.437.0
Unit test result summary: Pass 1459, Fail 44, Blocked 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5731