### PR TITLE
[apptools-android] Add tests to test default splash screen for apptools android

### DIFF
--- a/apptools/apptools-android-tests/apptools/Custom_Icon_Splash_Screen.html
+++ b/apptools/apptools-android-tests/apptools/Custom_Icon_Splash_Screen.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Yun, Liu<yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>Custom_Icon_Splash_Screen</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<body>
+  <p>
+    <strong>Test steps:</strong>
+  </p>
+  <ol>
+    <li>If org.xwalk.test exists in apptools-android-tests/tools/ directory, remove it <br/>
+        Then run below commands under apptools-android-tests/tools/ directory: <br/>
+        On Linux or OS X host: <br/>
+        &nbsp; &nbsp; Shared Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
+        &nbsp; &nbsp; Embedded Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
+        &nbsp; &nbsp; $ cd org.xwalk.test <br/>
+        &nbsp; &nbsp; Update "src" to "../../../icon/icon.jpg" for "icons" field in app/manifest.json file <br/>
+        &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
+        On Windows host: <br/>
+        &nbsp; &nbsp; Shared Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
+        &nbsp; &nbsp; Embedded Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
+        &nbsp; &nbsp; $ cd org.xwalk.test <br/>
+        &nbsp; &nbsp; Update "src" to "../../../icon/icon.jpg" for "icons" field in app\manifest.json file <br/>
+        &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
+        Shared Mode: <br/>
+        &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
+        &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
+        Embedded Mode or Lite Mode: <br/>
+        &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
+        &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
+        Launch the app on android device
+    </li>
+  </ol>
+  <p>
+    <strong>Expected Results:</strong>
+  </p>
+  <ol>
+    <li>While the app is starting, the app Custom icon "../../icon/icon.jpg" must be displayed centred on the screen.</li>
+  </ol>
+  <p>Note: On faster devices, the splash screen will only be displayed on first start. After that the startup is faster, so the splash might not be visible any more.</p>
+</body>
+

--- a/apptools/apptools-android-tests/apptools/Default_Splash_Screen.html
+++ b/apptools/apptools-android-tests/apptools/Default_Splash_Screen.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Yun, Liu<yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>Default_Splash_Screen</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<body>
+  <p>
+    <strong>Test steps:</strong>
+  </p>
+  <ol>
+    <li>If org.xwalk.test exists in apptools-android-tests/tools/ directory, remove it <br/>
+        Then run below commands under apptools-android-tests/tools/ directory: <br/>
+        On Linux or OS X host: <br/>
+        &nbsp; &nbsp; Shared Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-shared <br/>
+        &nbsp; &nbsp; Embedded Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite <br/>
+        &nbsp; &nbsp; $ cd org.xwalk.test <br/>
+        &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
+        On Windows host: <br/>
+        &nbsp; &nbsp; Shared Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-shared <br/>
+        &nbsp; &nbsp; Embedded Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test <br/>
+        &nbsp; &nbsp; Lite Mode: <br/>
+        &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite <br/>
+        &nbsp; &nbsp; $ cd org.xwalk.test <br/>
+        &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
+        Shared Mode: <br/>
+        &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>
+        &nbsp; &nbsp; Install shared mode app on android device which is "x86" architecture <br/>
+        Embedded Mode or Lite Mode: <br/>
+        &nbsp; &nbsp; Install arm app on android device which is "arm" architecture <br/>
+        &nbsp; &nbsp; Install x86 app on android device which is "x86" architecture <br/>
+        Launch the app on android device
+    </li>
+  </ol>
+  <p>
+    <strong>Expected Results:</strong>
+  </p>
+  <ol>
+    <li>While the app is starting, the app icon must be displayed centred on the screen.</li>
+  </ol>
+  <p>Note: On faster devices, the splash screen will only be displayed on first start. After that the startup is faster, so the splash might not be visible any more.</p>
+</body>
+

--- a/apptools/apptools-android-tests/tests.full.xml
+++ b/apptools/apptools-android-tests/tests.full.xml
@@ -413,6 +413,16 @@ reduce the APK size" status="approved" type="Functional">
           <test_script_entry>/opt/apptools-android-tests/apptools/Manifest_Background_Color.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Default_Splash_Screen" priority="P1" purpose="Android - Validate if app can be started with default splash screen" status="approved" type="Functional">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/apptools/Default_Splash_Screen.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Custom_Icon_Splash_Screen" priority="P1" purpose="Android - Validate if app can be started with custom icon splash screen" status="approved" type="Functional">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/apptools/Custom_Icon_Splash_Screen.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/apptools/apptools-android-tests/tests.xml
+++ b/apptools/apptools-android-tests/tests.xml
@@ -413,6 +413,16 @@ reduce the APK size">
           <test_script_entry>/opt/apptools-android-tests/apptools/Manifest_Background_Color.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Default_Splash_Screen" purpose="Android - Validate if app can be started with default splash screen">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/apptools/Default_Splash_Screen.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/CLI" execution_type="manual" id="Custom_Icon_Splash_Screen" purpose="Android - Validate if app can be started with custom icon splash screen">
+        <description>
+          <test_script_entry>/opt/apptools-android-tests/apptools/Custom_Icon_Splash_Screen.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5558