### PR TITLE
[atip] Update environment set up script to support variable platforms

### DIFF
--- a/tools/atip/tests/environment.py
+++ b/tools/atip/tests/environment.py
@@ -31,6 +31,7 @@ import os
 import sys
 import json
 from atip import environment as atipenv
+from set_env import *
 reload(sys)
 sys.setdefaultencoding('utf-8')
 
@@ -98,6 +99,7 @@ def before_all(context):
     context.web = None
     context.android = None
     context.apps = {}
+    set_env_variables()
     context.bdd_config = load_default_config()
     if not context.bdd_config:
         sys.exit(1)

--- a/tools/atip/tools/set_env.py
+++ b/tools/atip/tools/set_env.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+import ConfigParser
+import sys
+import os
+
+PLATFROMS = ['android_xwalk', 'android_cordova', 'xw_deepin', 'chrome_ubuntu', 'windows']
+PLATFORM = 'android_xwalk'
+
+def read_config():
+    try:
+        global PLATFORM
+        config = ConfigParser.ConfigParser()
+        with open('data.conf', "r") as cfgfile:
+            config.readfp(cfgfile)
+        PLATFORM = config.get('info', 'env_platform')
+    except Exception as e:
+        print "Parser config data.config failed: %s" % e
+
+def set_env_variables():
+    read_config()
+    if PLATFORM not in PLATFROMS:
+        print 'Unsupportted platform type: %s' % PLATFORM
+        sys.exit(1)
+
+    if PLATFORM == 'android_xwalk':
+        os.environ.update({'TEST_PLATFORM' : 'android',\
+                           'DEVICE_ID': '',\
+                           'CONNECT_TYPE': 'adb',\
+                           'TIZEN_USER': '',\
+                           'LAUNCHER': 'XWalkLauncher',\
+                           'WEBDRIVER_VARS': '{"webdriver_url":"http://127.0.0.1:9515", "desired_capabilities": {"xwalkOptions": {"androidPackage": "TEST_PKG_NAME", "androidActivity": "TEST_ACTIVITY_NAME"}}, "test_prefix": "file:///android_asset/www/"}'})
+    elif PLATFORM == 'android_cordova':
+        os.environ.update({'TEST_PLATFORM' : 'android',\
+                           'DEVICE_ID': '',\
+                           'CONNECT_TYPE': 'adb',\
+                           'TIZEN_USER': '',\
+                           'LAUNCHER': 'CordovaLauncher',\
+                           'WEBDRIVER_VARS': '{"webdriver_url":"http://127.0.0.1:9515", "desired_capabilities": {"xwalkOptions": {"androidPackage": "TEST_PKG_NAME", "androidActivity": "TEST_ACTIVITY_NAME"}}, "test_prefix": "file:///android_asset/www/"}'})
+    elif PLATFORM == 'xw_deepin':
+        os.environ.update({'TEST_PLATFORM' : 'deepin',\
+                           'DEVICE_ID': '',\
+                           'CONNECT_TYPE': '',\
+                           'TIZEN_USER': '',\
+                           'LAUNCHER': 'CordovaLauncher',\
+                           'WEBDRIVER_VARS': '{"webdriver_url":"http://127.0.0.1:9515", "desired_capabilities": {"loggingPrefs":{},"xwalkOptions": {"binary": "/usr/bin/TEST_BINARY", "debugPort": "12450"}}}'})
+    elif PLATFORM == 'chrome_ubuntu':
+        os.environ.update({'TEST_PLATFORM' : 'chrome_ubuntu',\
+                           'DEVICE_ID': '',\
+                           'CONNECT_TYPE': '',\
+                           'TIZEN_USER': '',\
+                           'LAUNCHER': '',\
+                           'WEBDRIVER_VARS': '{"webdriver_url":"http://127.0.0.1:9515", "desired_capabilities": {"chrome.binary": "/usr/bin/chromium-browser"}, "test_prefix": "file:///"}'})
+    elif PLATFORM == 'windows':
+        os.environ.update({'TEST_PLATFORM' : 'windows',\
+                           'DEVICE_ID': '',\
+                           'CONNECT_TYPE': '',\
+                           'TIZEN_USER': '',\
+                           'LAUNCHER': '',\
+                           'WEBDRIVER_VARS': '{"webdriver_url":"http://127.0.0.1:9515", "desired_capabilities": {"loggingPrefs": {}, "xwalkOptions": { "binary": "C:\\\\Program Files\\\\TEST_BINARY"}}}'})

--- a/tools/resources/bdd/data.conf
+++ b/tools/resources/bdd/data.conf
@@ -1,3 +1,4 @@
 [info]
 platform=x86-memo
 test_type=result
+env_platform=android_xwalk


### PR DESCRIPTION
- Update environment set up script to python version in order to support variable
platforms

MEMO8 PAD:
webapi-devicecapabilities-w3c-tests:
Impacted TCs num(approved): New 0, Update 0, Delete 0
Unit test Platform: Crosswalk Project for Android 18.46.471.0
Unit test result summary: Pass 6, Fail 0, Blocked 0

In windows platform, process of bdd tests also works normally