### PR TITLE
[tools] Sync testharness.js framework to latest

### DIFF
--- a/tools/resources/testharness/README.md
+++ b/tools/resources/testharness/README.md
@@ -1,30 +1,32 @@
-## Introdution ##
+# W3C testharness.js testing framework
 
-testharness.js provides a framework for writing low-level tests of
+## Introdution
+
+`testharness.js` provides a framework for writing low-level tests of
 browser functionality in javascript. It provides a convenient API for
 making assertions and is intended to work for both simple synchronous
 tests and for tests of asynchronous behaviour.
 
-## Getting Started ##
+## Getting Started
 
-To use testharness.js you must include two scripts, in the order given:
+To use `testharness.js` you must include two scripts, in the order given:
 
 ``` html
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 ```
 
-## Full documentation ##
+## Documentation
 
 Full user documentation for the API is in the
-[docs/api.md](https://github.com/w3c/testharness.js/blob/master/docs/api.md) file.
+[docs/api.md](https://github.com/w3c/testharness.js/blob/master/docs/api.md)
+file.
 
-You can also read a tutorial on 
-[Using testharness.js](http://darobin.github.com/test-harness-tutorial/docs/using-testharness.html).
+You can also read a tutorial of [using
+testharness.js](http://darobin.github.com/test-harness-tutorial/docs/using-testharness.html).
 
 ## Note ##
 
-The testharness files come from
-https://github.com/w3c/testharness.js (commit cf0b67dff57c3140c882b1ffd2b5f4c7adc2ba44)
+The `testharness*` files come from
+https://github.com/w3c/testharness.js/commit/eaa4c5f793f07e2dc6edbeddb3d5bb6275ebd580
 without any modification.
-

--- a/tools/resources/testharness/testharnessreport.js
+++ b/tools/resources/testharness/testharnessreport.js
@@ -1,4 +1,6 @@
-/*global add_completion_callback, setup */
+/* global add_completion_callback */
+/* global setup */
+
 /*
  * This file is intended for vendors to implement
  * code needed to integrate testharness.js tests with their own test systems.
@@ -22,8 +24,6 @@
  * For more documentation about the callback functions and the
  * parameters they are called with see testharness.js
  */
-
-
 
 var metadata_generator = {
 
@@ -219,10 +219,14 @@ var metadata_generator = {
      * Metadata is in pretty-printed JSON format
      */
     generateSource: function() {
+        /* "\/" is used instead of a plain forward slash so that the contents
+        of testharnessreport.js can (for convenience) be copy-pasted into a
+        script tag without issue. Otherwise, the HTML parser would think that
+        the script ended in the middle of that string literal. */
         var source =
             '<script id="metadata_cache">/*\n' +
             this.jsonifyObject(this.currentMetadata, '') + '\n' +
-            '*/</script>\n';
+            '*/<\/script>\n';
         return source;
     },
 
@@ -385,13 +389,20 @@ function dump_test_results(tests, status) {
     var test_results = tests.map(function(x) {
         return {name:x.name, status:x.status, message:x.message, stack:x.stack}
     });
-    data = {test:window.location.href,
-            tests:test_results,
-            status: status.status,
-            message: status.message,
-            stack: status.stack};
+    var data = {test:window.location.href,
+                tests:test_results,
+                status: status.status,
+                message: status.message,
+                stack: status.stack};
     results_element.textContent = JSON.stringify(data);
-    document.documentElement.lastChild.appendChild(results_element);
+
+    // To avoid a HierarchyRequestError with XML documents, ensure that 'results_element'
+    // is inserted at a location that results in a valid document.
+    var parent = document.body
+        ? document.body                 // <body> is required in XHTML documents
+        : document.documentElement;     // fallback for optional <body> in HTML5, SVG, etc.
+
+    parent.appendChild(results_element);
 }
 
 metadata_generator.setup();


### PR DESCRIPTION
https://github.com/w3c/testharness.js/commit/eaa4c5f793f07e2dc6edbeddb3d5bb6275ebd580

$ git log --no-merges --oneline cf0b67dff57c3140c882b1ffd2b5f4c7adc2ba44..head testharness.js
shows these changes since last sync:

5423ec7 Issue #179: Fix step_timeout
7e9a45d Reinstate InUseAttributeError.
e8f43ce Fix #59: stop cross-origin objects from throwing in harness when creating failed assertion messages.
f54f26e Allow using assert_inherits with function objects.
ed8c5a4 Add [test.]step_timeout function.
3cfb463 braces
4abfeec Fix handling of assertions in workers
e19ed06 Fix potential infinite loop in AssertionError.get_stack().
2ae2785 Add ability to subscribe to only certain events via postMessage.
84094aa Set correct this value in worker structured clone function.
57fb468 Tweak comments and indentation per review feedback.
b55d498 Fall back to ServiceWorker.postMessage() when MessageChannel not available. (gecko bug 1158347)
bfba3c3 Fix AssertionError.get_stack for IE
3bd0373 Fix typo getting error stack in worker.
c48d50e Don't error out trying to access cross-origin functions when document.domain got set.