### PR TITLE
[usecase] Add Set-Cookie test

### DIFF
--- a/usecase/usecase-webapi-xwalk-tests/samples/SetCookie/REAMDE.md
+++ b/usecase/usecase-webapi-xwalk-tests/samples/SetCookie/REAMDE.md
@@ -1,0 +1,11 @@
+## Feature Requirement
+
+https://crosswalk-project.org/jira/browse/XWALK-5985
+
+## Usecase Design
+
+This sample demonstrates HTTP response header Set-Cookie.
+
+This usecase covers following interface and methods:
+
+* XMLHttpRequest interface: open send getResponseHeader onreadystatechange

--- a/usecase/usecase-webapi-xwalk-tests/samples/SetCookie/index.html
+++ b/usecase/usecase-webapi-xwalk-tests/samples/SetCookie/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Wang, Chunyan <chunyanx.wang@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, width=device-width">
+<link rel="stylesheet" type="text/css" href="../../css/bootstrap.css">
+<link rel="stylesheet" type="text/css" href="../../css/main.css">
+<link rel="stylesheet" type="text/css" href="css/style.css">
+<script src="../../js/jquery-2.1.3.min.js"></script>
+<script src="../../js/bootstrap.min.js"></script>
+<script src="../../js/common.js"></script>
+<script src="../../js/tests.js"></script>
+<div id="header">
+  <h3 id="main_page_title"></h3>
+</div>
+<div class="content">
+  <iframe id="ifr" frameborder="no" height="400"
+          src="http://127.0.0.1:8081/opt/usecase-webapi-xwalk-tests/samples/SetCookie/res/iframe.html">
+  </iframe>
+</div>
+<div class="footer">
+  <div id="footer"></div>
+</div>
+<div class="modal fade" id="popup_info">
+  <p>Verifies the value of response header 'Set-Cookie'.</p>
+</div>
+

--- a/usecase/usecase-webapi-xwalk-tests/samples/SetCookie/res/headers.cgi
+++ b/usecase/usecase-webapi-xwalk-tests/samples/SetCookie/res/headers.cgi
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+#Copyright (c) 2015 Intel Corporation.
+#
+#Redistribution and use in source and binary forms, with or without modification,
+#are permitted provided that the following conditions are met:
+#
+#* Redistributions of works must retain the original copyright notice, this list
+#  of conditions and the following disclaimer.
+#* Redistributions in binary form must reproduce the original copyright notice,
+#  this list of conditions and the following disclaimer in the documentation
+#  and/or other materials provided with the distribution.
+#* Neither the name of Intel Corporation nor the names of its contributors
+#  may be used to endorse or promote products derived from this work without
+#  specific prior written permission.
+#
+#THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+#AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+#INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+#BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+#OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+#EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+echo "Connection: Keep-Alive"
+echo "Content-Encoding: gzip"
+echo "Content-Length: 1449"
+echo "Content-Type: text/html"
+echo "Date: Sat, 26 Dec 2015 08:10:10 GMT"
+echo "Last-Modified: Fri, 25 Dec 2015 07:05:59 GMT"
+echo "Server: Mongoose/1.3 (Linux)"
+echo "Set-Cookie: theme=light"
+echo "Set-Cookie: user_session=abc123; expires=Sat, 09-Jan-2016 23:59:59 GMT; path=/"
+echo "Vary: Accept-Encoding"
+echo
+echo "TEST"

--- a/usecase/usecase-webapi-xwalk-tests/samples/SetCookie/res/iframe.html
+++ b/usecase/usecase-webapi-xwalk-tests/samples/SetCookie/res/iframe.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<meta charset="utf-8">
+<title>Reference File</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Chunyan Wang" href="mailto:chunyanx.wang@intel.com">
+<body onload="oninit()">
+  <ul>
+    <li>Content-Length:<span id="clength" style="color:green;"></span></li>
+    <li>Content-Type:<span id="ctype" style="color:green;"></span></li>
+    <li>Date:<span id="date" style="color:green;"></span></li>
+    <li>Last-Modified:<span id="lmodified" style="color:green;"></span></li>
+    <li>Server:<span id="server" style="color:green;"></span></li>
+    <li>Set-Cookie:<span id="cookie" style="color:green;"></span></li>
+  </ul>
+
+  <script>
+    function oninit() {
+      var txtCLength = document.getElementById("clength");
+      var txtType = document.getElementById("ctype");
+      var txtDate = document.getElementById("date");
+      var txtLModified = document.getElementById("lmodified");
+      var txtServer = document.getElementById("server");
+      var txtCookie = document.getElementById("cookie");
+
+      var request = new XMLHttpRequest();
+      var url = "http://127.0.0.1:8081/opt/usecase-webapi-xwalk-tests/samples/SetCookie/res/headers.cgi";
+      request.onreadystatechange = function() {
+        if(request.readyState == 4) {
+          txtCLength.textContent = request.getResponseHeader("Content-Length");
+          txtType.textContent = request.getResponseHeader("Content-Type");
+          txtDate.textContent = request.getResponseHeader("Date");
+          txtLModified.textContent = request.getResponseHeader("Last-Modified");
+          txtServer.textContent = request.getResponseHeader("Server");
+          txtCookie.textContent = request.getResponseHeader("Set-Cookie");
+        }
+      }
+      request.open("GET", url);
+      request.send(null);
+    }
+  </script>
+</body>
+

--- a/usecase/usecase-webapi-xwalk-tests/steps/SetCookie/step.js
+++ b/usecase/usecase-webapi-xwalk-tests/steps/SetCookie/step.js
@@ -1,0 +1,8 @@
+var step = '<font class="fontSize">'
+         + '<p>Test Purpose: </p>'
+         + '<p>Verifies HTTP response header "Set-Cookie".</p>'
+         + '<p>Test steps: </p>'
+         + '<p>Check the "Set-Cookie" value.</p>'
+         + '<p>Expected Result: </p>'
+         + '<p>Test passes if it should get the response header value expect "Set-Cookie", the value of "Set-Cookie" should be null.</p>'
+         + '</font>'

--- a/usecase/usecase-webapi-xwalk-tests/suite.json
+++ b/usecase/usecase-webapi-xwalk-tests/suite.json
@@ -20,6 +20,7 @@
         "data": "data",
         "inst.apk.py": "inst.py",
         "samples/CSP/res/resources": "csp/resources",
+        "samples/SetCookie/res": "setcookie/res",
         "tests.android.xml": "tests.xml",
         "tests.auto.xml": "tests.auto.xml",
         "tests.full.xml": "tests.full.xml",

--- a/usecase/usecase-webapi-xwalk-tests/tests.android.xml
+++ b/usecase/usecase-webapi-xwalk-tests/tests.android.xml
@@ -57,6 +57,8 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/WebAPI" execution_type="auto" id="WebStorage" purpose="Web Storage">
       </testcase>
+      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="SetCookie" purpose="SetCookie">
+      </testcase>
     </set>
     <set background="brand-danger" icon="glyphicon-th-large" name="Performance &amp;amp; Optimization">
       <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="AnimationTiming" purpose="Animation Timing">

--- a/usecase/usecase-webapi-xwalk-tests/tests.full.xml
+++ b/usecase/usecase-webapi-xwalk-tests/tests.full.xml
@@ -86,6 +86,8 @@
           <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-webapi-xwalk-tests/testscripts/WebStorage.feature</bdd_test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/WebAPI" type="functional_positive" status="approved" execution_type="manual" platform="android" priority="P0" id="SetCookie" purpose="SetCookie">
+      </testcase>
     </set>
     <set name="Performance &amp;amp; Optimization" background="brand-danger" icon="glyphicon-th-large" type="js" ui-auto="bdd">
       <testcase component="Crosswalk Use Cases/WebAPI" type="functional_positive" status="approved" execution_type="manual" platform="all" priority="P0" id="AnimationTiming" purpose="Animation Timing">


### PR DESCRIPTION
The XMLHttpRequest API need docroot for usecase in tinyweb, it is blocked by
https://crosswalk-project.org/jira/browse/XWALK-5905.

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: Crosswalk Project for Android 18.46.455.0
Unit test result summary: pass 1, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5985