### PR TITLE
[Windows] Drop WebCL, Vibration related tests from usecase

### DIFF
--- a/usecase/usecase-webapi-xwalk-tests/tests.windows.xml
+++ b/usecase/usecase-webapi-xwalk-tests/tests.windows.xml
@@ -111,13 +111,9 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="Touch" purpose="Touch">
       </testcase>
-      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="Vibration" purpose="Vibration">
-      </testcase>
       <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="WebAudio" purpose="WebAudio">
       </testcase>
       <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="WebGL" purpose="WebGL">
-      </testcase>
-      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="auto" id="WebCL" purpose="WebCL">
       </testcase>
       <testcase component="Crosswalk Use Cases/WebAPI" execution_type="auto" id="WebCrypto" purpose="WebCrypto">
       </testcase>


### PR DESCRIPTION
Impacted tests(approved): new 0, update 0, delete 2
Unit test platform: Crosswalk Project for Windows 18.46.468.0
Unit test result summary: pass 0, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-6194