### PR TITLE
[apptools-android] Add tests to test build external extensions without .js file for apptools android

### DIFF
--- a/apptools/apptools-android-tests/apptools/Manifest_ContactExtension.html
+++ b/apptools/apptools-android-tests/apptools/Manifest_ContactExtension.html
@@ -48,9 +48,7 @@ Authors:
         &nbsp; &nbsp; Lite Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ ./crosswalk-app-tools/src/crosswalk-app create org.xwalk.test --android-lite --android-crosswalk=<path to release crosswalk zip> <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
-        &nbsp; &nbsp; Cope ../../../testapp/extension_permission to app/ <br/>
-        &nbsp; &nbsp; Set "start_url" to "extension_permission/index.html" in app/manifest.json file <br/>
-        &nbsp; &nbsp; Add '"xwalk_extensions": ["extension_permission/contactextension"]' to app/manifest.json file <br/>
+        &nbsp; &nbsp; Cope ../../../testapp/extension_permission/* to app/, instead of index.html and manifest.json <br/>
         &nbsp; &nbsp; $ ../crosswalk-app-tools/src/crosswalk-app build <br/>
         On Windows host: <br/>
         &nbsp; &nbsp; Shared Mode: <br/>
@@ -60,9 +58,7 @@ Authors:
         &nbsp; &nbsp; Lite Mode: <br/>
         &nbsp; &nbsp; &nbsp; &nbsp; $ node .\crosswalk-app-tools\src\crosswalk-app create org.xwalk.test --android-lite --android-crosswalk=<path to release crosswalk zip> <br/>
         &nbsp; &nbsp; $ cd org.xwalk.test <br/>
-        &nbsp; &nbsp; Cope ..\..\..\testapp\extension_permission to app\ <br/>
-        &nbsp; &nbsp; Set "start_url" to "extension_permission/index.html" in app\manifest.json file <br/>
-        &nbsp; &nbsp; Add '"xwalk_extensions": ["extension_permission/contactextension"]' to app\manifest.json file <br/>
+        &nbsp; &nbsp; Cope ..\..\..\testapp\extension_permission\* to app\, instead of index.html and manifest.json <br/>
         &nbsp; &nbsp; $ node ..\crosswalk-app-tools\src\crosswalk-app build <br/>
         Shared Mode: <br/>
         &nbsp; &nbsp; Install shared mode app on android device which is "arm" architecture <br/>

--- a/apptools/apptools-android-tests/apptools/create_package.py
+++ b/apptools/apptools-android-tests/apptools/create_package.py
@@ -363,5 +363,39 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(return_code, 0)
         self.assertEquals(data['xwalk_package_id'].strip(os.linesep), "org.xwalk.test")
 
+    def test_extensions_without_jsFile(self):
+        comm.setUp()
+        os.chdir(comm.XwalkPath)
+        comm.clear("org.xwalk.test")
+        os.mkdir("org.xwalk.test")
+        os.chdir('org.xwalk.test')
+        shutil.copytree(comm.ConstPath + "/../testapp/extension_permission/", comm.XwalkPath + "/org.xwalk.test/extension_permission/")
+        os.remove(comm.XwalkPath + "/org.xwalk.test/extension_permission/contactextension/contactextension.js")
+        cmd = comm.HOST_PREFIX + comm.PackTools + \
+            "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + " --crosswalk=" + comm.crosswalkzip + " " + comm.XwalkPath + "/org.xwalk.test/extension_permission/"
+        return_code = os.system(cmd)
+        apks = os.listdir(os.getcwd())
+        apkLength = 0
+        if comm.MODE != " --android-shared":
+            for i in range(len(apks)):
+                if apks[i].endswith(".apk") and "x86" in apks[i]:
+                    if comm.BIT == "64":
+                        self.assertIn("64", apks[i])
+                    apkLength = apkLength + 1
+                if apks[i].endswith(".apk") and "arm" in apks[i]:
+                    if comm.BIT == "64":
+                        self.assertIn("64", apks[i])
+                    apkLength = apkLength + 1
+            self.assertEquals(apkLength, 2)
+        else:
+            for i in range(len(apks)):
+                if apks[i].endswith(".apk") and "shared" in apks[i]:
+                    apkLength = apkLength + 1
+                    appVersion = apks[i].split('-')[1]
+            self.assertEquals(apkLength, 1)
+        comm.run(self)
+        comm.clear("org.xwalk.test")
+        self.assertEquals(return_code, 0)
+
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-android-tests/testapp/extension_permission/manifest.json
+++ b/apptools/apptools-android-tests/testapp/extension_permission/manifest.json
@@ -1,0 +1,9 @@
+{
+  "xwalk_package_id": "org.xwalk.test",
+  "start_url": "index.html",
+  "xwalk_extensions": ["contactextension"],
+  "xwalk_app_version": "0.1",
+  "xwalk_target_platforms": [
+    "android"
+  ]
+}


### PR DESCRIPTION
Impacted tests(approved): new 1, update 1, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-5825