### PR TITLE
[EmbeddingAPI-autocase] Add autocase for XWalkView API getFavicon

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -45,6 +45,7 @@ import android.os.Bundle;
 import android.test.MoreAsserts;
 import android.util.Log;
 import android.util.Pair;
+import android.graphics.Bitmap;
 import android.webkit.WebResourceResponse;
 
 public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActivity> {
@@ -1071,6 +1072,15 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             @Override
             public XWalkSettings call() throws Exception {
                 return view.getSettings();
+            }
+        });
+    }
+
+    protected Bitmap getFaviconOnUiThread() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<Bitmap>() {
+            @Override
+            public Bitmap call() throws Exception {
+                return mXWalkView.getFavicon();
             }
         });
     }

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v6/XWalkViewTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v6/XWalkViewTest.java
@@ -5,14 +5,20 @@
 package org.xwalk.embedding.test.v6;
 
 
+import java.io.InputStream;
+import java.net.URL;
 import java.util.Locale;
+import java.util.concurrent.Callable;
 
 import android.graphics.Point;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 
 import org.apache.http.Header;
 import org.apache.http.HttpRequest;
 
 import org.xwalk.embedding.base.XWalkViewTestBase;
+import org.xwalk.embedding.util.CommonResources;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.test.suitebuilder.annotation.SmallTest;
@@ -134,5 +140,41 @@ public class XWalkViewTest extends XWalkViewTestBase {
         loadDataSync(null, page, "text/html", false);
         mTestHelperBridge.getOnScaleChangedHelper().waitForCallback(onScaleChangedCallCount);
         assertEquals(defaultScale, getPixelScale(), .01f);
+    }
+
+    @SmallTest
+    public void testGetFavicon() {
+        try {
+            final String faviconUrl = mWebServer.setResponseBase64(
+                    "/" + CommonResources.FAVICON_FILENAME, CommonResources.FAVICON_DATA_BASE64,
+                    CommonResources.getImagePngHeaders(false));
+            final String pageUrl = mWebServer.setResponse("/favicon.html",
+                    CommonResources.FAVICON_STATIC_HTML, null);
+
+            loadUrlAsync(pageUrl);
+
+            // The getFavicon will return the right icon a certain time after
+            // the page load completes which makes it slightly hard to test.
+            pollOnUiThread(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception{
+                    return mXWalkView.getFavicon() != null;
+                }
+            });
+
+            final Object originalFaviconSource = (new URL(faviconUrl)).getContent();
+            final Bitmap originalFavicon =
+                    BitmapFactory.decodeStream((InputStream) originalFaviconSource);
+
+            final Bitmap currentFavicon = getFaviconOnUiThread();
+
+            assertNotNull(originalFavicon);
+
+            assertTrue(currentFavicon.sameAs(originalFavicon));
+        } catch (Exception e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+            assertFalse(true);
+        }
     }
 }

--- a/embeddingapi/embedding-api-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-api-android-tests/tests.full.xml
@@ -118,7 +118,7 @@
           <test_script_entry>org.xwalk.embedding.test.v6.XWalkSettingTest</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.XWalkViewTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="4">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.XWalkViewTest" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="5">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v6.XWalkViewTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-api-android-tests/tests_v6.xml
+++ b/embeddingapi/embedding-api-android-tests/tests_v6.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite name="webapi-embeddingapi-xwalk-tests" category="Android embedding APIs">
     <set name="EmbeddingApiTest" type="androidunit" location="device">
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.XWalkViewTest" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="4">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.XWalkViewTest" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="5">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v6.XWalkViewTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -45,6 +45,7 @@ import android.os.Bundle;
 import android.test.MoreAsserts;
 import android.util.Log;
 import android.util.Pair;
+import android.graphics.Bitmap;
 import android.webkit.WebResourceResponse;
 
 public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActivity> {
@@ -1040,6 +1041,15 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             @Override
             public XWalkSettings call() throws Exception {
                 return view.getSettings();
+            }
+        });
+    }
+
+    protected Bitmap getFaviconOnUiThread() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<Bitmap>() {
+            @Override
+            public Bitmap call() throws Exception {
+                return mXWalkView.getFavicon();
             }
         });
     }

--- a/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
@@ -118,7 +118,7 @@
           <test_script_entry>org.xwalk.embedding.test.v6.XWalkSettingTestAsync</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.XWalkViewTestAsync" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="4">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.XWalkViewTestAsync" platform="android" priority="P1" purpose="Check if the methods of XWalkView interface can be executed correctly." status="approved" type="functional_positive" subcase="5">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v6.XWalkViewTestAsync</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/tests_v6.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests_v6.xml
@@ -8,7 +8,7 @@
           <test_script_entry>org.xwalk.embedding.test.v6.XWalkSettingTestAsync</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.XWalkViewTestAsync" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="4">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.XWalkViewTestAsync" purpose="Check if the methods of XWalkView interface can be executed correctly." subcase="5">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v6.XWalkViewTestAsync</test_script_entry>
         </description>


### PR DESCRIPTION
-Add autocase for XWalkView API getFavicon
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-5420