### PR TITLE
[EmbeddingAPI] Add usecase for XWalkView API getFavicon

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -754,5 +754,14 @@
                 <category android:name="XWalkView.UIClient.ResourceClient" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".basic.XWalkViewWithGetFaviconAsync"
+            android:label="@string/title_activity_xwalk_view_with_get_favicon_async"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Basic" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/favicon.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/favicon.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.2//EN" "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>Favicon</title>
+  <link rel="icon" href="cat.png" type="image/png" />
+</head>
+<body>
+  <p>The favicon will be shown by Toast</p>
+</body>
+</html>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_get_favicon_async.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_get_favicon_async.xml
@@ -1,0 +1,43 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.asyncsample.basic.XWalkViewWithGetFaviconAsync">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Check if XWalkView can get favicon. If you click 'Get Favicon', the favicon in the html will show."
+        android:id="@+id/textView" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/message_tv"
+        android:textColor="#00ff00"
+        android:layout_below="@+id/textView"/>
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/get_favicon_btn"
+        android:text="Get Favicon"
+        android:layout_below="@+id/message_tv"
+        android:layout_alignParentStart="true" />
+
+    <ImageView
+        android:id="@+id/imageview"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:scaleType="centerInside"
+        android:layout_below="@+id/get_favicon_btn" />
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/imageview" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
@@ -109,5 +109,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_on_touch_listener_async">XWalkViewWithOnTouchListenerAsync</string>
     <string name="title_activity_xwalk_view_with_on_js_alert_async">XWalkViewWithOnJsAlertAsync</string>
     <string name="title_activity_xwalk_view_with_response_headers_async">XWalkViewWithOnReceivedResponseHeadersAsync</string>
+    <string name="title_activity_xwalk_view_with_get_favicon_async">XWalkViewWithGetFaviconAsync</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -763,8 +763,7 @@ This usecase covers following interface and methods:
 
 This usecase covers following interface and methods:
 
-* XWalkSetting interface: scaptureBitmapAsync methods
-* XWalkView interface: load methods
+* XWalkView interface: load, scaptureBitmapAsync methods
 
 
 
@@ -798,3 +797,13 @@ This usecase covers following interface and methods:
 
 * XWalkResourceClient interface: onReceivedResponseHeaders
 * XWalkView interface: load methods
+
+
+
+### 78. The [XWalkViewWithGetFaviconAsync](basic/XWalkViewWithGetFaviconAsync.java) sample check XWalkView can get favicon from the html, include:
+
+* XWalkView API getFavicon method can work
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, getFavicon methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/basic/XWalkViewWithGetFaviconAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/basic/XWalkViewWithGetFaviconAsync.java
@@ -1,0 +1,92 @@
+package org.xwalk.embedded.api.asyncsample.basic;
+import org.xwalk.embedded.api.asyncsample.R;
+
+import android.app.AlertDialog;
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.os.Message;
+import android.widget.ImageView;
+import android.widget.Button;
+import android.view.View;
+import android.view.View.OnClickListener;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkView;
+import org.xwalk.core.XWalkUIClient;
+
+public class XWalkViewWithGetFaviconAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private XWalkInitializer mXWalkInitializer;
+    private ImageView mFavicon;
+    private Button mGetFavicon;
+
+    class TestXWalkUIClientBase extends XWalkUIClient {
+
+        public TestXWalkUIClientBase(XWalkView arg0) {
+            super(arg0);
+        }
+
+        @Override
+        public void onIconAvailable(XWalkView view, String url, Message msg) {
+            msg.sendToTarget();
+        }
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        setContentView(R.layout.activity_xwalk_view_with_get_favicon_async);
+
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can get favicon from the html.\n\n")
+        .append("Expected Result:\n\n")
+        .append("1. Click the button 'Get Favicon'.\n")
+        .append("2. Test passes if image of cat shows.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mXWalkView.setUIClient(new TestXWalkUIClientBase(mXWalkView));
+
+        mFavicon = (ImageView) findViewById(R.id.imageview);
+        mGetFavicon = (Button) findViewById(R.id.get_favicon_btn);
+        mGetFavicon.setOnClickListener(new OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                // TODO Auto-generated method stub
+                if (mXWalkView.getFavicon() != null) {
+                    mFavicon.setImageBitmap(mXWalkView.getFavicon());
+                }
+            }
+        });
+        mXWalkView.load("file:///android_asset/favicon.html", null);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -755,5 +755,14 @@
                 <category android:name="XWalkView.UIClient.ResourceClient" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".basic.XWalkViewWithGetFavicon"
+            android:label="@string/title_activity_xwalk_view_with_get_favicon"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Basic" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/assets/favicon.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/assets/favicon.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.2//EN" "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>Favicon</title>
+  <link rel="icon" href="cat.png" type="image/png" />
+</head>
+<body>
+  <p>The favicon will be shown by Toast</p>
+</body>
+</html>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_get_favicon.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_get_favicon.xml
@@ -1,0 +1,43 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.sample.basic.XWalkViewWithGetFavicon">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Check if XWalkView can get favicon. If you click 'Get Favicon', the favicon in the html will show."
+        android:id="@+id/textView" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/message_tv"
+        android:textColor="#00ff00"
+        android:layout_below="@+id/textView"/>
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/get_favicon_btn"
+        android:text="Get Favicon"
+        android:layout_below="@+id/message_tv"
+        android:layout_alignParentStart="true" />
+
+    <ImageView
+        android:id="@+id/imageview"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:scaleType="centerInside"
+        android:layout_below="@+id/get_favicon_btn" />
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/imageview" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
@@ -115,5 +115,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_on_touch_listener">XWalkViewWithOnTouchListener</string>
     <string name="title_activity_xwalk_view_with_on_js_alert">XWalkViewWithOnJsAlert</string>
     <string name="title_activity_xwalk_view_with_response_headers">XWalkViewWithOnReceivedResponseHeaders</string>
+    <string name="title_activity_xwalk_view_with_get_favicon">XWalkViewWithGetFavicon</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -762,8 +762,7 @@ This usecase covers following interface and methods:
 
 This usecase covers following interface and methods:
 
-* XWalkSetting interface: scaptureBitmapAsync methods
-* XWalkView interface: load methods
+* XWalkView interface: load, scaptureBitmapAsync methods
 
 
 
@@ -797,3 +796,13 @@ This usecase covers following interface and methods:
 
 * XWalkResourceClient interface: onReceivedResponseHeaders
 * XWalkView interface: load methods
+
+
+
+### 78. The [XWalkViewWithGetFavicon](basic/XWalkViewWithGetFavicon.java) sample check XWalkView can get favicon from the html, include:
+
+* XWalkView API getFavicon method can work
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, getFavicon methods

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/basic/XWalkViewWithGetFavicon.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/basic/XWalkViewWithGetFavicon.java
@@ -1,0 +1,72 @@
+package org.xwalk.embedded.api.sample.basic;
+
+import org.xwalk.embedded.api.sample.R;
+
+import android.app.AlertDialog;
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.os.Message;
+import android.widget.ImageView;
+import android.widget.Button;
+import android.view.View;
+import android.view.View.OnClickListener;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkView;
+import org.xwalk.core.XWalkUIClient;
+
+public class XWalkViewWithGetFavicon extends XWalkActivity {
+    private XWalkView mXWalkView;
+    private ImageView mFavicon;
+    private Button mGetFavicon;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+    	super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_xwalk_view_with_get_favicon);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+    }
+
+    class TestXWalkUIClientBase extends XWalkUIClient {
+
+        public TestXWalkUIClientBase(XWalkView arg0) {
+            super(arg0);
+        }
+
+        @Override
+        public void onIconAvailable(XWalkView view, String url, Message msg) {
+            msg.sendToTarget();
+        }
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can get favicon from the html.\n\n")
+        .append("Expected Result:\n\n")
+        .append("1. Click the button 'Get Favicon'.\n")
+        .append("2. Test passes if image of cat shows.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView.setUIClient(new TestXWalkUIClientBase(mXWalkView));
+
+        mFavicon = (ImageView) findViewById(R.id.imageview);
+        mGetFavicon = (Button) findViewById(R.id.get_favicon_btn);
+        mGetFavicon.setOnClickListener(new OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                // TODO Auto-generated method stub
+                if (mXWalkView.getFavicon() != null) {
+                    mFavicon.setImageBitmap(mXWalkView.getFavicon());
+                }
+            }
+        });
+        mXWalkView.load("file:///android_asset/favicon.html", null);
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -957,6 +957,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithGetFavicon" purpose="XWalkViewWithGetFavicon Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -1915,8 +1927,46 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithGetFaviconAsync" purpose="XWalkViewWithGetFaviconAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="SilentDownload">
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkLayoutWithSilentDownload" purpose="XWalkView Layout Test With Silent Download">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkJSWithSilentDownload" purpose="XWalkView JS Test With Silent Download">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+    </set>
+    <set name="SilentDownload-LZMA">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkLayoutWithSilentDownload" purpose="XWalkView Layout Test With Silent Download">
         <description>
           <pre_condition />

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -1056,6 +1056,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithGetFavicon" purpose="XWalkViewWithGetFavicon Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -2009,8 +2021,48 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithGetFaviconAsync" purpose="XWalkViewWithGetFaviconAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="SilentDownload">
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkLayoutWithSilentDownload" platform="android" priority="P0" purpose="XWalkView Layout Test With Silent Download" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkJSWithSilentDownload" platform="android" priority="P0" purpose="XWalkView JS Test With Silent Download" status="approved" type="functional_positive">
+        <description>
+          <pre_condition />
+          <post_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+    </set>
+    <set name="SilentDownload-LZMA">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkLayoutWithSilentDownload" platform="android" priority="P0" purpose="XWalkView Layout Test With Silent Download" status="approved" type="functional_positive">
         <description>
           <pre_condition />


### PR DESCRIPTION
-Add usecase for XWalkView API getFavicon
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5420