### PR TITLE
[EmbeddingAPI] Add usecase for XWalkView Setting API setInitialPageScale

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -683,8 +683,16 @@
         </activity>
         <activity
             android:name=".setting.XWalkViewSettingSupportZoomAsync"
-            android:label="@string/title_activity_xwalk_view_setting_support_zoom_async"
-            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            android:label="@string/title_activity_xwalk_view_setting_support_zoom_async" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Setting" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".setting.XWalkViewSettingSetInitialPageScaleAsync"
+            android:label="@string/title_activity_xwalk_view_setting_set_initial_pagescale_async"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="XWalkView.Setting" />

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
@@ -98,5 +98,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_setting_support_zoom_async">
         XWalkViewSettingSupportZoomAsync
     </string>
+    <string name="title_activity_xwalk_view_setting_set_initial_pagescale_async">XWalkViewSettingSetInitialPageScaleAsync</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -702,6 +702,18 @@ This usecase covers following interface and methods:
 
 
 
+### 69. The [XWalkViewSettingSetInitialPageScaleAsync](setting/XWalkViewSettingSetInitialPageScaleAsync.java) sample check XWalkSetting API setInitialPageScale method can work, include:
+
+* XWalkSetting API setInitialPageScale method can work
+
+This usecase covers following interface and methods:
+
+* XWalkSetting interface: setInitialPageScale
+* XWalkView interface: load me
+>>>>>>> [EmbeddingAPI] Add usecase for XWalkView Setting API setInitialPageScale
+
+
+
 ### 70. The [XWalkViewSettingTextZoomAsync](setting/XWalkViewSettingTextZoomAsync.java) sample check XWalkSetting API getTextZoom & setTextZoom method can work, include:
 
 * XWalkSetting API getTextZoom & setTextZoom method can work

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/setting/XWalkViewSettingSetInitialPageScaleAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/setting/XWalkViewSettingSetInitialPageScaleAsync.java
@@ -1,0 +1,82 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.asyncsample.setting;
+
+import org.xwalk.embedded.api.asyncsample.R;
+
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkSettings;
+import org.xwalk.core.XWalkView;
+
+import android.content.Context;
+import android.graphics.Point;
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.WindowManager;
+
+public class XWalkViewSettingSetInitialPageScaleAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private XWalkInitializer mXWalkInitializer;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public void onXWalkInitCancelled() {
+
+    }
+
+    @Override
+    public void onXWalkInitStarted() {
+
+    }
+
+    @Override
+    public void onXWalkInitFailed() {
+
+    }
+
+    @Override
+    public void onXWalkInitCompleted() {
+        setContentView(R.layout.xwview_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView Setting can setInitialPageScale.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Load the html page with whole blue background.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if the blue background spans the entire screen size.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        WindowManager wm = (WindowManager) getSystemService(Context.WINDOW_SERVICE);
+        Point screenSize = new Point();
+        wm.getDefaultDisplay().getSize(screenSize);
+
+        final String pageTemplate = "<html><head>"
+                                + "<meta name='viewport' content='initial-scale=1.0' />"
+                                + "</head><body style='margin:0; padding:0'>"
+                                + "<div style='background:blue;width:" + screenSize.x
+                                + "px;height:" + screenSize.y
+                                + "px'>A big div</div>"
+                                + "</body></html>";
+
+        XWalkSettings settings = mXWalkView.getSettings();
+        settings.setInitialPageScale(1.0f);
+        mXWalkView.load(null, pageTemplate);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -684,8 +684,16 @@
         </activity>
         <activity
             android:name=".setting.XWalkViewSettingSupportZoom"
-            android:label="@string/title_activity_xwalk_view_setting_support_zoom"
-            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            android:label="@string/title_activity_xwalk_view_setting_support_zoom" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Setting" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".setting.XWalkViewSettingSetInitialPageScale"
+            android:label="@string/title_activity_xwalk_view_setting_set_initial_pagescale"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="XWalkView.Setting" />

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
@@ -104,5 +104,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_setting_support_zoom">
         XWalkViewSettingSupportZoom
     </string>
+    <string name="title_activity_xwalk_view_setting_set_initial_pagescale">XWalkViewSettingSetInitialPageScale</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -701,6 +701,18 @@ This usecase covers following interface and methods:
 
 
 
+### 69. The [XWalkViewSettingSetInitialPageScale](setting/XWalkViewSettingSetInitialPageScale.java) sample check XWalkSetting API setInitialPageScale method can work, include:
+
+* XWalkSetting API setInitialPageScale method can work
+
+This usecase covers following interface and methods:
+
+* XWalkSetting interface: setInitialPageScale
+>>>>>>> [EmbeddingAPI] Add usecase for XWalkView Setting API setInitialPageScale
+* XWalkView interface: load methods
+
+
+
 ### 70. The [XWalkViewSettingTextZoom](setting/XWalkViewSettingTextZoom.java) sample check XWalkSetting API getTextZoom & setTextZoom method can work, include:
 
 * XWalkSetting API getTextZoom & setTextZoom method can work
@@ -719,4 +731,3 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkSetting interface: setUseWideViewPort, getUseWideViewPort, setSupportZoom, supportZoom, setBuiltInZoomControls, getBuiltInZoomControls methods
-* XWalkView interface: load methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/setting/XWalkViewSettingSetInitialPageScale.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/setting/XWalkViewSettingSetInitialPageScale.java
@@ -1,0 +1,61 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.sample.setting;
+
+import org.xwalk.embedded.api.sample.R;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkSettings;
+import org.xwalk.core.XWalkView;
+
+import android.content.Context;
+import android.graphics.Point;
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.WindowManager;
+
+public class XWalkViewSettingSetInitialPageScale extends XWalkActivity {
+    private XWalkView mXWalkView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.xwview_layout);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView Setting can setInitialPageScale.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Load the html page with whole blue background.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if the blue background spans the entire screen size.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        WindowManager wm = (WindowManager) getSystemService(Context.WINDOW_SERVICE);
+        Point screenSize = new Point();
+        wm.getDefaultDisplay().getSize(screenSize);
+
+        final String pageTemplate = "<html><head>"
+                                + "<meta name='viewport' content='initial-scale=1.0' />"
+                                + "</head><body style='margin:0; padding:0'>"
+                                + "<div style='background:blue;width:" + screenSize.x
+                                + "px;height:" + screenSize.y
+                                + "px'>A big div</div>"
+                                + "</body></html>";
+
+        XWalkSettings settings = mXWalkView.getSettings();
+        settings.setInitialPageScale(1.0f);
+        mXWalkView.load(null, pageTemplate);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -873,6 +873,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingSetInitialPageScale" purpose="XWalkViewSettingSetInitialPageScale Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -1736,6 +1748,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingSupportZoomAsync" purpose="XWalkViewSettingSupportZoomAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingSetInitialPageScaleAsync" purpose="XWalkViewSettingSetInitialPageScaleAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -972,6 +972,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingSetInitialPageScale" purpose="XWalkViewSettingSetInitialPageScale Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -1830,6 +1842,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingSupportZoomAsync" purpose="XWalkViewSettingSupportZoomAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingSetInitialPageScaleAsync" purpose="XWalkViewSettingSetInitialPageScaleAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>


### PR DESCRIPTION
-Add usecase for XWalkView Setting API setInitialPageScale
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-5423