### PR TITLE
[Crosswalk-17][misc] Add timeout for cookie upgrade test

### DIFF
--- a/misc/webmanu-system-android-tests/tests.full.xml
+++ b/misc/webmanu-system-android-tests/tests.full.xml
@@ -172,7 +172,7 @@
       <testcase component="Crosswalk System" execution_type="manual" id="Crosswalk_Cookie_upgrade" priority="P2" purpose="Validate the cookie can work well after upgrade app" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/webmanu-system-android-tests/systemmanu/bdd/Crosswalk_Cookie_upgrade.html</test_script_entry>
-          <bdd_test_script_entry test_script_expected_result="0">/opt/webmanu-system-android-tests/web-system-app/testscripts/Crosswalk_Cookie_upgrade.feature</bdd_test_script_entry>
+          <bdd_test_script_entry test_script_expected_result="0" timeout="300">/opt/webmanu-system-android-tests/web-system-app/testscripts/Crosswalk_Cookie_upgrade.feature</bdd_test_script_entry>
         </description>
       </testcase>
     </set>

--- a/misc/webmanu-system-android-tests/tests.xml
+++ b/misc/webmanu-system-android-tests/tests.xml
@@ -172,7 +172,7 @@
       <testcase component="Crosswalk System" execution_type="manual" id="Crosswalk_Cookie_upgrade" purpose="Validate the cookie can work well after upgrade app">
         <description>
           <test_script_entry>/opt/webmanu-system-android-tests/systemmanu/bdd/Crosswalk_Cookie_upgrade.html</test_script_entry>
-          <bdd_test_script_entry test_script_expected_result="0">/opt/webmanu-system-android-tests/web-system-app/testscripts/Crosswalk_Cookie_upgrade.feature</bdd_test_script_entry>
+          <bdd_test_script_entry test_script_expected_result="0" timeout="300">/opt/webmanu-system-android-tests/web-system-app/testscripts/Crosswalk_Cookie_upgrade.feature</bdd_test_script_entry>
         </description>
       </testcase>
     </set>


### PR DESCRIPTION
cookie test need to load web page for long time, poor network
will increase this time.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android 17.46.448.10
Unit test result summary: pass 1, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6052