### PR TITLE
[apptools-android] Remove the duplicated module for apptools android

### DIFF
--- a/apptools/apptools-android-tests/apptools/CI/crosswalk_pkg_basic.py
+++ b/apptools/apptools-android-tests/apptools/CI/crosswalk_pkg_basic.py
@@ -30,7 +30,6 @@
 
 import unittest
 import os
-import comm
 import zipfile
 import shutil
 from xml.etree import ElementTree


### PR DESCRIPTION
Failure analysis:
https://crosswalk-project.org/jira/browse/XWALK-6016

Impacted tests(approved): new 0, update 10, delete 0
Unit test platform: [Android]
Unit test result summary: pass 9, fail 1, block 0