### PR TITLE
[EmbeddingAPI] add usecase for API clearSslPreferences()

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -781,5 +781,14 @@
                 <category android:name="XWalkView.Basic" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".misc.XWalkViewWithClearSslPreferencesAsync"
+            android:label="@string/title_activity_xwalk_view_with_clear_ssl_preferences_async"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Misc" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_clear_ssl_preferences_async.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_clear_ssl_preferences_async.xml
@@ -1,0 +1,45 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.asyncsample.misc.XWalkViewWithClearSslPreferencesAsync">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="1. Click 'Refresh' button to load 12306 website with ssl certificates.\n2. Message 'XWalkResourceClient.onReceivedSslError is invoked' will show.\n3. As we expect no ssl error, click 'Refresh' button again. onReceivedSslError() will not be triggered.\n4. This time we click 'clearSslPreferences' button to clear the SSL preferences table stored in response.\n5. Then we click 'Refresh' button again and we will get message 'XWalkResourceClient.onReceivedSslError is invoked' again."
+        android:id="@+id/textView" />
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Refresh"
+        android:id="@+id/refresh_button"
+        android:layout_below="@+id/textView"
+        android:layout_alignParentStart="true" />
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="ClearSslPreferences"
+        android:id="@+id/clear_button"
+        android:layout_below="@+id/textView"
+        android:layout_toRightOf="@+id/refresh_button"
+        android:layout_marginLeft="5dp" />
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/client_sslerror_tip"
+        android:layout_below="@+id/refresh_button"/>
+
+    <org.xwalk.core.XWalkView
+        android:id="@+id/client_sslerror_xwalk_view"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/client_sslerror_tip">
+    </org.xwalk.core.XWalkView>
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
@@ -112,5 +112,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_get_favicon_async">XWalkViewWithGetFaviconAsync</string>
     <string name="title_activity_xwalk_view_with_load_extension_async">XWalkViewWithLoadExtensionAsync</string>
     <string name="title_activity_xwalk_view_with_iframes_async">XWalkViewWithIframesAsync</string>
+    <string name="title_activity_xwalk_view_with_clear_ssl_preferences_async">XWalkViewWithClearSslPreferencesAsync</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -828,3 +828,14 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load method
 * ResourceClient interface: shouldInterceptLoadRequest method
+
+
+
+### 81. The [XWalkViewWithClearSslPreferencesAsync](misc/XWalkViewWithClearSslPreferencesAsync.java) sample check XWalkView can clear ssl preferences, include:
+
+* XWalkView can clear ssl preferences
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, clearSslPreferences method
+* ResourceClient interface: onReceivedSslError method

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/misc/XWalkViewWithClearSslPreferencesAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/misc/XWalkViewWithClearSslPreferencesAsync.java
@@ -1,0 +1,103 @@
+package org.xwalk.embedded.api.asyncsample.misc;
+
+import org.xwalk.embedded.api.asyncsample.R;
+
+import android.app.AlertDialog;
+import android.graphics.Color;
+import android.net.http.SslError;
+import android.os.Bundle;
+import android.view.KeyEvent;
+import android.view.View;
+import android.webkit.ValueCallback;
+import android.widget.Button;
+import android.widget.TextView;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkUIClient;
+import org.xwalk.core.XWalkView;
+
+public class XWalkViewWithClearSslPreferencesAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+
+    private XWalkView mXWalkView;
+    private XWalkInitializer mXWalkInitializer;
+
+    private TextView tv;
+
+    private Boolean mAllowSslError = true;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+                .append("Verifies XWalkView API clearSslPreferences() works.\n\n")
+                .append("Test  Step:\n\n")
+                .append("1. Click 'Refresh' button to load 12306 website with ssl certificates.\n")
+                .append("2. Message 'XWalkResourceClient.onReceivedSslError is invoked' will show.\n")
+                .append("3. As we expect no ssl error, click 'Refresh' button again. onReceivedSslError() will not be triggered.\n")
+                .append("4. This time we click 'clearSslPreferences' button to clear the SSL preferences table stored in response.\n")
+                .append("5. Then we click 'Refresh' button again and we will get message 'XWalkResourceClient.onReceivedSslError is invoked' again.\n")
+                .append("Expected Result:\n\n")
+                .append("Test passes if this API can clear the SSL preferences table stored in response to proceeding with SSL certificate error.");
+        new  AlertDialog.Builder(this)
+                .setTitle("Info")
+                .setMessage(mess.toString())
+                .setPositiveButton("confirm", null)
+                .show();
+        setContentView(R.layout.activity_xwalk_view_with_clear_ssl_preferences_async);
+        tv = (TextView)findViewById(R.id.client_sslerror_tip);
+        tv.setTextColor(Color.GREEN);
+
+        mXWalkView = (XWalkView) findViewById(R.id.client_sslerror_xwalk_view);
+        mXWalkView.setResourceClient(new XWalkResourceClient(mXWalkView) {
+            @Override
+            public void onReceivedSslError(XWalkView view, ValueCallback<Boolean> callback, SslError error) {
+                callback.onReceiveValue(mAllowSslError);
+                tv.setText("XWalkResourceClient.onReceivedSslError is invoked. Event: " + error.toString());
+            }
+        });
+
+        Button bt = (Button)findViewById(R.id.refresh_button);
+        bt.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mXWalkView.load("https://kyfw.12306.cn/otn/regist/init", null);
+                tv.setText("onReceivedSslError() method is not triggered, ssl error is denied");
+            }
+        });
+
+        Button clear = (Button)findViewById(R.id.clear_button);
+        clear.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                // TODO Auto-generated method stub
+                mXWalkView.clearSslPreferences();
+            }
+        });
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -782,5 +782,14 @@
                 <category android:name="XWalkView.Basic" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".misc.XWalkViewWithClearSslPreferences"
+            android:label="@string/title_activity_xwalk_view_with_clear_ssl_preferences"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Misc" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_clear_ssl_preferences.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_clear_ssl_preferences.xml
@@ -1,0 +1,45 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.sample.misc.XWalkViewWithClearSslPreferences">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="1. Click 'Refresh' button to load 12306 website with ssl certificates.\n2. Message 'XWalkResourceClient.onReceivedSslError is invoked' will show.\n3. As we expect no ssl error, click 'Refresh' button again. onReceivedSslError() will not be triggered.\n4. This time we click 'clearSslPreferences' button to clear the SSL preferences table stored in response.\n5. Then we click 'Refresh' button again and we will get message 'XWalkResourceClient.onReceivedSslError is invoked' again."
+        android:id="@+id/textView" />
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Refresh"
+        android:id="@+id/refresh_button"
+        android:layout_below="@+id/textView"
+        android:layout_alignParentStart="true" />
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="ClearSslPreferences"
+        android:id="@+id/clear_button"
+        android:layout_below="@+id/textView"
+        android:layout_toRightOf="@+id/refresh_button"
+        android:layout_marginLeft="5dp" />
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/client_sslerror_tip"
+        android:layout_below="@+id/refresh_button"/>
+
+    <org.xwalk.core.XWalkView
+        android:id="@+id/client_sslerror_xwalk_view"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/client_sslerror_tip">
+    </org.xwalk.core.XWalkView>
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
@@ -118,5 +118,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_get_favicon">XWalkViewWithGetFavicon</string>
     <string name="title_activity_xwalk_view_with_load_extension">XWalkViewWithLoadExtension</string>
     <string name="title_activity_xwalk_view_with_iframes">XWalkViewWithIframes</string>
+    <string name="title_activity_xwalk_view_with_clear_ssl_preferences">XWalkViewWithClearSslPreferences</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -827,3 +827,14 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load method
 * ResourceClient interface: shouldInterceptLoadRequest method
+
+
+
+### 81. The [XWalkViewWithClearSslPreferences](misc/XWalkViewWithClearSslPreferences.java) sample check XWalkView can clear ssl preferences, include:
+
+* XWalkView can clear ssl preferences
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, clearSslPreferences method
+* ResourceClient interface: onReceivedSslError method

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/misc/XWalkViewWithClearSslPreferences.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/misc/XWalkViewWithClearSslPreferences.java
@@ -1,0 +1,83 @@
+package org.xwalk.embedded.api.sample.misc;
+
+import org.xwalk.embedded.api.sample.R;
+
+import android.app.AlertDialog;
+import android.graphics.Color;
+import android.net.http.SslError;
+import android.os.Bundle;
+import android.view.KeyEvent;
+import android.view.View;
+import android.webkit.ValueCallback;
+import android.widget.Button;
+import android.widget.TextView;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkUIClient;
+import org.xwalk.core.XWalkView;
+
+public class XWalkViewWithClearSslPreferences extends XWalkActivity {
+
+    private XWalkView mXWalkView;
+
+    private TextView tv;
+
+    private Boolean mAllowSslError = true;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_xwalk_view_with_clear_ssl_preferences);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+                .append("Verifies XWalkView API clearSslPreferences() works.\n\n")
+                .append("Test  Step:\n\n")
+                .append("1. Click 'Refresh' button to load 12306 website with ssl certificates.\n")
+                .append("2. Message 'XWalkResourceClient.onReceivedSslError is invoked' will show.\n")
+                .append("3. As we expect no ssl error, click 'Refresh' button again. onReceivedSslError() will not be triggered.\n")
+                .append("4. This time we click 'clearSslPreferences' button to clear the SSL preferences table stored in response.\n")
+                .append("5. Then we click 'Refresh' button again and we will get message 'XWalkResourceClient.onReceivedSslError is invoked' again.\n")
+                .append("Expected Result:\n\n")
+                .append("Test passes if this API can clear the SSL preferences table stored in response to proceeding with SSL certificate error.");
+        new  AlertDialog.Builder(this)
+                .setTitle("Info")
+                .setMessage(mess.toString())
+                .setPositiveButton("confirm", null)
+                .show();
+        tv = (TextView)findViewById(R.id.client_sslerror_tip);
+        tv.setTextColor(Color.GREEN);
+
+        mXWalkView = (XWalkView) findViewById(R.id.client_sslerror_xwalk_view);
+        mXWalkView.setResourceClient(new XWalkResourceClient(mXWalkView) {
+            @Override
+            public void onReceivedSslError(XWalkView view, ValueCallback<Boolean> callback, SslError error) {
+                callback.onReceiveValue(mAllowSslError);
+                tv.setText("XWalkResourceClient.onReceivedSslError is invoked. Event: " + error.toString());
+            }
+        });
+
+        Button bt = (Button)findViewById(R.id.refresh_button);
+        bt.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mXWalkView.load("https://kyfw.12306.cn/otn/regist/init", null);
+                tv.setText("onReceivedSslError() method is not triggered, ssl error is denied");
+            }
+        });
+
+        Button clear = (Button)findViewById(R.id.clear_button);
+        clear.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                // TODO Auto-generated method stub
+                mXWalkView.clearSslPreferences();
+            }
+        });
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -993,6 +993,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithClearSslPreferences" purpose="XWalkViewWithClearSslPreferences Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -1976,6 +1988,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithIframesAsync" purpose="XWalkViewWithIframesAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithClearSslPreferencesAsync" purpose="XWalkViewWithClearSslPreferencesAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -1092,6 +1092,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithClearSslPreferences" purpose="XWalkViewWithClearSslPreferences Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -2070,6 +2082,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithIframesAsync" purpose="XWalkViewWithIframesAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithClearSslPreferencesAsync" purpose="XWalkViewWithClearSslPreferencesAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>


### PR DESCRIPTION
-Add usecase for API clearSslPreferences()
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6438