### PR TITLE
[Crosswalk-16][misc] Update sampleapp android to support 64bit

### DIFF
--- a/misc/sampleapp-android-tests/sampleapp/comm.py
+++ b/misc/sampleapp-android-tests/sampleapp/comm.py
@@ -54,17 +54,11 @@ def setUp():
         sys.exit(1)
 
     fp = open(const_path + "/../arch.txt", 'r')
-    if fp.read().strip("\n\t") != "x86":
-        ARCH = "arm"
-    else:
-        ARCH = "x86"
+    ARCH = fp.read().strip("\n\t")
     fp.close()
 
     mode = open(const_path + "/../mode.txt", 'r')
-    if mode.read().strip("\n\t") != "shared":
-        MODE = "embedded"
-    else:
-        MODE = "shared"
+    MODE = mode.read().strip("\n\t")
     mode.close()
 
 

--- a/misc/sampleapp-android-tests/sampleapp/extensionsandroid_pack.py
+++ b/misc/sampleapp-android-tests/sampleapp/extensionsandroid_pack.py
@@ -50,11 +50,15 @@ def init(xmlpath):
     for elem in tree.iter(tag='property'):
         xwalk_version_name = elem.attrib.get('name')
         if xwalk_version_name == 'crosswalk-version':
-            #elem.set(str(elem.attrib.items()[1][0]),'15.44.375.0')
+            # 64bit support
+            if "64" in comm.ARCH:
+                xwalk_version = xwalk_version + "-64bit"
+            #elem.set(str(elem.attrib.items()[1][0]),'16.45.421.19-64bit')
             elem.set(str(elem.attrib.items()[1][0]), xwalk_version)
             for node in tree.iter(tag='get'):
-                #src_val = node.attrib.get('src').replace('stable', 'canary')
-                src_val = node.attrib.get('src').replace('stable', channel)
+                #src_val = https://download.01.org/crosswalk/releases/crosswalk/android/beta/16.45.421.19/crosswalk-16.45.421.19-64bit.zip
+                src_val = "https://download.01.org/crosswalk/releases/crosswalk/android/%s/%s/crosswalk-%s.zip" \
+                          % (channel, os.environ.get('XWALK_VERSION'), xwalk_version)
                 print node.attrib.items()[1][0]
                 node.set(str(node.attrib.items()[1][0]), src_val)
                 print src_val


### PR DESCRIPTION
- Crosswalk-16 branch need to be tested with Sampleapp sourcecode for Crosswalk-16
- Support 64bit android testing
- XWALK-5742 sampleapp switch function fail in 64bit android

Impacted TCs num(approved): New 0, Update 83, Delete 0
Unit test Platform: Android Crosswalk Canary 16.45.421.19-64bit
Android test result summary: Pass 78, Fail 5, Block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5818