### PR TITLE
[Windows][hotfix] Remove the msi file after copy it to opt directory to avoid to get a wrong msi

### DIFF
--- a/tools/build/pack_windows.py
+++ b/tools/build/pack_windows.py
@@ -430,6 +430,9 @@ def packMsi(build_json=None, app_src=None, app_dest=None, app_name=None):
             os.path.join(app_dest, "%s.msi" % app_name)):
         return False
 
+    if not doRemove([files[0]]):
+        return False
+
     os.chdir(orig_dir)
     return True
 


### PR DESCRIPTION
- It's fine to pack usecase-wrt-windows-tests