### PR TITLE
[EmbeddingAPI] Add usecase for XWalkResourceClient API onReceivedResp…

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -745,5 +745,14 @@
                 <category android:name="XWalkView.UIClient.ResourceClient" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".client.XWalkViewWithOnReceivedResponseHeadersAsync"
+            android:label="@string/title_activity_xwalk_view_with_response_headers_async"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.UIClient.ResourceClient" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_on_received_response_headers_async.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_on_received_response_headers_async.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (c) 2014 Intel Corporation. All rights reserved.
+
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.asyncsample.client.XWalkViewWithOnReceivedResponseHeadersAsync">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="If onReceivedResponseHeaders is invoked, below will show the 'onReceivedResponseHeaders is invoked. The Set-Cookie string is '"
+        android:id="@+id/textView" />
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textColor="#00ff00"
+        android:id="@+id/response_headers_label"
+        android:layout_below="@+id/textView"/>
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/response_headers_label" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
@@ -108,5 +108,6 @@ found in the LICENSE file.
     </string>
     <string name="title_activity_xwalk_view_with_on_touch_listener_async">XWalkViewWithOnTouchListenerAsync</string>
     <string name="title_activity_xwalk_view_with_on_js_alert_async">XWalkViewWithOnJsAlertAsync</string>
+    <string name="title_activity_xwalk_view_with_response_headers_async">XWalkViewWithOnReceivedResponseHeadersAsync</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -788,3 +788,14 @@ This usecase covers following interface and methods:
 
 * XWalkUIClient interface: onJsAlert, onJsConfirm, onJsPropmt methods
 * XWalkView interface: load methods
+
+
+
+### 77. The [XWalkViewWithOnReceivedResponseHeadersAsync](client/XWalkViewWithOnReceivedResponseHeadersAsync.java) sample check API XWalkResourceClient.onReceivedResponseHeaders can work, include:
+
+* API XWalkResourceClient.onReceivedResponseHeaders can work
+
+This usecase covers following interface and methods:
+
+* XWalkResourceClient interface: onReceivedResponseHeaders
+* XWalkView interface: load methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/client/XWalkViewWithOnReceivedResponseHeadersAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/client/XWalkViewWithOnReceivedResponseHeadersAsync.java
@@ -1,0 +1,84 @@
+package org.xwalk.embedded.api.asyncsample.client;
+
+import java.util.Map;
+
+import org.xwalk.embedded.api.asyncsample.R;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.TextView;
+import android.app.Activity;
+
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkView;
+import org.xwalk.core.XWalkWebResourceRequest;
+import org.xwalk.core.XWalkWebResourceResponse;
+
+public class XWalkViewWithOnReceivedResponseHeadersAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+
+    private XWalkView mXWalkView;
+    private TextView mTextView;
+    private XWalkInitializer mXWalkInitializer;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        setContentView(R.layout.activity_xwalk_view_with_on_received_response_headers_async);
+
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+            .append("Verifies onReceivedResponseHeaders API can be invoked in XWalkResourceClient.\n\n")
+            .append("Expected Result:\n\n")
+            .append("Test passes if the Set-Cookie string shows");
+        new AlertDialog.Builder(this)
+            .setTitle("Info")
+            .setMessage(mess.toString())
+            .setPositiveButton("confirm", null)
+            .show();
+
+        mTextView = (TextView) findViewById(R.id.response_headers_label);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mXWalkView.setResourceClient(new XWalkResourceClient(mXWalkView) {
+
+            @Override
+            public void onReceivedResponseHeaders(XWalkView view,
+                    XWalkWebResourceRequest request,
+                    XWalkWebResourceResponse response) {
+                // TODO Auto-generated method stub
+                super.onReceivedResponseHeaders(view, request, response);
+                if(response.getStatusCode() == 200) {
+                    Map<String, String> headers = response.getResponseHeaders();
+                    String cookies = headers.get("Set-Cookie");
+                    if(cookies != null) {
+                        mTextView.setText(cookies);
+                    }
+                }
+            }
+        });
+        mXWalkView.load("http://m.baidu.cn", null);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -746,5 +746,14 @@
                 <category android:name="XWalkView.UIClient.ResourceClient" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".client.XWalkViewWithOnReceivedResponseHeaders"
+            android:label="@string/title_activity_xwalk_view_with_response_headers"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.UIClient.ResourceClient" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_on_received_response_headers.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_on_received_response_headers.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (c) 2014 Intel Corporation. All rights reserved.
+
+     Use of this source code is governed by a BSD-style license that can be
+     found in the LICENSE file.
+-->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.sample.client.XWalkViewWithOnReceivedResponseHeaders">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="If onReceivedResponseHeaders is invoked, below will show the 'onReceivedResponseHeaders is invoked. The Set-Cookie string is '"
+        android:id="@+id/textView" />
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textColor="#00ff00"
+        android:id="@+id/response_headers_label"
+        android:layout_below="@+id/textView"/>
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/response_headers_label" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
@@ -114,5 +114,6 @@ found in the LICENSE file.
     </string>
     <string name="title_activity_xwalk_view_with_on_touch_listener">XWalkViewWithOnTouchListener</string>
     <string name="title_activity_xwalk_view_with_on_js_alert">XWalkViewWithOnJsAlert</string>
+    <string name="title_activity_xwalk_view_with_response_headers">XWalkViewWithOnReceivedResponseHeaders</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -786,3 +786,14 @@ This usecase covers following interface and methods:
 
 * XWalkUIClient interface: onJsAlert, onJsConfirm, onJsPropmt methods
 * XWalkView interface: load methods
+
+
+
+### 77. The [XWalkViewWithOnReceivedResponseHeaders](client/XWalkViewWithOnReceivedResponseHeaders.java) sample check API XWalkResourceClient.onReceivedResponseHeaders can work, include:
+
+* API XWalkResourceClient.onReceivedResponseHeaders can work
+
+This usecase covers following interface and methods:
+
+* XWalkResourceClient interface: onReceivedResponseHeaders
+* XWalkView interface: load methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/client/XWalkViewWithOnReceivedResponseHeaders.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/client/XWalkViewWithOnReceivedResponseHeaders.java
@@ -1,0 +1,64 @@
+package org.xwalk.embedded.api.sample.client;
+
+import java.util.Map;
+
+import org.xwalk.embedded.api.sample.R;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.TextView;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkView;
+import org.xwalk.core.XWalkWebResourceRequest;
+import org.xwalk.core.XWalkWebResourceResponse;
+
+public class XWalkViewWithOnReceivedResponseHeaders extends XWalkActivity{
+
+    private XWalkView mXWalkView;
+    private TextView mTextView;
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_xwalk_view_with_on_received_response_headers);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+            .append("Verifies onReceivedResponseHeaders API can be invoked in XWalkResourceClient.\n\n")
+            .append("Expected Result:\n\n")
+            .append("Test passes if the Set-Cookie string shows");
+        new AlertDialog.Builder(this)
+            .setTitle("Info")
+            .setMessage(mess.toString())
+            .setPositiveButton("confirm", null)
+            .show();
+
+        mTextView = (TextView) findViewById(R.id.response_headers_label);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mXWalkView.setResourceClient(new XWalkResourceClient(mXWalkView) {
+
+            @Override
+            public void onReceivedResponseHeaders(XWalkView view,
+                    XWalkWebResourceRequest request,
+                    XWalkWebResourceResponse response) {
+                // TODO Auto-generated method stub
+                super.onReceivedResponseHeaders(view, request, response);
+                if(response.getStatusCode() == 200) {
+                    Map<String, String> headers = response.getResponseHeaders();
+                    String cookies = headers.get("Set-Cookie");
+                    if(cookies != null) {
+                        mTextView.setText(cookies);
+                    }
+                }
+            }
+        });
+        mXWalkView.load("http://m.baidu.cn", null);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -945,6 +945,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnReceivedResponseHeaders" purpose="XWalkViewWithOnReceivedResponseHeaders Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -1880,6 +1892,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnJsAlertAsync" purpose="XWalkViewWithOnJsAlertAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnReceivedResponseHeadersAsync" purpose="XWalkViewWithOnReceivedResponseHeadersAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -1044,6 +1044,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnReceivedResponseHeaders" purpose="XWalkViewWithOnReceivedResponseHeaders Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -1974,6 +1986,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnJsAlertAsync" purpose="XWalkViewWithOnJsAlertAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithOnReceivedResponseHeadersAsync" purpose="XWalkViewWithOnReceivedResponseHeadersAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>


### PR DESCRIPTION
…onseHeaders

-Add usecase for XWalkResourceClient API onReceivedResponseHeaders
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5427