### PR TITLE
[usecase-wrt]Update suite.json for packing

### DIFF
--- a/usecase/usecase-wrt-android-tests/suite.json
+++ b/usecase/usecase-wrt-android-tests/suite.json
@@ -19,6 +19,7 @@
       },
       "subapp-list": {
         ".": {
+          "app-name": "usecase-wrt-android-tests",
           "apk-common-opts": "--enable-remote-debugging",
           "blacklist": [
             "manifest.json"
@@ -96,7 +97,7 @@
           "apk-type": "MANIFEST"
         },
         "samples/SchemeContent/res": {
-          "apk-type": "MANIFEST",
+          "apk-type": "MANIFEST"
         },
         "samples/SchemesCheck/res": {
           "apk-type": "MANIFEST"
@@ -172,6 +173,7 @@
       },
       "subapp-list": {
         ".": {
+          "app-name": "usecase-wrt-android-tests",
           "apk-common-opts": "--enable-remote-debugging",
           "blacklist": [
             "manifest.json"
@@ -313,6 +315,7 @@
       },
       "subapp-list": {
         ".": {
+          "app-name": "usecase-wrt-android-tests",
           "apk-common-opts": "--enable-remote-debugging",
           "blacklist": [
             "manifest.json"


### PR DESCRIPTION
Add app-name property for all the subapp to avoid packing errors.
Fix a JSON format error.

Related to: https://crosswalk-project.org/jira/browse/XWALK-6058