### PR TITLE
[Crosswalk-16][Cordova] Add Cordova4.x support for AppSecurityApi cases

### DIFF
--- a/cordova/cordova-sampleapp-android-tests/tests.4.x.xml
+++ b/cordova/cordova-sampleapp-android-tests/tests.4.x.xml
@@ -83,6 +83,36 @@
            <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/Eh_uninstall.py</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Cordova Sample Apps/PrivateNotes" execution_type="auto" id="privateNotes_build" purpose="Validate if sample app PrivateNotes could be built successfully">
+        <description>
+          <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/privateNotes_build.py</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Sample Apps/PrivateNotes" execution_type="auto" id="privateNotes_install" purpose="Validate if sample app PrivateNotes could be installed successfully">
+        <description>
+          <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/privateNotes_install.py</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Sample Apps/PrivateNotes" execution_type="auto" id="privateNotes_launch" purpose="Validate if sample app PrivateNotes could be launched successfully">
+        <description>
+           <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/privateNotes_launch.py</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Sample Apps/PrivateNotes" execution_type="auto" id="privateNotes_close" purpose="Validate if sample app PrivateNotes could be closed successfully">
+        <description>
+          <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/privateNotes_close.py</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Sample Apps/PrivateNotes" execution_type="auto" id="privateNotes_uninstall" purpose="Validate if sample app PrivateNotes could be uninstalled successfully">
+        <description>
+          <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/privateNotes_uninstall.py</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Sample Apps/PrivateNotes" execution_type="auto" id="privateNotes_uninstall_withAppRunning" purpose="Validate Crosswalk support that uninstall the sample app PrivateNotes when it's actually running">
+        <description>
+           <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/privateNotes_uninstall_withAppRunning.py</test_script_entry>
+        </description>
+      </testcase>
     </set>
     <set name="SampleApp_manual" type="js">
       <testcase component="Cordova Sample Apps/Spacedodge" execution_type="manual" id="Crosswalk_Cordova_SampleApp_Spacedodge_AppFunction" purpose="Validate if sample app Spacedodge function could work well">
@@ -140,6 +170,39 @@
             1. Make sure the Eh webapp is installed in two adnroid devices.
           </pre_condition>
           <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/Crosswalk_Cordova_SampleApp_Eh_AppFunction.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Sample Apps/PrivateNotes" execution_type="manual" id="Crosswalk_Cordova_SampleApp_PrivateNotes_AppFunction" purpose="Validate if sample app PrivateNotes function could work well">
+        <description>
+          <pre_condition>
+            1. Make sure the PrivateNotes webapp is launched.
+          </pre_condition>
+          <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/Crosswalk_Cordova_SampleApp_PrivateNotes_AppFunction.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Sample Apps/PrivateNotes" execution_type="manual" id="Crosswalk_Cordova_SampleApp_PrivateNotes_Icon" purpose="Validate if sample app PrivateNotes icon display normally">
+        <description>
+          <pre_condition>
+            1. Make sure PrivateNotes webapp is installed;
+            2. Make sure PrivateNotes webapp is available.
+          </pre_condition>
+          <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/Crosswalk_Cordova_SampleApp_PrivateNotes_Icon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Sample Apps/PrivateNotes" execution_type="manual" id="Crosswalk_Cordova_SampleApp_PrivateNotes_Switch" purpose="Validate if sample app PrivateNotes could switch back successfully">
+        <description>
+          <pre_condition>
+            1. Make sure the PrivateNotes webapp is launched.
+          </pre_condition>
+          <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/Crosswalk_Cordova_SampleApp_PrivateNotes_Switch.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Cordova Sample Apps/PrivateNotes" execution_type="manual" id="Crosswalk_Cordova_SampleApp_PrivateNotes_Orientation" purpose="Validate if sample app PrivateNotes could rotate between portrait orientation screen and landscape orientation screen">
+        <description>
+          <pre_condition>
+            1. Make sure the PrivateNotes webapp is launched.
+          </pre_condition>
+          <test_script_entry>/opt/cordova-sampleapp-android-tests/sampleapp/Crosswalk_Cordova_SampleApp_PrivateNotes_Orientation.html </test_script_entry>
         </description>
       </testcase>
     </set>

--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-pack_cordova_sample.py is used for auto build Cordova sample apps, including mobilespec, helloworld, remotedebugging, spacedodge, renamePkg, xwalkCommandLine, and except renamePkg and xwalkCommandLine only support Cordova 4.x, privateNotes only support Cordova 3.6, others support both Cordova 3.6 and Cordova 4.x build.  
+pack_cordova_sample.py is used for auto build Cordova sample apps, including mobilespec, helloworld, remotedebugging, spacedodge, renamePkg, xwalkCommandLine, privateNotes, and except renamePkg and xwalkCommandLine only support Cordova 4.x, others support both Cordova 3.6 and Cordova 4.x build.  
 **Note**: For cordova 4.x pkg, need to configure crosswalk version in crosswalk-test-suite/VERSION file
 
 ## Pre-conditions
@@ -8,7 +8,7 @@ pack_cordova_sample.py is used for auto build Cordova sample apps, including mob
 ###spacedodge build based on Cordova 4.x and Cordova 3.6
 * Clone https://github.com/crosswalk-project/crosswalk-samples.git to crosswalk-test-suite/tools/
 
-###privateNotes build based on Cordova Cordova 3.6
+###privateNotes build based on Cordova 4.x and Cordova 3.6
 * Clone https://github.com/gomobile/sample-my-private-notes.git to crosswalk-test-suite/tools/
 
 ###mobilespec build based on Cordova 4.x

--- a/tools/build/pack_cordova_sample.py
+++ b/tools/build/pack_cordova_sample.py
@@ -550,10 +550,10 @@ def installPlugins(plugin_tool, app_name):
         xwalk_version = "org.xwalk:xwalk_%s_library_beta:%s" % (pkg_mode_tmp, CROSSWALK_VERSION)
 
     webview_plugin_name = "cordova-plugin-crosswalk-webview"
-    install_variable_cmd = ""
     if os.path.exists(plugin_tool): 
         plugin_dirs = os.listdir(plugin_tool)
         for i_dir in plugin_dirs:
+            install_variable_cmd = ""
             i_plugin_dir = os.path.join(plugin_tool, i_dir)
             plugin_crosswalk_source = i_plugin_dir
             if i_dir == webview_plugin_name:
@@ -962,6 +962,12 @@ def packSampleApp_cli(app_name=None):
             os.chdir(orig_dir)
             return False
 
+    if checkContains(app_name, "PRIVATENOTES"):
+        status_plugman_cmd = "cordova plugin add https://github.com/01org/AppSecurityApi"
+        if not doCMD(status_plugman_cmd, DEFAULT_CMD_TIMEOUT * 5):
+            os.chdir(orig_dir)
+            return False
+
     if not installPlugins(plugin_tool, app_name):
         os.chdir(orig_dir)
         return False
@@ -980,7 +986,7 @@ def packSampleApp_cli(app_name=None):
     if checkContains(app_name, "REMOTEDEBUGGING"):
         pack_cmd = "cordova build android --debug"
 
-    if not doCMD(pack_cmd, DEFAULT_CMD_TIMEOUT):
+    if not doCMD(pack_cmd, DEFAULT_CMD_TIMEOUT * 5):
         os.chdir(orig_dir)
         return False
 


### PR DESCRIPTION
- It's fine to pack cordova 4.x privateNotes

Impacted tests(approved): new 0, update 10, delete 0
Unit test platform: Crosswalk Project for android 17.46.447.0
Unit test result summary: pass 10, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5866