### PR TITLE
[EmbeddingAPI] Add usecase for XWalkView API captureBitmapAsync

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -683,7 +683,8 @@
         </activity>
         <activity
             android:name=".setting.XWalkViewSettingSupportZoomAsync"
-            android:label="@string/title_activity_xwalk_view_setting_support_zoom_async" >
+            android:label="@string/title_activity_xwalk_view_setting_support_zoom_async"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="XWalkView.Setting" />
@@ -692,10 +693,20 @@
         <activity
             android:name=".setting.XWalkViewSettingSetInitialPageScaleAsync"
             android:label="@string/title_activity_xwalk_view_setting_set_initial_pagescale_async"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen" >
+            android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="XWalkView.Setting" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".basic.XWalkViewWithCaptureBitmapAsync"
+            android:label="@string/title_activity_xwalk_view_setting_capture_bitmap_async"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Basic" />
             </intent-filter>
         </activity>
     </application>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_capture_bitmap_async.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_capture_bitmap_async.xml
@@ -1,0 +1,27 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" >
+
+    <org.xwalk.core.XWalkView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/xwalkview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="1" >
+    </org.xwalk.core.XWalkView>
+
+    <Button
+        android:id="@+id/capture_btn"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:text="Capture Bitmap" />
+
+    <ImageView
+        android:id="@+id/imageview"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:layout_weight="1"
+        android:scaleType="centerInside" />
+
+</LinearLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
@@ -99,5 +99,7 @@ found in the LICENSE file.
         XWalkViewSettingSupportZoomAsync
     </string>
     <string name="title_activity_xwalk_view_setting_set_initial_pagescale_async">XWalkViewSettingSetInitialPageScaleAsync</string>
+    <string name="title_activity_xwalk_view_setting_capture_bitmap_async">XWalkViewWithCaptureBitmapAsync</string>
+
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -733,3 +733,15 @@ This usecase covers following interface and methods:
 
 * XWalkSetting interface: setUseWideViewPort, getUseWideViewPort, setSupportZoom, supportZoom, setBuiltInZoomControls, getBuiltInZoomControls methods
 * XWalkView interface: load methods
+
+
+
+
+### 74. The [XWalkViewWithCaptureBitmapAsync](basic/XWalkViewWithCaptureBitmapAsync.java) sample check XWalkView can capture the visible content of web page, include:
+
+* XWalkView API captureBitmapAsync method can work
+
+This usecase covers following interface and methods:
+
+* XWalkSetting interface: scaptureBitmapAsync methods
+* XWalkView interface: load methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/basic/XWalkViewWithCaptureBitmapAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/basic/XWalkViewWithCaptureBitmapAsync.java
@@ -1,0 +1,103 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.asyncsample.basic;
+
+import org.xwalk.embedded.api.asyncsample.R;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkGetBitmapCallback;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.Button;
+import android.widget.ImageView;
+
+
+public class XWalkViewWithCaptureBitmapAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private ImageView mImageView;
+    private Button mCaptureButton;
+    private XWalkGetBitmapCallback mXWalkGetBitmapCallback;
+    private XWalkInitializer mXWalkInitializer;
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        setContentView(R.layout.activity_xwalk_view_with_capture_bitmap_async);
+
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can capture the visible content of web page.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Click 'Capture Bitmap' button when finish loading baidu home page.\n")
+        .append("2. The captured bitmap will show on the bottom.\n\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if captured bitmap shows.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mImageView = (ImageView) findViewById(R.id.imageview);
+        mCaptureButton = (Button) findViewById(R.id.capture_btn);
+
+        mXWalkView.load("http://www.baidu.com", null);
+        mCaptureButton.setOnClickListener(new OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                // TODO Auto-generated method stub
+                if (mXWalkView == null) return;
+                mXWalkGetBitmapCallback = new XWalkGetBitmapCallbackImpl();
+                mXWalkView.captureBitmapAsync(mXWalkGetBitmapCallback);
+            }
+        });
+    }
+
+    class XWalkGetBitmapCallbackImpl extends XWalkGetBitmapCallback{
+
+        public XWalkGetBitmapCallbackImpl() {
+            super();
+        }
+
+        @Override
+        public void onFinishGetBitmap(Bitmap bitmap, int response) {
+            if (response == 0) {
+                mImageView.setImageBitmap(bitmap);
+                bitmap = null;
+            }
+        }
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -684,7 +684,8 @@
         </activity>
         <activity
             android:name=".setting.XWalkViewSettingSupportZoom"
-            android:label="@string/title_activity_xwalk_view_setting_support_zoom" >
+            android:label="@string/title_activity_xwalk_view_setting_support_zoom"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="XWalkView.Setting" />
@@ -693,10 +694,20 @@
         <activity
             android:name=".setting.XWalkViewSettingSetInitialPageScale"
             android:label="@string/title_activity_xwalk_view_setting_set_initial_pagescale"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen" >
+            android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="XWalkView.Setting" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".basic.XWalkViewWithCaptureBitmapAsync"
+            android:label="@string/title_activity_xwalk_view_setting_capture_bitmap_async"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Basic" />
             </intent-filter>
         </activity>
     </application>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_capture_bitmap_async.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_capture_bitmap_async.xml
@@ -1,0 +1,27 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical" >
+
+    <org.xwalk.core.XWalkView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/xwalkview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="1" >
+    </org.xwalk.core.XWalkView>
+
+    <Button
+        android:id="@+id/capture_btn"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:text="Capture Bitmap" />
+
+    <ImageView
+        android:id="@+id/imageview"
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:layout_weight="1"
+        android:scaleType="centerInside" />
+
+</LinearLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
@@ -105,5 +105,6 @@ found in the LICENSE file.
         XWalkViewSettingSupportZoom
     </string>
     <string name="title_activity_xwalk_view_setting_set_initial_pagescale">XWalkViewSettingSetInitialPageScale</string>
+    <string name="title_activity_xwalk_view_setting_capture_bitmap_async">XWalkViewWithCaptureBitmapAsync</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -731,3 +731,14 @@ This usecase covers following interface and methods:
 This usecase covers following interface and methods:
 
 * XWalkSetting interface: setUseWideViewPort, getUseWideViewPort, setSupportZoom, supportZoom, setBuiltInZoomControls, getBuiltInZoomControls methods
+
+
+
+### 74. The [XWalkViewWithCaptureBitmapAsync](basic/XWalkViewWithCaptureBitmapAsync.java) sample check XWalkView can capture the visible content of web page, include:
+
+* XWalkView API captureBitmapAsync method can work
+
+This usecase covers following interface and methods:
+
+* XWalkSetting interface: scaptureBitmapAsync methods
+* XWalkView interface: load methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/basic/XWalkViewWithCaptureBitmapAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/basic/XWalkViewWithCaptureBitmapAsync.java
@@ -1,0 +1,81 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.sample.basic;
+
+import org.xwalk.embedded.api.sample.R;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkGetBitmapCallback;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.Button;
+import android.widget.ImageView;
+
+
+public class XWalkViewWithCaptureBitmapAsync extends XWalkActivity {
+    private XWalkView mXWalkView;
+    private ImageView mImageView;
+    private Button mCaptureButton;
+    private XWalkGetBitmapCallback mXWalkGetBitmapCallback;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_xwalk_view_with_capture_bitmap_async);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can capture the visible content of web page.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Click 'Capture Bitmap' button when finish loading baidu home page.\n")
+        .append("2. The captured bitmap will show on the bottom.\n\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if captured bitmap shows.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mImageView = (ImageView) findViewById(R.id.imageview);
+        mCaptureButton = (Button) findViewById(R.id.capture_btn);
+
+        mXWalkView.load("http://www.baidu.com", null);
+        mCaptureButton.setOnClickListener(new OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                // TODO Auto-generated method stub
+                if (mXWalkView == null) return;
+                mXWalkGetBitmapCallback = new XWalkGetBitmapCallbackImpl();
+                mXWalkView.captureBitmapAsync(mXWalkGetBitmapCallback);
+            }
+        });
+    }
+
+    class XWalkGetBitmapCallbackImpl extends XWalkGetBitmapCallback{
+
+        public XWalkGetBitmapCallbackImpl() {
+            super();
+        }
+
+        @Override
+        public void onFinishGetBitmap(Bitmap bitmap, int response) {
+            if (response == 0) {
+                mImageView.setImageBitmap(bitmap);
+                bitmap = null;
+            }
+        }
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -885,6 +885,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithCaptureBitmapAsync" purpose="XWalkViewWithCaptureBitmapAsync Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -1760,6 +1772,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingSetInitialPageScaleAsync" purpose="XWalkViewSettingSetInitialPageScaleAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithCaptureBitmapAsync" purpose="XWalkViewWithCaptureBitmapAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -984,6 +984,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithCaptureBitmapAsync" purpose="XWalkViewWithCaptureBitmapAsync Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -1854,6 +1866,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingSetInitialPageScaleAsync" purpose="XWalkViewSettingSetInitialPageScaleAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithCaptureBitmapAsync" purpose="XWalkViewWithCaptureBitmapAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>


### PR DESCRIPTION
-Add usecase for XWalkView API captureBitmapAsync
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5880