### PR TITLE
[usecase]Remove tests ExtensionPermission from suite.json

### DIFF
--- a/usecase/usecase-wrt-android-tests/suite.json
+++ b/usecase/usecase-wrt-android-tests/suite.json
@@ -43,9 +43,6 @@
         "samples/CopyPasteNative/res": {
           "apk-type": "MANIFEST"
         },
-        "samples/ExtensionPermission/res": {
-          "apk-type": "MANIFEST"
-        },
         "samples/ImmersiveFullscreen/res": {
           "apk-type": "MANIFEST"
         },
@@ -205,9 +202,6 @@
         "samples/CopyPasteNative/res": {
           "apk-type": "MANIFEST"
         },
-        "samples/ExtensionPermission/res": {
-          "apk-type": "MANIFEST"
-        },
         "samples/GooglePlay/res": {
           "apk-mode-opt": "shared",
           "apk-type": "MANIFEST"
@@ -330,10 +324,6 @@
           }
         },
         "samples/CopyPasteNative/res": {
-          "apk-mode-opt": "shared",
-          "apk-type": "MANIFEST"
-        },
-        "samples/ExtensionPermission/res": {
           "apk-mode-opt": "shared",
           "apk-type": "MANIFEST"
         },


### PR DESCRIPTION
- The test ExtensionPermission has been removed in pr crosswalk-project#3128,
but it was not removed in pr crosswalk-project#3071.

Impacted TCs num(approved): New 0, Update 0, Delete 1