### PR TITLE
[usecase] Add permissions in manifest.json

### DIFF
--- a/usecase/usecase-webapi-xwalk-tests/manifest.json
+++ b/usecase/usecase-webapi-xwalk-tests/manifest.json
@@ -10,11 +10,16 @@
   "name": "usecase-webapi-xwalk-tests",
   "start_url": "index.html",
   "xwalk_description": "WebAPIUsecase",
-  "xwalk_permissions": [
-    "Contacts",
-    "Geolocation",
-    "Vibration",
-    "WifiDirect"
+  "xwalk_package_id": "org.xwalk.usecase_webapi_xwalk_tests",
+  "xwalk_android_permissions": [
+    "CAMERA",
+    "MODIFY_AUDIO_SETTINGS",
+    "RECORD_AUDIO",
+    "ACCESS_FINE_LOCATION",
+    "VIBRATE",
+    "CHANGE_WIFI_STATE",
+    "CHANGE_NETWORK_STATE",
+    "BILLING"
   ],
-  "xwalk_version": "0.1"
+  "xwalk_app_version": "0.1"
 }

--- a/usecase/usecase-webapi-xwalk-tests/suite.json
+++ b/usecase/usecase-webapi-xwalk-tests/suite.json
@@ -29,6 +29,7 @@
         ".": {
           "apk-common-opts": "--enable-remote-debugging",
           "app-name": "usecase-webapi-xwalk-tests",
+          "apk-type": "MANIFEST",
           "blacklist": [
             "*",
             ".git"
@@ -36,6 +37,7 @@
           "copylist": {
             "PACK-TOOL-ROOT/bootstrap-fw": ".",
             "icon.png": "icon.png",
+            "manifest.json": "manifest.json",
             "res": "res",
             "samples": "samples",
             "steps": "steps",

--- a/usecase/usecase-wrt-android-tests/samples/OpenFile/res/manifest.json
+++ b/usecase/usecase-wrt-android-tests/samples/OpenFile/res/manifest.json
@@ -8,5 +8,9 @@
   "name": "openfile",
   "start_url": "index.html",
   "xwalk_app_version": "0.1",
-  "xwalk_package_id": "org.xwalk.openfile"
+  "xwalk_package_id": "org.xwalk.openfile",
+  "xwalk_android_permissions": [
+    "READ_EXTERNAL_STORAGE",
+    "WRITE_EXTERNAL_STORAGE"
+  ]
 }

--- a/usecase/usecase-wrt-android-tests/samples/PermissionApiContacts/res/manifest.json
+++ b/usecase/usecase-wrt-android-tests/samples/PermissionApiContacts/res/manifest.json
@@ -8,7 +8,8 @@
   "name": "permission_api_contacts",
   "start_url": "index.html",
   "xwalk_android_permissions": [
-    "Contacts"
+    "READ_CONTACTS",
+    "WRITE_CONTACTS"
   ],
   "xwalk_app_version": "1.0.0",
   "xwalk_package_id": "org.xwalk.permissionapicontacts"


### PR DESCRIPTION
- Add permissions:</br>
  CAMERA</br>
  MODIFY_AUDIO_SETTINGS</br>
  RECORD_AUDIO</br>
  ACCESS_FINE_LOCATION</br>
  VIBRATE</br>
  CHANGE_WIFI_STATE</br>
  CHANGE_NETWORK_STATE</br>
  BILLING</br>
  READ_EXTERNAL_STORAGE</br>
  WRITE_EXTERNAL_STORAGE</br>
  READ_CONTACTS</br>
  WRITE_CONTACTS</br>
- Update xwalk_permissions to xwalk_android_permissions
- Update xwalk_version to xwalk_app_version
- Failure Analysis:
  Not find permissions for Notifications and Midi SysEx.

Impacted tests(approved): new 0, update 10, delete 0
Unit test platform: Crosswalk Project for Android 18.46.453.0
Unit test result summary: pass 9, fail 1, block 0

https://crosswalk-project.org/jira/browse/XWALK-6092