### PR TITLE
[usecase-wrt] Guarantee subapp VideoPlay WRITE_EXTERNAL_STORAGE permi…

### DIFF
--- a/usecase/usecase-wrt-android-tests/samples/VideoPlay/res/manifest.json
+++ b/usecase/usecase-wrt-android-tests/samples/VideoPlay/res/manifest.json
@@ -1,5 +1,8 @@
 {
   "name": "videoplay",
   "start_url": "index.html",
-  "xwalk_package_id": "org.xwalk.videoplay"
+  "xwalk_package_id": "org.xwalk.videoplay",
+  "xwalk_android_permissions": [
+    "WRITE_EXTERNAL_STORAGE"
+  ]
 }


### PR DESCRIPTION
…ssion

VideoPlay requires to access external storage, so guarantee the
WRITE_EXTERNAL_STORAGE permission for the this app.

BUG=https://crosswalk-project.org/jira/browse/XWALK-6062