### PR TITLE
[EmbeddingAPI] Add usecase for XWalkView theme-color support disable-…

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -790,5 +790,14 @@
                 <category android:name="XWalkView.Misc" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".misc.XWalkViewWithThemeColorAsync"
+            android:label="@string/title_activity_xwalk_view_with_theme_color_async"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Misc" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/red_toolbar_theme.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/red_toolbar_theme.html
@@ -1,0 +1,111 @@
+<html contenteditable>
+<head>
+	<meta name="theme-color" content="#ff0000">
+<head/>
+  <body>
+    <h1>Yo this is a webpage</h1>
+    <p>Watch me stretch!</p>
+     <p>
+riverrun, past Eve and Adam's, from swerve of shore to bend
+of bay, brings us by a commodius vicus of recirculation back to
+Howth Castle and Environs.
+</p>
+<p>
+Sir Tristram, violer d'amores, fr'over the short sea, had passen-
+core rearrived from North Armorica on this side the scraggy
+isthmus of Europe Minor to wielderfight his penisolate war: nor
+had topsawyer's rocks by the stream Oconee exaggerated themselse
+to Laurens County's gorgios while they went doublin their mumper
+all the time: nor avoice from afire bellowsed mishe mishe to
+tauftauf thuartpeatrick: not yet, though venissoon after, had a
+kidscad buttended a bland old isaac: not yet, though all's fair in
+vanessy, were sosie sesthers wroth with twone nathandjoe. Rot a
+peck of pa's malt had Jhem or Shen brewed by arclight and rory
+end to the regginbrow was to be seen ringsome on the aquaface.
+</p>
+<p>
+The fall (bababadalgharaghtakammi
+narronnkonnbronntonner-
+ronntuonnthunntrovarrhounawn
+skawntoohoohoordenenthur-
+nuk!) of a once wallstrait oldparr is retaled early in bed and later
+on on on on on on on on on on on on on on on on on on on on onof the
+offwall entailed at such short notice the pftjschute of Finnegan,
+erse solid man, that the humptyhillhead of humself prumptly sends
+an unquiring one well to the west in quest of his tumptytumtoes:
+and their upturnpikepointandplace is at the knock out in the park
+where oranges have been laid to rust upon the green since dev-
+linsfirst loved livvy.
+</p>
+<p>
+What clashes here of wills gen wonts, oystrygods gaggin fishy-
+gods! Brékkek Kékkek Kékkek Kékkek! Kóax Kóax Kóax! Ualu
+Ualu Ualu! Quaouauh! Where the Baddelaries partisans are still
+out to mathmaster Malachus Micgranes and the Verdons cata-
+pelting the camibalistics out of the Whoyteboyce of Hoodie
+Head. Assiegates and boomeringstroms. Sod's brood, be me fear!
+Sanglorians, save! Arms apeal with larms, appalling. Killykill-
+killy: a toll, a toll. What chance cuddleys, what cashels aired
+and ventilated! What bidimetoloves sinduced by what tegotetab-
+solvers! What true feeling for their's hayair with what strawng
+voice of false jiccup! O here here how hoth sprowled met the
+duskt the father of fornicationists but, (O my shining stars and
+body!) how hath fanespanned most high heaven the skysign of
+soft advertisement! But was iz? Iseut? Ere were sewers? The oaks
+of ald now they lie in peat yet elms leap where askes lay. Phall if
+you but will, rise you must: and none so soon either shall the
+pharce for the nunce come to a setdown secular phoenish.
+</p>
+<p>
+Bygmester Finnegan, of the Stuttering Hand, freemen's mau-
+rer, lived in the broadest way immarginable in his rushlit toofar-
+back for messuages before joshuan judges had given us numbers
+or Helviticus committed deuteronomy (one yeastyday he sternely
+struxk his tete in a tub for to wstruxk his tete in a tub for to wstruxk his tete in a tub for ut again, by the might of moses, the very wat-
+er was eviparated and all the guenneses had met their exodus so
+that ought to show you what a pentschanjeuchy chap he was!)
+and during mighty odd years this man of hod, cement and edi-
+fices in Toper's Thorp piled buildung supra buildung pon the
+banks for the livers by the Soangso. He addle liddle phifie Annie
+ugged the little craugged the little craugged the little craugged the little crauhile balbulous, mithre ahead, with goodly trowel in
+grasp and ivoroiled overalls which he habitacularly fondseed, like
+Haroun Childeric Eggeberth he would caligulate by multiplicab-
+les the alltitude and malltitude until he seesaw by neatlight of the
+liquor wheretwin 'twas born, his roundhead staple of other days
+to rise in undress maisonry upstanded (joygrantit!), a waalworth
+of a skyerscape of most eyeful hoyth entowerly, erigenating from
+</p><p>
+Of the first was he to bare arms and a name: Wassaily Boos-
+laeugh of Riesengeborg. His crest of huroldry, in vert with
+ancillars, troublant, argent, a hegoak, poursuivant, horrid, horned.
+His scutschum fessed, with archers strung, helio, of the second.
+Hootch is for husbandman handling his hoe. Hohohoho, Mister
+Finn, you're going to be Mister Finnagain! Comeday morm and,
+O, you're vine! Sendday's eve and, ah, you're vinegar! Hahahaha,
+Mister Funn, you're going to be fined again!
+</p><p>
+What then agentlike brought about that tragoady thundersday
+this municipal sin business? Our cubehouse still rocks as earwitness
+to the thunder of his arafatas but we hear also through successive
+ages that shebby choruysh of unkalified muzzlenimiissilehims that
+would blackguardise the whitestone ever hurtleturtled out of
+heaven. Stay us wherefore in our search for tighteousness, O Sus-
+tainer, what time we rise and when we take up to toothmick and
+before we lump down upown our leatherbed and in the night and
+at the fading of the stars ! For a nod to the nabir is better than wink
+to the wabsanti. Otherways wesways like that provost scoffing
+bedoueen the jebel and the jpysiabedoueen the jebel and the jpysiabedoueen the jebel and thwe'll know if the feast is a flyday. She
+has a gift of seek on site and she allcasually ansars helpers, the
+dreamydeary. Heed! Hedreamydeary. Heed! Hedreamydeary. Heed! Hedreamydeary. Heed!it moughdreamydeary. Heed! Hedreamydeary. Heed! Hedr
+promises, as others looked at it. (There extand by now one thou-
+sand and one stories, all told, of the same). But so sore did abe
+ite ivvy's holired abbles, (what with the wallhall's horrors of rolls-
+rights, carhacks, stonengens, kisstvanes, tramtrees, fargobawlers,
+autokinotons, hippohobbilies, streetfleets, tournintaxes, mega-
+phoggs, circuses and wardsmoats and basilikerks and aeropagods
+and the hoyse and the jollybrool and the peeler in the coat and
+the mecklenburk bitch bite at his ear and the merlinburrow bur-
+rocks and his fore old porecourts, the bore the more, and his
+</p>
+  </body>
+</html>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_theme_color_async.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_theme_color_async.xml
@@ -1,0 +1,37 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.asyncsample.misc.XWalkViewWithThemeColorAsync">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="Starting in version 39 of Chrome for Android on Lollipop, it can be able to use the theme-color meta tag to set the toolbar color, and Crosswalk already support it now. The key string to enable/disable website's 'theme-color' attribute. Default is true, and it only works on Android Lollipop or later."
+        android:id="@+id/textView" />
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/refresh_button"
+        android:text="Get ENABLE_THEME_COLOR Value"
+        android:layout_below="@+id/textView"
+        android:layout_alignParentStart="true" />
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/theme_colcr_preference"
+        android:textColor="#00ff00"
+        android:layout_below="@+id/refresh_button"/>
+
+    <org.xwalk.core.XWalkView
+        android:id="@+id/xwalk_view"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/theme_colcr_preference">
+    </org.xwalk.core.XWalkView>
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
@@ -113,5 +113,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_load_extension_async">XWalkViewWithLoadExtensionAsync</string>
     <string name="title_activity_xwalk_view_with_iframes_async">XWalkViewWithIframesAsync</string>
     <string name="title_activity_xwalk_view_with_clear_ssl_preferences_async">XWalkViewWithClearSslPreferencesAsync</string>
+    <string name="title_activity_xwalk_view_with_theme_color_async">XWalkViewWithThemeColorAsync</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -839,3 +839,14 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load, clearSslPreferences method
 * ResourceClient interface: onReceivedSslError method
+
+
+
+### 82. The [XWalkViewWithThemeColorAsync](misc/XWalkViewWithThemeColorAsync.java) sample demonstrates XWalkView can support theme-color meta tag by setting ENABLE_THEME_COLOR, include:
+
+* XWalkView can set style value
+* XWalkView can get style value
+
+This usecase covers following interface and methods:
+
+* XWalkPreferences interface: getBooleanValue, setValue

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/misc/XWalkViewWithThemeColorAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/misc/XWalkViewWithThemeColorAsync.java
@@ -1,0 +1,80 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.asyncsample.misc;
+
+import org.xwalk.embedded.api.asyncsample.R;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkPreferences;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.TextView;
+import android.view.View;
+
+public class XWalkViewWithThemeColorAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private XWalkInitializer mXWalkInitializer;
+
+    private TextView themeValue;
+
+@Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can work with theme-color meta tag by setting XWalkPreferences.ENABLE_THEME_COLOR. Notice this feature only works on Android Lollipop or later.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Default XWalkPreferences theme-color is enabled, just load the page.\n")
+        .append("2. Click android recent-apps button to see our app status.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if recent app list can show red toolbar XWalkView.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        setContentView(R.layout.activity_xwalk_view_with_theme_color_async);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+
+        mXWalkView.load("file:///android_asset/red_toolbar_theme.html", null);
+
+        Button bt = (Button)findViewById(R.id.refresh_button);
+        themeValue= (TextView)findViewById(R.id.theme_colcr_preference);
+        bt.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Boolean value = XWalkPreferences.getBooleanValue(XWalkPreferences.ENABLE_THEME_COLOR);
+                themeValue.setText("XWalkPreferences.ENABLE_THEME_COLOR is " + value);
+            }
+        });
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -791,5 +791,14 @@
                 <category android:name="XWalkView.Misc" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".misc.XWalkViewWithThemeColor"
+            android:label="@string/title_activity_xwalk_view_with_theme_color"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Misc" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/assets/red_toolbar_theme.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/assets/red_toolbar_theme.html
@@ -1,0 +1,111 @@
+<html contenteditable>
+<head>
+	<meta name="theme-color" content="#ff0000">
+<head/>
+  <body>
+    <h1>Yo this is a webpage</h1>
+    <p>Watch me stretch!</p>
+     <p>
+riverrun, past Eve and Adam's, from swerve of shore to bend
+of bay, brings us by a commodius vicus of recirculation back to
+Howth Castle and Environs.
+</p>
+<p>
+Sir Tristram, violer d'amores, fr'over the short sea, had passen-
+core rearrived from North Armorica on this side the scraggy
+isthmus of Europe Minor to wielderfight his penisolate war: nor
+had topsawyer's rocks by the stream Oconee exaggerated themselse
+to Laurens County's gorgios while they went doublin their mumper
+all the time: nor avoice from afire bellowsed mishe mishe to
+tauftauf thuartpeatrick: not yet, though venissoon after, had a
+kidscad buttended a bland old isaac: not yet, though all's fair in
+vanessy, were sosie sesthers wroth with twone nathandjoe. Rot a
+peck of pa's malt had Jhem or Shen brewed by arclight and rory
+end to the regginbrow was to be seen ringsome on the aquaface.
+</p>
+<p>
+The fall (bababadalgharaghtakammi
+narronnkonnbronntonner-
+ronntuonnthunntrovarrhounawn
+skawntoohoohoordenenthur-
+nuk!) of a once wallstrait oldparr is retaled early in bed and later
+on on on on on on on on on on on on on on on on on on on on onof the
+offwall entailed at such short notice the pftjschute of Finnegan,
+erse solid man, that the humptyhillhead of humself prumptly sends
+an unquiring one well to the west in quest of his tumptytumtoes:
+and their upturnpikepointandplace is at the knock out in the park
+where oranges have been laid to rust upon the green since dev-
+linsfirst loved livvy.
+</p>
+<p>
+What clashes here of wills gen wonts, oystrygods gaggin fishy-
+gods! Brékkek Kékkek Kékkek Kékkek! Kóax Kóax Kóax! Ualu
+Ualu Ualu! Quaouauh! Where the Baddelaries partisans are still
+out to mathmaster Malachus Micgranes and the Verdons cata-
+pelting the camibalistics out of the Whoyteboyce of Hoodie
+Head. Assiegates and boomeringstroms. Sod's brood, be me fear!
+Sanglorians, save! Arms apeal with larms, appalling. Killykill-
+killy: a toll, a toll. What chance cuddleys, what cashels aired
+and ventilated! What bidimetoloves sinduced by what tegotetab-
+solvers! What true feeling for their's hayair with what strawng
+voice of false jiccup! O here here how hoth sprowled met the
+duskt the father of fornicationists but, (O my shining stars and
+body!) how hath fanespanned most high heaven the skysign of
+soft advertisement! But was iz? Iseut? Ere were sewers? The oaks
+of ald now they lie in peat yet elms leap where askes lay. Phall if
+you but will, rise you must: and none so soon either shall the
+pharce for the nunce come to a setdown secular phoenish.
+</p>
+<p>
+Bygmester Finnegan, of the Stuttering Hand, freemen's mau-
+rer, lived in the broadest way immarginable in his rushlit toofar-
+back for messuages before joshuan judges had given us numbers
+or Helviticus committed deuteronomy (one yeastyday he sternely
+struxk his tete in a tub for to wstruxk his tete in a tub for to wstruxk his tete in a tub for ut again, by the might of moses, the very wat-
+er was eviparated and all the guenneses had met their exodus so
+that ought to show you what a pentschanjeuchy chap he was!)
+and during mighty odd years this man of hod, cement and edi-
+fices in Toper's Thorp piled buildung supra buildung pon the
+banks for the livers by the Soangso. He addle liddle phifie Annie
+ugged the little craugged the little craugged the little craugged the little crauhile balbulous, mithre ahead, with goodly trowel in
+grasp and ivoroiled overalls which he habitacularly fondseed, like
+Haroun Childeric Eggeberth he would caligulate by multiplicab-
+les the alltitude and malltitude until he seesaw by neatlight of the
+liquor wheretwin 'twas born, his roundhead staple of other days
+to rise in undress maisonry upstanded (joygrantit!), a waalworth
+of a skyerscape of most eyeful hoyth entowerly, erigenating from
+</p><p>
+Of the first was he to bare arms and a name: Wassaily Boos-
+laeugh of Riesengeborg. His crest of huroldry, in vert with
+ancillars, troublant, argent, a hegoak, poursuivant, horrid, horned.
+His scutschum fessed, with archers strung, helio, of the second.
+Hootch is for husbandman handling his hoe. Hohohoho, Mister
+Finn, you're going to be Mister Finnagain! Comeday morm and,
+O, you're vine! Sendday's eve and, ah, you're vinegar! Hahahaha,
+Mister Funn, you're going to be fined again!
+</p><p>
+What then agentlike brought about that tragoady thundersday
+this municipal sin business? Our cubehouse still rocks as earwitness
+to the thunder of his arafatas but we hear also through successive
+ages that shebby choruysh of unkalified muzzlenimiissilehims that
+would blackguardise the whitestone ever hurtleturtled out of
+heaven. Stay us wherefore in our search for tighteousness, O Sus-
+tainer, what time we rise and when we take up to toothmick and
+before we lump down upown our leatherbed and in the night and
+at the fading of the stars ! For a nod to the nabir is better than wink
+to the wabsanti. Otherways wesways like that provost scoffing
+bedoueen the jebel and the jpysiabedoueen the jebel and the jpysiabedoueen the jebel and thwe'll know if the feast is a flyday. She
+has a gift of seek on site and she allcasually ansars helpers, the
+dreamydeary. Heed! Hedreamydeary. Heed! Hedreamydeary. Heed! Hedreamydeary. Heed!it moughdreamydeary. Heed! Hedreamydeary. Heed! Hedr
+promises, as others looked at it. (There extand by now one thou-
+sand and one stories, all told, of the same). But so sore did abe
+ite ivvy's holired abbles, (what with the wallhall's horrors of rolls-
+rights, carhacks, stonengens, kisstvanes, tramtrees, fargobawlers,
+autokinotons, hippohobbilies, streetfleets, tournintaxes, mega-
+phoggs, circuses and wardsmoats and basilikerks and aeropagods
+and the hoyse and the jollybrool and the peeler in the coat and
+the mecklenburk bitch bite at his ear and the merlinburrow bur-
+rocks and his fore old porecourts, the bore the more, and his
+</p>
+  </body>
+</html>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_theme_color.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_theme_color.xml
@@ -1,0 +1,37 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.sample.misc.XWalkViewWithThemeColor">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="Starting in version 39 of Chrome for Android on Lollipop, it can be able to use the theme-color meta tag to set the toolbar color, and Crosswalk already support it now. The key string to enable/disable website's 'theme-color' attribute. Default is true, and it only works on Android Lollipop or later."
+        android:id="@+id/textView" />
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/refresh_button"
+        android:text="Get ENABLE_THEME_COLOR Value"
+        android:layout_below="@+id/textView"
+        android:layout_alignParentStart="true" />
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/theme_colcr_preference"
+        android:textColor="#00ff00"
+        android:layout_below="@+id/refresh_button"/>
+
+    <org.xwalk.core.XWalkView
+        android:id="@+id/xwalk_view"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/theme_colcr_preference">
+    </org.xwalk.core.XWalkView>
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
@@ -119,5 +119,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_load_extension">XWalkViewWithLoadExtension</string>
     <string name="title_activity_xwalk_view_with_iframes">XWalkViewWithIframes</string>
     <string name="title_activity_xwalk_view_with_clear_ssl_preferences">XWalkViewWithClearSslPreferences</string>
+    <string name="title_activity_xwalk_view_with_theme_color">XWalkViewWithThemeColor</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -838,3 +838,14 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load, clearSslPreferences method
 * ResourceClient interface: onReceivedSslError method
+
+
+
+### 82. The [XWalkViewWithThemeColor](misc/XWalkViewWithThemeColor.java) sample demonstrates XWalkView can support theme-color meta tag by setting ENABLE_THEME_COLOR, include:
+
+* XWalkView can set style value
+* XWalkView can get style value
+
+This usecase covers following interface and methods:
+
+* XWalkPreferences interface: getBooleanValue, setValue

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/misc/XWalkViewWithThemeColor.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/misc/XWalkViewWithThemeColor.java
@@ -1,0 +1,60 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedded.api.sample.misc;
+
+import org.xwalk.embedded.api.sample.R;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkPreferences;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.TextView;
+import android.view.View;
+
+public class XWalkViewWithThemeColor extends XWalkActivity {
+    private XWalkView mXWalkView;
+    private Boolean enable_theme_color = true;
+
+    private TextView themeValue;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_xwalk_view_with_theme_color);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can work with theme-color meta tag by setting XWalkPreferences.ENABLE_THEME_COLOR. Notice this feature only works on Android Lollipop or later.\n\n")
+        .append("Test  Step:\n\n")
+        .append("1. Default XWalkPreferences theme-color is enabled, just load the page.\n")
+        .append("2. Click android recent-apps button to see our app status.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if recent app list can show red toolbar XWalkView.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView.load("file:///android_asset/red_toolbar_theme.html", null);
+
+        Button bt = (Button)findViewById(R.id.refresh_button);
+        themeValue= (TextView)findViewById(R.id.theme_colcr_preference);
+        bt.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Boolean value = XWalkPreferences.getBooleanValue(XWalkPreferences.ENABLE_THEME_COLOR);
+                themeValue.setText("XWalkPreferences.ENABLE_THEME_COLOR is " + value);
+            }
+        });
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -1005,6 +1005,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithThemeColor" purpose="XWalkViewWithThemeColor Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -2000,6 +2012,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithClearSslPreferencesAsync" purpose="XWalkViewWithClearSslPreferencesAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithThemeColorAsync" purpose="XWalkViewWithThemeColorAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -1104,6 +1104,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithThemeColor" purpose="XWalkViewWithThemeColor Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -2094,6 +2106,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithClearSslPreferencesAsync" purpose="XWalkViewWithClearSslPreferencesAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithThemeColorAsync" purpose="XWalkViewWithThemeColorAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>


### PR DESCRIPTION
…able on Android

-Add usecase for XWalkView theme-color support disable-able on Android
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6440