### PR TITLE
[wrt] Update tests using make_apk.py by app tools

### DIFF
--- a/wrt/wrt-security-android-tests/README.md
+++ b/wrt/wrt-security-android-tests/README.md
@@ -14,6 +14,17 @@ This test suite is for wrt-security-android-tests
 4. Need to edit the file "wrt-security-android-tests/mode.txt" according to the mode of build.
    If test need "embedded" mode, content of the file should be "embedded".
 
+5. Set CROSSWALK_APP_TOOLS_CACHE_DIR
+  ```export CROSSWALK_APP_TOOLS_CACHE_DIR=[local-path]```
+
+6. Clone crosswalk-app-tools to CROSSWALK_APP_TOOLS_CACHE_DIR
+   ```
+   git clone https://github.com/crosswalk-project/crosswalk-app-tools
+   cd crosswalk-app-tools
+   sudo npm install
+   ```
+7. Download the crosswalk zip you want to test to CROSSWALK_APP_TOOLS_CACHE_DIR
+
 ## Test Step
 
 1. unzip wrt-security-android-tests<version>.zip -d [testprefix-path]
@@ -24,7 +35,8 @@ This test suite is for wrt-security-android-tests
 
    testkit-lite -f [testprefix-path]/opt/wrt-security-android-tests/tests.xml -A
    -o [testprefix-path]/opt/wrt-security-android-tests/result.xml --comm localhost
-   --testenvs "DEVICE_ID=Medfield3C6DFF2E;CONNECT_TYPE=adb" --testprefix=[testprefix-path]
+   --testenvs "DEVICE_ID=Medfield3C6DFF2E;CONNECT_TYPE=adb;XWALK_VERSION=18.46.458.0"
+   --testprefix=[testprefix-path]
 
   DEVICE_ID can also be multiple ids like "DEVICE_ID=Medfield3C6DFF2E,Medfield3C6DFF00".
   Query device id by command "adb devices -l" in host.

--- a/wrt/wrt-security-android-tests/security/permissiontest.py
+++ b/wrt/wrt-security-android-tests/security/permissiontest.py
@@ -34,41 +34,39 @@ import sys
 import commands
 import comm
 
+comm.setUp()
 
 class TestSecurityFunctions(unittest.TestCase):
 
     def test_permission_chinese(self):
-        comm.setUp()
-        manifestPath = comm.ConstPath + \
-            "/../testapp/permission_field_chinese_tests/manifest.json"
-        cmd = "python %smake_apk.py --package=org.xwalk.example --arch=%s --mode=%s --manifest=%s" % \
-              (comm.Pck_Tools, comm.ARCH, comm.MODE, manifestPath)
+        app_src = comm.ConstPath + \
+            "/../testapp/permission_field_chinese_tests"
+        cmd = "%s --crosswalk=%s --platforms=android --android=%s --targets=%s %s" % \
+              (comm.apptools, comm.crosswalkzip, comm.MODE, comm.ARCH, app_src)
         packInfo = commands.getstatusoutput(cmd)
         self.assertNotEquals(0, packInfo[0])
 
     def test_permission_noapi(self):
-        comm.setUp()
-        manifestPath = comm.ConstPath + \
-            "/../testapp/permission_field_noapi_tests/manifest.json"
-        cmd = "python %smake_apk.py --package=org.xwalk.example --arch=%s --mode=%s --manifest=%s" % \
-              (comm.Pck_Tools, comm.ARCH, comm.MODE, manifestPath)
+        app_src = comm.ConstPath + \
+            "/../testapp/permission_field_noapi_tests"
+        cmd = "%s --crosswalk=%s --platforms=android --android=%s --targets=%s %s" % \
+              (comm.apptools, comm.crosswalkzip, comm.MODE, comm.ARCH, app_src)
         packInfo = commands.getstatusoutput(cmd)
         self.assertNotEquals(0, packInfo[0])
 
     def test_permission_null(self):
-        comm.setUp()
-        manifestPath = comm.ConstPath + \
-            "/../testapp/permission_field_null_tests/manifest.json"
-        cmd = "python %smake_apk.py --package=org.xwalk.example --arch=%s --mode=%s --manifest=%s" % \
-              (comm.Pck_Tools, comm.ARCH, comm.MODE, manifestPath)
-        comm.gen_pkg(cmd, self)
+        app_name = "permission_field_null_tests"
+        app_src = comm.ConstPath + \
+            "/../testapp/permission_field_null_tests"
+        cmd = "%s --crosswalk=%s --platforms=android --android=%s --targets=%s %s" % \
+              (comm.apptools, comm.crosswalkzip, comm.MODE, comm.ARCH, app_src)
+        comm.gen_pkg(cmd, app_name, self)
 
     def test_permission_splite(self):
-        comm.setUp()
-        manifestPath = comm.ConstPath + \
-            "/../testapp/permission_field_splite_tests/manifest.json"
-        cmd = "python %smake_apk.py --package=org.xwalk.example --arch=%s --mode=%s --manifest=%s" % \
-              (comm.Pck_Tools, comm.ARCH, comm.MODE, manifestPath)
+        app_src = comm.ConstPath + \
+            "/../testapp/permission_field_splite_tests"
+        cmd = "%s --crosswalk=%s --platforms=android --android=%s --targets=%s %s" % \
+              (comm.apptools, comm.crosswalkzip, comm.MODE, comm.ARCH, app_src)
         packInfo = commands.getstatusoutput(cmd)
         self.assertNotEquals(0, packInfo[0])
 

--- a/wrt/wrt-security-android-tests/suite.json
+++ b/wrt/wrt-security-android-tests/suite.json
@@ -13,7 +13,6 @@
     "apk,cordova": {
       "blacklist": [],
       "copylist": {
-        "PACK-TOOL-ROOT/crosswalk": "tools/crosswalk",
         "PACK-TOOL-ROOT/resources/xsl": ".",
         "arch.txt": "arch.txt",
         "mode.txt": "mode.txt",

--- a/wrt/wrt-security-android-tests/testapp/permission_field_chinese_tests/manifest.json
+++ b/wrt/wrt-security-android-tests/testapp/permission_field_chinese_tests/manifest.json
@@ -1,7 +1,8 @@
 {
   "name": "permission_field_chinese_tests",
   "start_url": "index.html",
-  "xwalk_permissions": [
+  "xwalk_package_id": "org.xwalk.permission_field_chinese_tests",
+  "xwalk_android_permissions": [
     "\u4fe1\u606f"
   ]
 }

--- a/wrt/wrt-security-android-tests/testapp/permission_field_noapi_tests/manifest.json
+++ b/wrt/wrt-security-android-tests/testapp/permission_field_noapi_tests/manifest.json
@@ -1,7 +1,8 @@
 {
   "name": "permission_field_noapi_tests",
   "start_url": "index.html",
-  "xwalk_permissions": [
+  "xwalk_package_id": "org.xwalk.permission_field_noapi_tests",
+  "xwalk_android_permissions": [
     "getapi"
   ]
 }

--- a/wrt/wrt-security-android-tests/testapp/permission_field_null_tests/manifest.json
+++ b/wrt/wrt-security-android-tests/testapp/permission_field_null_tests/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "permission_field_null_tests",
   "start_url": "index.html",
-  "xwalk_permissions": []
+  "xwalk_package_id": "org.xwalk.permission_field_null_tests",
+  "xwalk_android_permissions": []
 }

--- a/wrt/wrt-security-android-tests/testapp/permission_field_splite_tests/manifest.json
+++ b/wrt/wrt-security-android-tests/testapp/permission_field_splite_tests/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "permission_field_split_tests",
   "start_url": "index.html",
-  "permissions": ["Messaging":"Contacts"]
+  "xwalk_package_id": "org.xwalk.permission_field_split_tests",
+  "xwalk_android_permissions": ["VIBRATE":"READ_CONTACTS"]
 }


### PR DESCRIPTION
- Replace make_apk.py by app tools
- Support 64bit
- Failure analysis:
  XWALK-6016 Build both x86 and arm apk using crosswalk-pkg with "--targets=x86"

Impacted tests(approved): new 0, update 4, delete 0
Unit test platform: Crosswalk Project for Android 18.46.458.0
Unit test result summary: pass 2, fail 2, block 0

https://crosswalk-project.org/jira/browse/XWALK-5737