### PR TITLE
[EmbeddingAPI-autocase] Fix the testOnLoadStartedWithLocalUrl case bug

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v1/XWalkResourceClientTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v1/XWalkResourceClientTest.java
@@ -46,9 +46,9 @@ public class XWalkResourceClientTest extends XWalkViewTestBase {
     }
 
     @SmallTest
-    public void testOnLoadStartedWithLocalUrl() {
+    public void testOnLoadStartedWithLoadUrl() {
         try {
-            String url = "file:///android_asset/index.html";
+            String url = "http://m.baidu.com/";
             OnLoadStartedHelper mOnLoadStartedHelper = mTestHelperBridge.getOnLoadStartedHelper();
             int currentCallCount = mOnLoadStartedHelper.getCallCount();
             loadUrlAsync(url);
@@ -228,7 +228,7 @@ public class XWalkResourceClientTest extends XWalkViewTestBase {
         } catch (Exception e) {
             assertTrue(false);
             e.printStackTrace();
-        }  
+        }
     }
 
     @SmallTest
@@ -332,9 +332,9 @@ public class XWalkResourceClientTest extends XWalkViewTestBase {
                     new WebResourceResponse("text/html", "UTF-8", new EmptyInputStream()));
             int shouldInterceptRequestCallCount = mShouldInterceptLoadRequestHelper.getCallCount();
             int onPageFinishedCallCount = mTestHelperBridge.getOnPageFinishedHelper().getCallCount();
-    
+
             loadUrlAsync(aboutPageUrl);
-    
+
             mShouldInterceptLoadRequestHelper.waitForCallback(shouldInterceptRequestCallCount);
             mTestHelperBridge.getOnPageFinishedHelper().waitForCallback(onPageFinishedCallCount);
         } catch (Exception e) {
@@ -473,7 +473,7 @@ public class XWalkResourceClientTest extends XWalkViewTestBase {
             loadUrlAsync(existingFileUrl);
             mShouldInterceptLoadRequestHelper.waitForCallback(callCount);
             assertEquals(existingFileUrl, mShouldInterceptLoadRequestHelper.getUrls().get(0));
-    
+
             mTestHelperBridge.getOnPageFinishedHelper().waitForCallback(onPageFinishedCallCount);
             assertEquals(title, getTitleOnUiThread());
             assertEquals(onPageFinishedCallCount + 1,
@@ -566,7 +566,7 @@ public class XWalkResourceClientTest extends XWalkViewTestBase {
             e.printStackTrace();
         }
     }
-    
+
     @SmallTest
     public void testOnReceivedLoadErrorOnFailedSubresourceLoad() {
         try {

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v1/XWalkResourceClientTestAsync.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v1/XWalkResourceClientTestAsync.java
@@ -46,9 +46,9 @@ public class XWalkResourceClientTestAsync extends XWalkViewTestBase {
     }
 
     @SmallTest
-    public void testOnLoadStartedWithLocalUrl() {
+    public void testOnLoadStartedWithLoadUrl() {
         try {
-            String url = "file:///android_asset/index.html";
+            String url = "http://m.baidu.com/";
             OnLoadStartedHelper mOnLoadStartedHelper = mTestHelperBridge.getOnLoadStartedHelper();
             int currentCallCount = mOnLoadStartedHelper.getCallCount();
             loadUrlAsync(url);
@@ -228,7 +228,7 @@ public class XWalkResourceClientTestAsync extends XWalkViewTestBase {
         } catch (Exception e) {
             assertTrue(false);
             e.printStackTrace();
-        }  
+        }
     }
 
     @SmallTest
@@ -332,9 +332,9 @@ public class XWalkResourceClientTestAsync extends XWalkViewTestBase {
                     new WebResourceResponse("text/html", "UTF-8", new EmptyInputStream()));
             int shouldInterceptRequestCallCount = mShouldInterceptLoadRequestHelper.getCallCount();
             int onPageFinishedCallCount = mTestHelperBridge.getOnPageFinishedHelper().getCallCount();
-    
+
             loadUrlAsync(aboutPageUrl);
-    
+
             mShouldInterceptLoadRequestHelper.waitForCallback(shouldInterceptRequestCallCount);
             mTestHelperBridge.getOnPageFinishedHelper().waitForCallback(onPageFinishedCallCount);
         } catch (Exception e) {
@@ -473,7 +473,7 @@ public class XWalkResourceClientTestAsync extends XWalkViewTestBase {
             loadUrlAsync(existingFileUrl);
             mShouldInterceptLoadRequestHelper.waitForCallback(callCount);
             assertEquals(existingFileUrl, mShouldInterceptLoadRequestHelper.getUrls().get(0));
-    
+
             mTestHelperBridge.getOnPageFinishedHelper().waitForCallback(onPageFinishedCallCount);
             assertEquals(title, getTitleOnUiThread());
             assertEquals(onPageFinishedCallCount + 1,
@@ -566,7 +566,7 @@ public class XWalkResourceClientTestAsync extends XWalkViewTestBase {
             e.printStackTrace();
         }
     }
-    
+
     @SmallTest
     public void testOnReceivedLoadErrorOnFailedSubresourceLoad() {
         try {


### PR DESCRIPTION
-Fix the testOnLoadStartedWithLocalUrl case bug
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 0, update 2, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-3508