### PR TITLE
[EmbeddingAPI-autocase] Add autocase for XWalkView theme-color suppor…

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v6/XWalkPreferenceTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v6/XWalkPreferenceTest.java
@@ -1,0 +1,64 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedding.test.v6;
+
+import org.xwalk.core.XWalkPreferences;
+import org.xwalk.embedding.base.XWalkViewTestBase;
+import android.annotation.SuppressLint;
+import android.test.suitebuilder.annotation.SmallTest;
+
+@SuppressLint("NewApi")
+public class XWalkPreferenceTest extends XWalkViewTestBase {
+
+    @SmallTest
+    public void testSetThemeColor_enable() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    XWalkPreferences.setValue(XWalkPreferences.ENABLE_THEME_COLOR, true);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testSetThemeColor_disbale() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    XWalkPreferences.setValue(XWalkPreferences.ENABLE_THEME_COLOR, false);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+
+    @SmallTest
+    public void testGetThemeColor() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    assertTrue(XWalkPreferences.getBooleanValue(XWalkPreferences.ENABLE_THEME_COLOR));
+                    XWalkPreferences.setValue(XWalkPreferences.ENABLE_THEME_COLOR, false);
+                    assertFalse(XWalkPreferences.getBooleanValue(XWalkPreferences.ENABLE_THEME_COLOR));
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+}

--- a/embeddingapi/embedding-api-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-api-android-tests/tests.full.xml
@@ -138,6 +138,11 @@
           <test_script_entry>org.xwalk.embedding.test.v6.ClearSslPreferenceTest</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.XWalkPreferenceTest" platform="android" priority="P1" purpose="Check if the methods of XWalkPreferenceTest can be executed correctly." status="approved" type="functional_positive" subcase="3">
+        <description>
+          <test_script_entry>org.xwalk.embedding.test.v6.XWalkPreferenceTest</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/embeddingapi/embedding-api-android-tests/tests_v6.xml
+++ b/embeddingapi/embedding-api-android-tests/tests_v6.xml
@@ -23,9 +23,14 @@
           <test_script_entry>org.xwalk.embedding.test.v6.XWalkResourceClientTest</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.ClearSslPreferenceTest" purpose="Check if the methods of XWalkUIClient interface can be executed correctly."  subcase="1">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.ClearSslPreferenceTest" purpose="Check if the methods of ClearSslPreferenceTest interface can be executed correctly."  subcase="1">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v6.ClearSslPreferenceTest</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.XWalkPreferenceTest" purpose="Check if the methods of XWalkPreferenceTest interface can be executed correctly."  subcase="3">
+        <description>
+          <test_script_entry>org.xwalk.embedding.test.v6.XWalkPreferenceTest</test_script_entry>
         </description>
       </testcase>
     </set>

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v6/XWalkPreferenceTestAsync.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v6/XWalkPreferenceTestAsync.java
@@ -1,0 +1,64 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedding.test.v6;
+
+import org.xwalk.core.XWalkPreferences;
+import org.xwalk.embedding.base.XWalkViewTestBase;
+import android.annotation.SuppressLint;
+import android.test.suitebuilder.annotation.SmallTest;
+
+@SuppressLint("NewApi")
+public class XWalkPreferenceTestAsync extends XWalkViewTestBase {
+
+    @SmallTest
+    public void testSetThemeColor_enable() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    XWalkPreferences.setValue(XWalkPreferences.ENABLE_THEME_COLOR, true);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testSetThemeColor_disbale() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    XWalkPreferences.setValue(XWalkPreferences.ENABLE_THEME_COLOR, false);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+
+    @SmallTest
+    public void testGetThemeColor() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    assertTrue(XWalkPreferences.getBooleanValue(XWalkPreferences.ENABLE_THEME_COLOR));
+                    XWalkPreferences.setValue(XWalkPreferences.ENABLE_THEME_COLOR, false);
+                    assertFalse(XWalkPreferences.getBooleanValue(XWalkPreferences.ENABLE_THEME_COLOR));
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+}

--- a/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
@@ -138,6 +138,11 @@
           <test_script_entry>org.xwalk.embedding.test.v6.ClearSslPreferenceTestAsync</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.XWalkPreferenceTestAsync" platform="android" priority="P1" purpose="Check if the methods of XWalkPreferenceTestAsync can be executed correctly." status="approved" type="functional_positive" subcase="3">
+        <description>
+          <test_script_entry>org.xwalk.embedding.test.v6.XWalkPreferenceTestAsync</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/embeddingapi/embedding-asyncapi-android-tests/tests_v6.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests_v6.xml
@@ -28,6 +28,11 @@
           <test_script_entry>org.xwalk.embedding.test.v6.ClearSslPreferenceTestAsync</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v6.XWalkPreferenceTestAsync" purpose="Check if the methods of XWalkPreferenceTestAsync can be executed correctly." subcase="3">
+        <description>
+          <test_script_entry>org.xwalk.embedding.test.v6.XWalkPreferenceTestAsync</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
…t disable-able on Android

-Add autocase for XWalkView theme-color support disable-able on Android
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6440