### PR TITLE
[usecase-webapi] Add an instruction to README

### DIFF
--- a/usecase/usecase-webapi-xwalk-tests/samples/IAPXiaomiStore/REAME.md
+++ b/usecase/usecase-webapi-xwalk-tests/samples/IAPXiaomiStore/REAME.md
@@ -3,6 +3,7 @@
 This example is for testing the in-app purchase API for Xiaomi App Store. So this example app can only be run on a MIUI system.
 ## Prerequisites
 * Get the latest ipa.zip from [Crosswalk android extension iap example](https://github.com/crosswalk-project/crosswalk-android-extensions/releases/), unzip it and copy the unzipped files to IapXiaomiStore/iap directory before you build the this app.
+* To use XiaoMi Store, you may need to embed the "MiGameCenterSDKService.apk" and put it under the crosswalk/template/assets folder before you build the app, please download it from [here](http://file.market.xiaomi.com/download/Wali/03e214556fc45326e72bf816ff501eb8f3d428294/MISDKservice4.4.33.rar)
 
 ## License
-Copyright (c) 2014 Intel Corporation. Except as noted, this software is licensed under BSD-3-Clause License. Please see the COPYING file for the BSD-3-Clause License.
+Copyright (c) 2016 Intel Corporation. Except as noted, this software is licensed under BSD-3-Clause License. Please see the COPYING file for the BSD-3-Clause License.


### PR DESCRIPTION
Add an instruction of embedding "MiGameCenterSDKService.apk" before building
sub app IAPXiaomiStore to README