### PR TITLE
[EmbeddingAPI] Add usecase for XWalkView API setOnTouchListener

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -727,5 +727,14 @@
                 <category android:name="XWalkView.Setting" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".misc.XWalkViewWithOnTouchListenerAsync"
+            android:label="@string/title_activity_xwalk_view_with_on_touch_listener_async"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Misc" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_on_touch_listener_async.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_on_touch_listener_async.xml
@@ -1,0 +1,28 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.asyncsample.misc.XWalkViewWithOnTouchListenerAsync">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="If onTouchEvent is invoked, below will show the 'onTouchEvent is invoked. Action is UP/DOWN/MOVE'"
+        android:id="@+id/textView" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/message_tv"
+        android:textColor="#00ff00"
+        android:layout_below="@+id/textView"/>
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/xwalkview"
+        android:layout_below="@+id/message_tv" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
@@ -106,5 +106,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_setting_default_fixed_font_size_async">
         XWalkViewSettingDefaultFixedFontSizeAsync
     </string>
+    <string name="title_activity_xwalk_view_with_on_touch_listener_async">XWalkViewWithOnTouchListenerAsync</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -766,3 +766,14 @@ This usecase covers following interface and methods:
 
 * XWalkSetting interface: scaptureBitmapAsync methods
 * XWalkView interface: load methods
+
+
+
+### 75. The [XWalkViewWithOnTouchListenerAsync](misc/XWalkViewWithOnTouchListenerAsync.java) sample check XWalkView API setOnTouchListener method can work, include:
+
+* XWalkView API setOnTouchListener method can work
+
+This usecase covers following interface and methods:
+
+* XWalkSetting interface: setOnTouchListener
+* XWalkView interface: load methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/misc/XWalkViewWithOnTouchListenerAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/misc/XWalkViewWithOnTouchListenerAsync.java
@@ -1,0 +1,94 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.asyncsample.misc;
+
+import org.xwalk.embedded.api.asyncsample.R;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkView;
+
+import android.widget.TextView;
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.View.OnTouchListener;
+
+
+public class XWalkViewWithOnTouchListenerAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private TextView mTextView;
+    private XWalkInitializer mXWalkInitializer;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        setContentView(R.layout.activity_xwalk_view_with_on_touch_listener_async);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mTextView = (TextView) findViewById(R.id.message_tv);
+
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView API OnTouchListener can work.\n\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if the message 'onTouchEvent is invoked; Action is UP/DOWN/MOVE' shows");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView.load("http://www.baidu.com/", null);
+        mXWalkView.setOnTouchListener(new OnTouchListener() {
+
+            @Override
+            public boolean onTouch(View v, MotionEvent event) {
+                // TODO Auto-generated method stub
+                int action = event.getActionMasked();
+                switch (action) {
+                case MotionEvent.ACTION_DOWN:
+                    mTextView.setText("onTouchEvent is invoked. Action is DOWN");
+                    break;
+                case MotionEvent.ACTION_MOVE:
+                    mTextView.setText("onTouchEvent is invoked. Action is MOVE");
+                   break;
+                case MotionEvent.ACTION_UP:
+                    mTextView.setText("onTouchEvent is invoked. Action is UP");
+                    break;
+                case MotionEvent.ACTION_CANCEL:
+                    mTextView.setText("onTouchEvent is invoked. Action is CANCEL");
+                    break;
+                case MotionEvent.ACTION_OUTSIDE:
+                    mTextView.setText("onTouchEvent is invoked. Action is OUTSIDE");
+                    break;
+                }
+                return false;
+            }
+        });
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -728,5 +728,14 @@
                 <category android:name="XWalkView.Setting" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".misc.XWalkViewWithOnTouchListener"
+            android:label="@string/title_activity_xwalk_view_with_on_touch_listener"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Misc" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_on_touch_listener.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_on_touch_listener.xml
@@ -1,0 +1,28 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.sample.misc.XWalkViewWithOnTouchListener">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="If onTouchEvent is invoked, below will show the 'onTouchEvent is invoked. Action is UP/DOWN/MOVE'"
+        android:id="@+id/textView" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/message_tv"
+        android:textColor="#00ff00"
+        android:layout_below="@+id/textView"/>
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/xwalkview"
+        android:layout_below="@+id/message_tv" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
@@ -112,5 +112,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_setting_default_fixed_font_size">
         XWalkViewSettingDefaultFixedFontSize
     </string>
+    <string name="title_activity_xwalk_view_with_on_touch_listener">XWalkViewWithOnTouchListener</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -764,3 +764,14 @@ This usecase covers following interface and methods:
 
 * XWalkSetting interface: scaptureBitmapAsync methods
 * XWalkView interface: load methods
+
+
+
+### 75. The [XWalkViewWithOnTouchListener](misc/XWalkViewWithOnTouchListener.java) sample check XWalkView API setOnTouchListener method can work, include:
+
+* XWalkView API setOnTouchListener method can work
+
+This usecase covers following interface and methods:
+
+* XWalkSetting interface: setOnTouchListener
+* XWalkView interface: load methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/misc/XWalkViewWithOnTouchListener.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/misc/XWalkViewWithOnTouchListener.java
@@ -1,0 +1,73 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.sample.misc;
+
+import org.xwalk.embedded.api.sample.R;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkView;
+
+import android.widget.TextView;
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.View.OnTouchListener;
+
+
+public class XWalkViewWithOnTouchListener extends XWalkActivity {
+    private XWalkView mXWalkView;
+    private TextView mTextView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_xwalk_view_with_on_touch_listener);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        mTextView = (TextView) findViewById(R.id.message_tv);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView API OnTouchListener can work.\n\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if the message 'onTouchEvent is invoked; Action is UP/DOWN/MOVE' shows");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView.load("http://www.baidu.com/", null);
+        mXWalkView.setOnTouchListener(new OnTouchListener() {
+
+            @Override
+            public boolean onTouch(View v, MotionEvent event) {
+                // TODO Auto-generated method stub
+                int action = event.getActionMasked();
+                switch (action) {
+                case MotionEvent.ACTION_DOWN:
+                    mTextView.setText("onTouchEvent is invoked. Action is DOWN");
+                    break;
+                case MotionEvent.ACTION_MOVE:
+                    mTextView.setText("onTouchEvent is invoked. Action is MOVE");
+                   break;
+                case MotionEvent.ACTION_UP:
+                    mTextView.setText("onTouchEvent is invoked. Action is UP");
+                    break;
+                case MotionEvent.ACTION_CANCEL:
+                    mTextView.setText("onTouchEvent is invoked. Action is CANCEL");
+                    break;
+                case MotionEvent.ACTION_OUTSIDE:
+                    mTextView.setText("onTouchEvent is invoked. Action is OUTSIDE");
+                    break;
+                }
+                return false;
+            }
+        });
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -922,6 +922,18 @@
         </description>
       </testcase>
     </set>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnTouchListener" purpose="XWalkViewWithOnTouchListener Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
         <description>
@@ -1832,6 +1844,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingDefaultFixedFontSizeAsync" purpose="XWalkViewSettingDefaultFixedFontSizeAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnTouchListenerAsync" purpose="XWalkViewWithOnTouchListenerAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -1020,6 +1020,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnTouchListener" purpose="XWalkViewWithOnTouchListener Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -1926,6 +1938,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingDefaultFixedFontSizeAsync" purpose="XWalkViewSettingDefaultFixedFontSizeAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnTouchListenerAsync" purpose="XWalkViewWithOnTouchListenerAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>


### PR DESCRIPTION
-Add usecase for XWalkView API setOnTouchListener
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5884