### PR TITLE
[cordova] Add tests for googlemaps plugin

### DIFF
--- a/cordova/cordova-sampleapp-android-tests/sampleapp/GoogleMapsPlugin.html
+++ b/cordova/cordova-sampleapp-android-tests/sampleapp/GoogleMapsPlugin.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<meta charset="utf-8">
+<meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, width=device-width">
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Li, Hao" href="mailto:haox.li@intel.com">
+<link rel="help" href="https://crosswalk-project.org/jira/browse/XWALK-5779">
+<div>
+  <h4>Precondition</h4>
+  <ul>
+    <li>Cordova Android 4+, CLI 5+
+      <div>$ sudo npm install cordova -g</div>
+    </li>
+    <li>minSdkVersion 16 (4.1 is the minimum supported version)</li>
+    <li>Set the environment path to the <span style="font-weight: bold;">Android SDK Platform-tools*</span> and <span style="font-weight: bold;">**Android SDK Build-tools</span></li>
+    <li>Install <a href="http://ant.apache.org/">Apache Ant</a></li>
+    <li>Set the JAVA_HOME to the environment path</li>
+  </ul>
+  <div>Refer to <a href="https://github.com/mapsplugin/cordova-plugin-googlemaps/wiki/Tutorial-for-Mac">
+                https://github.com/mapsplugin/cordova-plugin-googlemaps/wiki/Tutorial-for-Mac</a></div>
+  <h4>Test Steps</h4>
+  <ol>
+    <li>Obtain the Google Maps API key for Android
+      <ul>
+        <li>Find the keytool
+          <div> ~/.android/</div></li>
+        <li>Display the SHA-1 fingerprint
+          <div>keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android</div></li>
+        <li>Go to <a href="https://code.google.com/apis/console/">https://code.google.com/apis/console/</a></li>
+        <li>Register your project</li>
+        <li>Turn on <span style="font-weight: bold;">Google Maps Android API v2</span>.</li>
+        <li>Go to <span style="font-weight: bold;">API Access page</span>.</li>
+        <li>Click [Create New Android Key] button</li>
+        <li>In the resulting dialog, enter the SHA-1 fingerprint, then a semicolon, then the package name: org.xwalk.hellomap</li>
+        <li>Write down the API Key See [the official document: Get an Android certificate and the Google Maps API key]</li>
+      </ul>
+    </li>
+    <li>Build
+      <ul>
+        <li>cd res/GoogleMapsPlugin</li>
+        <li>./google-maps-plugin.py -k [google Maps API key]</li>
+      </ul>
+    </li>
+    <p>Details <a href="https://github.com/mapsplugin/cordova-plugin-googlemaps/wiki/Tutorial-for-CrossWalk-Webview-Plugin-%28Android%29">
+                 https://github.com/mapsplugin/cordova-plugin-googlemaps/wiki/Tutorial-for-CrossWalk-Webview-Plugin-%28Android%29</a></p>
+    <li>Install and Run
+      <ul>
+        <li>The apk can be installed and uninstalled successfully</li>
+        <li>Launch the app, the google map load successfully</li>
+        <li>Click full screen, the google map should change to full screen, full screen button is hiddened</li>
+      </ul>
+    </li>
+  </ol>
+</div>
+
+

--- a/cordova/cordova-sampleapp-android-tests/sampleapp/res/GoogleMapsPlugin/COPYING
+++ b/cordova/cordova-sampleapp-android-tests/sampleapp/res/GoogleMapsPlugin/COPYING
@@ -1,0 +1,6 @@
+The index.html comes from
+https://github.com/mapsplugin/cordova-plugin-googlemaps
+without any modification.
+
+The tests are dual-licensed under:
+https://github.com/mapsplugin/cordova-plugin-googlemaps/blob/master/LICENSE

--- a/cordova/cordova-sampleapp-android-tests/sampleapp/res/GoogleMapsPlugin/REAMDE.md
+++ b/cordova/cordova-sampleapp-android-tests/sampleapp/res/GoogleMapsPlugin/REAMDE.md
@@ -1,0 +1,11 @@
+## Usecase Design
+
+This sample demonstrates GoogleMaps plugin functionalities, include:
+
+* Set z order of web view with the preference ZOrderOnTop
+* Cordova GoogleMaps plugin for Android
+
+This usecase covers following methods:
+
+* zOrderOnTop
+* plugin.google.maps.Map.getMap

--- a/cordova/cordova-sampleapp-android-tests/sampleapp/res/GoogleMapsPlugin/google-maps-plugin.py
+++ b/cordova/cordova-sampleapp-android-tests/sampleapp/res/GoogleMapsPlugin/google-maps-plugin.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2015 Intel Corporation.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of works must retain the original copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the original copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of Intel Corporation nor the names of its contributors
+#   may be used to endorse or promote products derived from this work without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Authors:
+#         Li, Hao <haox.li@intel.com>
+
+import os
+import commands
+import sys
+import shutil
+import time
+import glob
+from optparse import OptionParser, make_option
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+BUILD_TMP = "/tmp"
+
+def buildHelloMap(key):
+    if not os.path.exists(BUILD_TMP):
+        os.mkdir(BUILD_TMP)
+
+    os.chdir(BUILD_TMP)
+    build_src = BUILD_TMP +"/HelloMap"
+    if os.path.exists(build_src):
+        shutil.rmtree(build_src)
+
+    os.system('cordova create HelloMap com.example.hellomap HelloMap')
+    os.chdir(build_src)
+    os.system('cordova platform add android')
+    os.system('cordova plugin add %s/../../tools/cordova-plugin-crosswalk-webview' % SCRIPT_DIR)
+    os.system('cordova plugin add https://github.com/mapsplugin/cordova-plugin-googlemaps --variable API_KEY_FOR_ANDROID="%s"' % key)
+    shutil.copyfile(SCRIPT_DIR + '/index.html', build_src  + '/www/index.html')
+    # Update android:theme="@android:style/Theme.Black.NoTitleBar" to android:theme="@android:style/Theme.Translucent.NoTitleBar" in AndroidManifest.xml
+    os.system('sed -i "s/%s/%s/g" %s' % ("@android:style\/Theme.Black.NoTitleBar", "@android:style\/Theme.Translucent.NoTitleBar", build_src + "/platforms/android/AndroidManifest.xml"))
+    # Set zOrderOnTop in config.xml
+    lines = open(build_src + '/config.xml', 'r').readlines()
+    lines.insert(-1, '    <preference name="xwalkZOrderOnTop" value="true" />\n')
+    f = open(build_src + '/config.xml', 'w')
+    f.writelines(lines)
+    f.close()
+    os.system('cordova build android')
+    time.sleep(5)
+    files = glob.glob(os.path.join(build_src + "/platforms/android/build/outputs/apk", "*-debug.apk"))
+    if len(files) == 0:
+        print("No apk build in %s/platforms/android/build/outputs/apk" % build_src)
+        return
+    for apk in files:
+        shutil.copy2(apk, SCRIPT_DIR)
+
+def main():
+    try:
+        usage = "Usage: ./google-maps-plugin.py -k <key>"
+        opts_parser = OptionParser(usage=usage)
+        opts_parser.add_option(
+            "-k",
+            "--key",
+            dest="key",
+            help="Google Maps API key")
+        global BUILD_PARAMETERS
+        (BUILD_PARAMETERS, args) = opts_parser.parse_args()
+
+        if not BUILD_PARAMETERS.key:
+            print("Google Maps API key is missing.")
+            sys.exit(1)
+
+        buildHelloMap(BUILD_PARAMETERS.key)
+
+    except Exception as e:
+        print "Got wrong options: %s, exit ..." % e
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/cordova/cordova-sampleapp-android-tests/sampleapp/res/GoogleMapsPlugin/index.html
+++ b/cordova/cordova-sampleapp-android-tests/sampleapp/res/GoogleMapsPlugin/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script type="text/javascript" src="cordova.js"></script>
+    <script type="text/javascript">
+    var map;
+    document.addEventListener("deviceready", function() {
+      var div = document.getElementById("map_canvas");
+
+      // Initialize the map view
+      map = plugin.google.maps.Map.getMap(div);
+
+      // Wait until the map is ready status.
+      map.addEventListener(plugin.google.maps.event.MAP_READY, onMapReady);
+    }, false);
+
+    function onMapReady() {
+      var button = document.getElementById("button");
+      button.addEventListener("click", onBtnClicked, false);
+    }
+
+    function onBtnClicked() {
+      map.showDialog();
+    }
+    </script>
+  </head>
+  <body>
+    <h3>PhoneGap-GoogleMaps-Plugin</h3>
+    <div style="width:100%;height:400px" id="map_canvas"></div>
+    <button id="button">Full Screen</button>
+  </body>
+</html>

--- a/cordova/cordova-sampleapp-android-tests/suite.json
+++ b/cordova/cordova-sampleapp-android-tests/suite.json
@@ -43,6 +43,7 @@
         "PACK-TOOL-ROOT/../VERSION": "VERSION",
         "PACK-TOOL-ROOT/cordova_plugins/cordova-plugin-crosswalk-webview": "tools/cordova-plugin-crosswalk-webview",
         "PACK-TOOL-ROOT/resources/xsl": ".",
+        "sampleapp/res/GoogleMapsPlugin": "res/GoogleMapsPlugin",
         "README.md": "README.md",
         "arch.txt": "arch.txt",
         "cordova-4.x": "cordova-version",

--- a/cordova/cordova-sampleapp-android-tests/tests.4.x.xml
+++ b/cordova/cordova-sampleapp-android-tests/tests.4.x.xml
@@ -142,6 +142,11 @@
           <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/Crosswalk_Cordova_SampleApp_Eh_AppFunction.html </test_script_entry>
         </description>
       </testcase>
+      <testcase component="Cordova Sample Apps/GoogleMapsPlugin" execution_type="manual" id="GoogleMapsPlugin" purpose="Validate Cordova GoogleMaps plugin for iOS and Android">
+        <description>
+          <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/GoogleMapsPlugin.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/cordova/cordova-sampleapp-android-tests/tests.full.xml
+++ b/cordova/cordova-sampleapp-android-tests/tests.full.xml
@@ -205,6 +205,11 @@
           <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/Crosswalk_Cordova_SampleApp_PrivateNotes_Orientation.html </test_script_entry>
         </description>
       </testcase>
+      <testcase component="Cordova Sample Apps/GoogleMapsPlugin" execution_type="manual" id="GoogleMapsPlugin" purpose="Validate Cordova GoogleMaps plugin for iOS and Android" status="approved" type="Functional">
+        <description>
+          <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/GoogleMapsPlugin.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
- Set z order of web view with the preference xwalkZOrderOnTop
- Cordova GoogleMaps plugin for Android
- Fail Analyse: <br/>
   XWALK-5869 xwalkZorderOnTop does not make webview in top level.<br/>
  XWALK-5868 ANIMATABLE_XWALK_VIEW is not false by default

Impacted TCs num(approved): New 1, Update 0, Delete 0
Unit test platform: cordova-plugin-crosswalk-webview
Android test result summary: Pass 0, Fail 1, Block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5779