### PR TITLE
[Cordova] Support to download and install 64 bit crosswalk canary aar by itself

### DIFF
--- a/usecase/usecase-cordova-android-tests/res/comm.py
+++ b/usecase/usecase-cordova-android-tests/res/comm.py
@@ -54,7 +54,7 @@ def setUp():
             CROSSWALK_BRANCH = pkg_version_json["crosswalk-branch"]
 
 
-def installCrosswalk(pkgmode):
+def installCrosswalk(pkgmode, pkgarch=None):
     if CROSSWALK_BRANCH == 'canary':
         username = commands.getoutput("echo $USER")
 
@@ -63,22 +63,28 @@ def installCrosswalk(pkgmode):
             pkg_mode_tmp = "core"
         xwalk_library_tmp = "xwalk_%s_library" % pkg_mode_tmp
 
+
         xwalk_library_path = "/home/%s/.m2/repository/org/xwalk/%s/%s/%s-%s" \
             % (username, xwalk_library_tmp, CROSSWALK_VERSION, xwalk_library_tmp, CROSSWALK_VERSION)
         repository_aar_path = "%s.aar" % (xwalk_library_path)
         repository_pom_path = "%s.pom" % (xwalk_library_path)
         if not os.path.exists(repository_aar_path) or not os.path.exists(repository_pom_path):
             aar_name = "crosswalk"
+            version_name = CROSSWALK_VERSION
+            classifier_tmp = ""
             if pkgmode == "shared":
                 aar_name = "crosswalk-shared"
+            elif pkgarch == "x86_64" or pkgarch == "arm64":
+               version_name = CROSSWALK_VERSION + "-64bit"
+               classifier_tmp = " -Dclassifier=64bit"
 
             wget_cmd = "wget https://download.01.org/crosswalk/releases/crosswalk/" \
                     "android/canary/%s/%s-%s.aar" % \
-                    (CROSSWALK_VERSION, aar_name, CROSSWALK_VERSION)
+                    (CROSSWALK_VERSION, aar_name, version_name)
             install_cmd = "mvn install:install-file -DgroupId=org.xwalk " \
                     "-DartifactId=%s -Dversion=%s -Dpackaging=aar " \
-                    "-Dfile=%s-%s.aar -DgeneratePom=true" % \
-                    (xwalk_library_tmp, CROSSWALK_VERSION, aar_name, CROSSWALK_VERSION)
+                    "-Dfile=%s-%s.aar -DgeneratePom=true%s" % \
+                    (xwalk_library_tmp, CROSSWALK_VERSION, aar_name, version_name, classifier_tmp)
             os.system(wget_cmd)
             os.system(install_cmd)
 

--- a/usecase/usecase-cordova-android-tests/samples/CrosswalkVersion/res/test.py
+++ b/usecase/usecase-cordova-android-tests/samples/CrosswalkVersion/res/test.py
@@ -62,14 +62,14 @@ pack_arch_tmp = "arm"
 if BUILD_PARAMETERS.pkgmode == "embedded":
     pkg_mode_tmp = "core"
 
-if BUILD_PARAMETERS.pkgarch and BUILD_PARAMETERS.pkgarch != "arm":
-    apk_name_arch = BUILD_PARAMETERS.pkgarch
-    if BUILD_PARAMETERS.pkgarch == "x86":
-        pack_arch_tmp = "x86"
-    elif BUILD_PARAMETERS.pkgarch == "x86_64":
-        pack_arch_tmp = "x86 --xwalk64bit"
-    elif BUILD_PARAMETERS.pkgarch == "arm64":
-        pack_arch_tmp = "arm --xwalk64bit"
+    if BUILD_PARAMETERS.pkgarch and BUILD_PARAMETERS.pkgarch != "arm":
+        apk_name_arch = BUILD_PARAMETERS.pkgarch
+        if BUILD_PARAMETERS.pkgarch == "x86":
+            pack_arch_tmp = "x86"
+        elif BUILD_PARAMETERS.pkgarch == "x86_64":
+            pack_arch_tmp = "x86 --xwalk64bit"
+        elif BUILD_PARAMETERS.pkgarch == "arm64":
+            pack_arch_tmp = "arm --xwalk64bit"
 
 VERSION_TYPES = []
 EXCEPTED_VERSIONS = []
@@ -94,7 +94,7 @@ elif comm.CROSSWALK_BRANCH == "canary":
             "xwalk_%s_library:%s" % (pkg_mode_tmp, comm.CROSSWALK_VERSION),
             "%s" % (comm.CROSSWALK_VERSION)]
     EXCEPTED_VERSIONS = [comm.CROSSWALK_VERSION, comm.CROSSWALK_VERSION, comm.CROSSWALK_VERSION]
-    comm.installCrosswalk(BUILD_PARAMETERS.pkgmode)
+    comm.installCrosswalk(BUILD_PARAMETERS.pkgmode, BUILD_PARAMETERS.pkgarch)
 else:
     print "CROSSWALK_BRANCH in VERSION file is unavailable"
     sys.exit(1)


### PR DESCRIPTION
- Download and install 64 bit crosswalk canary aar by itself

Impacted tests(approved): new 0, update 2, delete 0
Unit test platform: Crosswalk Project for android 19.48.483.0
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6301