### PR TITLE
Update the correct .deb file path for deb packages

### DIFF
--- a/tools/build/pack_deb.py
+++ b/tools/build/pack_deb.py
@@ -408,7 +408,7 @@ def packDEB(build_json=None, app_src=None, app_dest=None, app_name=None):
         return False
 
     # After build successfully, copy the .deb from app_src+"pkg" to app_dest
-    if not doCMD("cp -rf %s/*deb %s" % (app_src, app_dest)):
+    if not doCMD("cp -rf %s/pkg/*.deb %s" % (app_src, app_dest)):
         return False
     return True
 


### PR DESCRIPTION
Update the correct file path of .deb files when packing the test suites
of Crosswalk for Linux.

Related to: XWALK-5783