### PR TITLE
[webapi] Remove apt-cmd-opt command on Windows

### DIFF
--- a/webapi/tct-webgl-nonw3c-tests/suite.json
+++ b/webapi/tct-webgl-nonw3c-tests/suite.json
@@ -43,7 +43,6 @@
         "tests.xml": "tests.xml"
       },
       "pkg-app": {
-        "apk-cmd-opt": "xwalk --ignore-gpu-blacklist",
         "copylist": {
           "PACK-TOOL-ROOT/resources/testharness": "resources",
           "PACK-TOOL-ROOT/resources/webrunner": "webrunner",


### PR DESCRIPTION
WebGL test suite can't build if the command exists, when removed it doesn't effect pass rate.