### PR TITLE
[Crosswalk-18][webapi] Fix timeout issue in DeviceOrientation for Windows

### DIFF
--- a/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceAcceleration_attributes_readonly.html
+++ b/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceAcceleration_attributes_readonly.html
@@ -38,9 +38,7 @@ Authors:
 <script src="../resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  setup(function(){
-    tizen.power.turnScreenOn();
-  }, {explicit_done: true, timeout: 2000});
+  setup({explicit_done: true, timeout: 2000});
   var run = false;
   on_event(window, "devicemotion", function(event) {
     if(!run) {
@@ -62,9 +60,13 @@ Authors:
       }, "Check if the DeviceAccelerationt.z is readonly");
 
       done();
+
+      if(t) {
+         clearTimeout(t);
+      }
     }
   });
-  setTimeout(function () {
+  var t = setTimeout(function () {
     test(function() {
       assert_unreached("Can not fire devicemotion event");
     }, "Check if the DeviceAccelerationt.x is readonly");

--- a/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceAcceleration_attributes_test.html
+++ b/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceAcceleration_attributes_test.html
@@ -38,9 +38,7 @@ Authors:
 <script src="../resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  setup(function(){
-    tizen.power.turnScreenOn();
-  }, {explicit_done: true, timeout: 2000});
+  setup({explicit_done: true, timeout: 2000});
   var run = false;
   on_event(window, "devicemotion", function(event) {
     if(!run) {
@@ -51,46 +49,51 @@ Authors:
       }, "Check if the DeviceAccelerationt.x attribute exists");
 
       test(function() {
-        assert_equals(typeof event.acceleration.x, "number", "Attribute x is type of");
-      }, "Check if DeviceAcceleration.x is type of double");
+        assert_equals(event.acceleration.x, null, "Attribute x init value");
+      }, "Check if DeviceAcceleration.x init value is null");
 
       test(function() {
         assert_true("y" in acceleration, "Attribute y missing in Acceleration object");
       }, "Check if the DeviceAccelerationt.y attribute exists");
 
       test(function() {
-        assert_equals(typeof event.acceleration.y, "number", "Attribute y is type of");
-      }, "Check if DeviceAcceleration.y is type of double");
+        assert_equals(event.acceleration.y, null, "Attribute y init value");
+      }, "Check if DeviceAcceleration.y init value is null");
 
       test(function() {
         assert_true("z" in acceleration, "Attribute z missing in Acceleration object");
       }, "Check if the DeviceAccelerationt.z attribute exists");
 
       test(function() {
-        assert_equals(typeof event.acceleration.z, "number", "Attribute z is type of");
-      }, "Check if DeviceAcceleration.z is type of double");
+        assert_equals(event.acceleration.z, null, "Attribute z init value");
+      }, "Check if DeviceAcceleration.z init value is null");
+
       done();
+
+      if(t) {
+         clearTimeout(t);
+      }
     }
   });
-  setTimeout(function () {
+  var t = setTimeout(function () {
     test(function() {
       assert_unreached("Can not fire devicemotion event");
     }, "Check if the DeviceAccelerationt.x attribute exists");
     test(function() {
       assert_unreached("Can not fire devicemotion event");
-    }, "Check if DeviceAcceleration.x is type of double");
+    }, "Check if DeviceAcceleration.x init value is null");
     test(function() {
       assert_unreached("Can not fire devicemotion event");
     }, "Check if the DeviceAccelerationt.y attribute exists");
     test(function() {
       assert_unreached("Can not fire devicemotion event");
-    }, "Check if DeviceAcceleration.y is type of double");
+    }, "Check if DeviceAcceleration.y init value is null");
     test(function() {
       assert_unreached("Can not fire devicemotion event");
     }, "Check if the DeviceAccelerationt.z attribute exists");
     test(function() {
       assert_unreached("Can not fire devicemotion event");
-    }, "Check if DeviceAcceleration.z is type of double");
+    }, "Check if DeviceAcceleration.z init value is null");
     done();
   }, 1500)
 </script>

--- a/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceMotionEvent_attributes_readonly.html
+++ b/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceMotionEvent_attributes_readonly.html
@@ -38,9 +38,7 @@ Authors:
 <script src="../resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  setup(function(){
-    tizen.power.turnScreenOn();
-  }, {explicit_done: true, timeout: 2000});
+  setup({explicit_done: true, timeout: 2000});
   var run = false;
   on_event(window, "devicemotion", function(event) {
     if(!run) {
@@ -60,10 +58,15 @@ Authors:
         event.rotationRate = null;
         assert_not_equals(event.rotationRate, "null", "The event.rotationRate value");
       }, "Check if DeviceMotionEvent.rotationRate is readonly");
+
       done();
+
+      if(t) {
+         clearTimeout(t);
+      }
     }
   });
-  setTimeout(function () {
+  var t = setTimeout(function () {
     test(function() {
       assert_unreached("Can not fire devicemotion event");
     }, "Check if DeviceMotionEvent.accelerationIncludingGravity is readonly");

--- a/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceMotionEvent_attributes_test.html
+++ b/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceMotionEvent_attributes_test.html
@@ -38,9 +38,7 @@ Authors:
 <script src="../resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  setup(function(){
-    tizen.power.turnScreenOn();
-  }, {explicit_done: true, timeout: 2000});
+  setup({explicit_done: true, timeout: 2000});
   var run = false;
   on_event(window, "devicemotion", function(event) {
     if(!run) {
@@ -72,10 +70,15 @@ Authors:
       test(function() {
         assert_equals(typeof event.rotationRate, "object", "Attribute rotationRate in DeviceMotionEvent of type");
       }, "Check if DeviceMotionEvent.rotationRate is type of DeviceRotationRate");
+
       done();
+
+      if(t) {
+         clearTimeout(t);
+      }
     }
   });
-  setTimeout(function () {
+  var t = setTimeout(function () {
     test(function() {
       assert_unreached("Can not fire devicemotion event");
     }, "Check if the DeviceMotionEvent.acceleration method exists");

--- a/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceOrientationEvent_attributes_readonly.html
+++ b/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceOrientationEvent_attributes_readonly.html
@@ -38,9 +38,7 @@ Authors:
 <script src="../resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  setup(function(){
-    tizen.power.turnScreenOn();
-  }, {explicit_done: true, timeout: 2000});
+  setup({explicit_done: true, timeout: 2000});
   var run = false;
   on_event(window, "deviceorientation", function(event) {
     if(!run) {
@@ -64,10 +62,15 @@ Authors:
         event.gamma = null;
         assert_not_equals(event.gamma, "null", "The DeviceOrientationEvent.gamma value");
       }, "Check if DeviceOrientationEvent.gamma is readonly");
+
       done();
+
+      if(t) {
+         clearTimeout(t);
+      }
     }
   });
-  setTimeout(function () {
+  var t = setTimeout(function () {
     test(function() {
       assert_unreached("Can not fire deviceorientation event");
     }, "Check if DeviceOrientationEvent.absolute is readonly");

--- a/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceOrientationEvent_attributes_test.html
+++ b/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceOrientationEvent_attributes_test.html
@@ -38,9 +38,7 @@ Authors:
 <script src="../resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  setup(function(){
-    tizen.power.turnScreenOn();
-  }, {explicit_done: true, timeout: 2000});
+  setup({explicit_done: true, timeout: 2000});
   var run = false;
   on_event(window, "deviceorientation", function(event) {
     if(!run) {
@@ -76,10 +74,15 @@ Authors:
       test(function() {
         assert_equals(typeof event.gamma, "number", "Attribute gamma is type of");
       }, "Check if DeviceOrientationEvent.gamma is type of double");
+
       done();
+
+      if(t) {
+         clearTimeout(t);
+      }
     }
   });
-  setTimeout(function () {
+  var t = setTimeout(function () {
     test(function() {
       assert_unreached("Can not fire deviceorientation event");
     }, "Check if the DeviceOrientationEvent.absolute attribute exists");

--- a/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceRotationRate_attributes_basic.html
+++ b/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceRotationRate_attributes_basic.html
@@ -38,9 +38,7 @@ Authors:
 <script src="../resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  setup(function(){
-    tizen.power.turnScreenOn();
-  }, {explicit_done: true, timeout: 2000});
+  setup({explicit_done: true, timeout: 2000});
   var run = false;
   on_event(window, "devicemotion", function(event) {
     if(!run) {
@@ -52,8 +50,8 @@ Authors:
       }, "Check if the DeviceRotationRate.alpha is readonly");
 
       test(function() {
-        assert_equals(typeof event.rotationRate.beta, "number" , "The type of DeviceRotationRate.beta");
-      }, "Check if the type of DeviceRotationRate.beta is number");
+        assert_equals(event.rotationRate.beta, null, "The DeviceRotationRate.beta init value");
+      }, "Check if the type of DeviceRotationRate.beta init value is null");
 
       test(function() {
         event.rotationRate.beta = 10000;
@@ -61,8 +59,8 @@ Authors:
       }, "Check if the DeviceRotationRate.beta is readonly");
 
       test(function() {
-        assert_equals(typeof event.rotationRate.gamma, "number" , "The type of DeviceRotationRate.gamma");
-      }, "Check if the type of DeviceRotationRate.gamma is number");
+        assert_equals(event.rotationRate.gamma, null, "The DeviceRotationRate.gamma init value");
+      }, "Check if the type of DeviceRotationRate.gamma init value is null");
 
       test(function() {
         event.rotationRate.gamma = 10000;
@@ -70,21 +68,25 @@ Authors:
       }, "Check if the DeviceRotationRate.gamma is readonly");
 
       done();
+
+      if(t) {
+         clearTimeout(t);
+      }
     }
   });
-  setTimeout(function () {
+  var t = setTimeout(function () {
     test(function() {
       assert_unreached("Can not fire devicemotion event");
     }, "Check if the DeviceRotationRate.alpha is readonly");
     test(function() {
       assert_unreached("Can not fire devicemotion event");
-    }, "Check if the type of DeviceRotationRate.beta is number");
+    }, "Check if the DeviceRotationRate.beta init value is null");
     test(function() {
       assert_unreached("Can not fire devicemotion event");
     }, "Check if the DeviceRotationRate.beta is readonly");
     test(function() {
       assert_unreached("Can not fire devicemotion event");
-    }, "Check if the type of DeviceRotationRate.gamma is number");
+    }, "Check if the DeviceRotationRate.gamma init value is null");
     test(function() {
       assert_unreached("Can not fire devicemotion event");
     }, "Check if the DeviceRotationRate.gamma is readonly");

--- a/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceRotationRate_attributes_test.html
+++ b/webapi/tct-deviceorientation-w3c-tests/deviceorientation/DeviceRotationRate_attributes_test.html
@@ -38,9 +38,7 @@ Authors:
 <script src="../resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  setup(function(){
-    tizen.power.turnScreenOn();
-  }, {explicit_done: true, timeout: 2000});
+  setup({explicit_done: true, timeout: 2000});
   var run = false;
   on_event(window, "devicemotion", function(event) {
     if(!run) {
@@ -51,8 +49,8 @@ Authors:
       }, "Check if the DeviceRotationRate.alpha attribute exists");
 
       test(function() {
-        assert_equals(typeof event.rotationRate.alpha, "number" , "DeviceRotationRate alpha is type of");
-      }, "Check if DeviceRotationRate.alpha is type of double");
+        assert_equals(event.rotationRate.alpha, null, "DeviceRotationRate alpha init value");
+      }, "Check if DeviceRotationRate.alpha init value is null");
 
       test(function() {
         assert_true("beta" in rotationRate, "Attribute beta missing in RotationRate object");
@@ -61,16 +59,21 @@ Authors:
       test(function() {
         assert_true("gamma" in rotationRate, "Attribute gamma missing in RotationRate object");
       }, "Check if the DeviceRotationRate.gamma attribute exists");
+
       done();
+
+      if(t) {
+         clearTimeout(t);
+      }
     }
   });
-  setTimeout(function () {
+  var t = setTimeout(function () {
     test(function() {
       assert_unreached("Can not fire devicemotion event");
     }, "Check if the DeviceRotationRate.alpha attribute exists");
     test(function() {
       assert_unreached("Can not fire devicemotion event");
-    }, "Check if DeviceRotationRate.alpha is type of double");
+    }, "Check if DeviceRotationRate.alpha init value is null");
     test(function() {
       assert_unreached("Can not fire devicemotion event");
     }, "Check if the DeviceRotationRate.beta attribute exists");

--- a/webapi/tct-deviceorientation-w3c-tests/tests.full.xml
+++ b/webapi/tct-deviceorientation-w3c-tests/tests.full.xml
@@ -6,7 +6,7 @@
       <capabilities>
         <capability name="accelerometer"/>
       </capabilities>
-      <testcase component="W3C_HTML5 APIs/Device/DeviceOrientation Event Specification" execution_type="auto" id="DeviceAcceleration_attributes_test" priority="P1" purpose="Test DeviceAcceleration attributes existence and type" status="approved" type="compliance" subcase="6">
+      <testcase component="W3C_HTML5 APIs/Device/DeviceOrientation Event Specification" execution_type="auto" id="DeviceAcceleration_attributes_test" priority="P1" purpose="Test DeviceAcceleration attributes existence and init value" status="approved" type="compliance" subcase="6">
         <description>
           <test_script_entry>/opt/tct-deviceorientation-w3c-tests/deviceorientation/DeviceAcceleration_attributes_test.html</test_script_entry>
         </description>
@@ -42,7 +42,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Device/DeviceOrientation Event Specification" execution_type="auto" id="DeviceRotationRate_attributes_test" priority="P1" purpose="Test DeviceRotationRate attributes existence and type" status="approved" type="compliance" subcase="4">
+      <testcase component="W3C_HTML5 APIs/Device/DeviceOrientation Event Specification" execution_type="auto" id="DeviceRotationRate_attributes_test" priority="P1" purpose="Test DeviceRotationRate attributes existence and init value" status="approved" type="compliance" subcase="4">
         <description>
           <test_script_entry>/opt/tct-deviceorientation-w3c-tests/deviceorientation/DeviceRotationRate_attributes_test.html</test_script_entry>
         </description>
@@ -78,7 +78,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Device/DeviceOrientation Event Specification" execution_type="auto" id="DeviceRotationRate_attributes_basic" priority="P2" purpose="Test DeviceRotationRate attributes readonly" status="approved" type="compliance" subcase="5">
+      <testcase component="W3C_HTML5 APIs/Device/DeviceOrientation Event Specification" execution_type="auto" id="DeviceRotationRate_attributes_basic" priority="P2" purpose="Test DeviceRotationRate attributes basic" status="approved" type="compliance" subcase="5">
         <description>
           <test_script_entry>/opt/tct-deviceorientation-w3c-tests/deviceorientation/DeviceRotationRate_attributes_basic.html</test_script_entry>
         </description>

--- a/webapi/tct-deviceorientation-w3c-tests/tests.xml
+++ b/webapi/tct-deviceorientation-w3c-tests/tests.xml
@@ -6,7 +6,7 @@
       <capabilities>
         <capability name="accelerometer"/>
       </capabilities>
-      <testcase component="W3C_HTML5 APIs/Device/DeviceOrientation Event Specification" execution_type="auto" id="DeviceAcceleration_attributes_test" purpose="Test DeviceAcceleration attributes existence and type" subcase="6">
+      <testcase component="W3C_HTML5 APIs/Device/DeviceOrientation Event Specification" execution_type="auto" id="DeviceAcceleration_attributes_test" purpose="Test DeviceAcceleration attributes existence and init value" subcase="6">
         <description>
           <test_script_entry>/opt/tct-deviceorientation-w3c-tests/deviceorientation/DeviceAcceleration_attributes_test.html</test_script_entry>
         </description>
@@ -21,7 +21,7 @@
           <test_script_entry>/opt/tct-deviceorientation-w3c-tests/deviceorientation/DeviceOrientationEvent_attributes_test.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Device/DeviceOrientation Event Specification" execution_type="auto" id="DeviceRotationRate_attributes_test" purpose="Test DeviceRotationRate attributes existence and type" subcase="4">
+      <testcase component="W3C_HTML5 APIs/Device/DeviceOrientation Event Specification" execution_type="auto" id="DeviceRotationRate_attributes_test" purpose="Test DeviceRotationRate attributes existence and init value" subcase="4">
         <description>
           <test_script_entry>/opt/tct-deviceorientation-w3c-tests/deviceorientation/DeviceRotationRate_attributes_test.html</test_script_entry>
         </description>
@@ -36,7 +36,7 @@
           <test_script_entry>/opt/tct-deviceorientation-w3c-tests/deviceorientation/DeviceMotionEvent_attributes_readonly.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Device/DeviceOrientation Event Specification" execution_type="auto" id="DeviceRotationRate_attributes_basic" purpose="Test DeviceRotationRate attributes readonly" subcase="5">
+      <testcase component="W3C_HTML5 APIs/Device/DeviceOrientation Event Specification" execution_type="auto" id="DeviceRotationRate_attributes_basic" purpose="Test DeviceRotationRate attributes basic" subcase="5">
         <description>
           <test_script_entry>/opt/tct-deviceorientation-w3c-tests/deviceorientation/DeviceRotationRate_attributes_basic.html</test_script_entry>
         </description>


### PR DESCRIPTION
- Update attribute init value according XWALK-2460 comment.
- Fix timeout still execute issue when tests finished in Windows

Impacted tests(approved): new 0, update 40, delete 0
Unit test platform: Crosswalk Project for Windows 17.45.426.0
Unit test result summary: pass 36, fail 4, block 0

Impacted tests(approved): new 0, update 40, delete 0
Unit test platform: Crosswalk Project for Android 19.48.484.0
Unit test result summary: pass 40, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-5634