### PR TITLE
[EmbeddingAPI] Add usecase for API clearClientCertPreferences

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -808,5 +808,14 @@
                 <category android:name="XWalkView.UIClient.ResourceClient" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".basic.XWalkViewWithClearClientCertPreferencesAsync"
+            android:label="@string/title_activity_xwalk_view_with_clear_clientcert_preferences_async"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Basic" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_clear_clientcert_preferences_async.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_clear_clientcert_preferences_async.xml
@@ -1,0 +1,46 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.asyncsample.basic.XWalkViewWithClearClientCertPreferencesAsync">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="XWalkView is handling a Bad SSL client certificate request. The load website is 'https://egov.privasphere.com/'. When api clearClientCertPreferences() is called it will clear any client certificate preferences stored in response to proceeding/cancelling client cert requests."
+        android:id="@+id/textView" />
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Clear ClientCert Preferences"
+        android:id="@+id/clear_button"
+        android:layout_below="@+id/textView"
+        android:layout_alignParentStart="true" />
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Reload"
+        android:id="@+id/reload_button"
+        android:layout_below="@+id/textView"
+        android:layout_toRightOf="@+id/clear_button"
+        android:layout_marginLeft="5dp" />
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textColor="#00ff00"
+        android:id="@+id/client_request"
+        android:layout_below="@+id/reload_button"/>
+
+    <org.xwalk.core.XWalkView
+        android:id="@+id/xwalk_view"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/client_request">
+    </org.xwalk.core.XWalkView>
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
@@ -115,5 +115,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_clear_ssl_preferences_async">XWalkViewWithClearSslPreferencesAsync</string>
     <string name="title_activity_xwalk_view_with_theme_color_async">XWalkViewWithThemeColorAsync</string>
     <string name="title_activity_xwalk_view_with_shouldinterceptloadrequest_async">XWalkViewWithShouldInterceptLoadRequestAsync</string>
+    <string name="title_activity_xwalk_view_with_clear_clientcert_preferences_async">XWalkViewWithClearClientCertPreferencesAsync</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -862,3 +862,14 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load, setResourceClient methods
 * ResourceClient interface: shouldInterceptLoadRequest method
+
+
+
+### 84. The [XWalkViewWithClearClientCertPreferencesAsync](basic/XWalkViewWithClearClientCertPreferencesAsync.java) sample demonstrates XWalkView can clear client certificate preferences, include:
+
+* XWalkView can clear client certificate preferences
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, clearClientCertPreferences methods
+* ResourceClient interface: onReceivedClientCertRequest method

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/basic/XWalkViewWithClearClientCertPreferencesAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/basic/XWalkViewWithClearClientCertPreferencesAsync.java
@@ -1,0 +1,108 @@
+package org.xwalk.embedded.api.asyncsample.basic;
+
+import org.xwalk.embedded.api.asyncsample.R;
+
+import android.app.Activity;
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.ClientCertRequest;
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkView;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.Button;
+import android.widget.TextView;
+
+public class XWalkViewWithClearClientCertPreferencesAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+    private XWalkView mXWalkView;
+    private TextView mClientCertRequest;
+    private XWalkInitializer mXWalkInitializer;
+    private static final String BAD_SSL_WEBSITE = "https://egov.privasphere.com/";
+
+    class ResourceClient extends XWalkResourceClient {
+
+        public ResourceClient(XWalkView xwalkView) {
+            super(xwalkView);
+        }
+
+        public void onReceivedClientCertRequest(XWalkView view,
+                ClientCertRequest handler) {
+            // TODO Auto-generated method stub
+            mClientCertRequest.setText("ClientCert Request: " + handler + "\n");
+            handler.cancel();
+        }
+    }
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public final void onXWalkInitStarted() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitCancelled() {
+        // It's okay to do nothing
+    }
+
+    @Override
+    public final void onXWalkInitFailed() {
+        // Do crash or logging or anything else in order to let the tester know if this method get called
+    }
+
+    @Override
+    public final void onXWalkInitCompleted() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can clear client certificate preferences.\n\n")
+        .append("Test Step:\n\n")
+        .append("1. Load the url defautly and ClientCertRequest info will show.\n")
+        .append("2. Click 'Reload' button and the info will disapper.\n")
+        .append("3. Click 'Clear ClientCert Preferences' button.\n")
+        .append("4. Click 'Reload' button and the info will show again.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if XWalkView can clear client certificate preferences.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        setContentView(R.layout.activity_xwalk_view_with_clear_clientcert_preferences_async);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mClientCertRequest = (TextView) findViewById(R.id.client_request);
+
+        mXWalkView.setResourceClient(new ResourceClient(mXWalkView));
+        mXWalkView.load(BAD_SSL_WEBSITE, null);
+
+        Button clear = (Button) findViewById(R.id.clear_button);
+        clear.setOnClickListener(new OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                // TODO Auto-generated method stub
+                mXWalkView.clearClientCertPreferences(null);
+            }
+        });
+
+        Button reload = (Button) findViewById(R.id.reload_button);
+        reload.setOnClickListener(new OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                // TODO Auto-generated method stub
+                mClientCertRequest.setText("");
+                mXWalkView.load(BAD_SSL_WEBSITE, null);
+            }
+        });
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -809,5 +809,14 @@
                 <category android:name="XWalkView.UIClient.ResourceClient" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".basic.XWalkViewWithClearClientCertPreferences"
+            android:label="@string/title_activity_xwalk_view_with_clear_clientcert_preferences"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Basic" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_clear_clientcert_preferences.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_clear_clientcert_preferences.xml
@@ -1,0 +1,46 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.sample.basic.XWalkViewWithClearClientCertPreferences">
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="XWalkView is handling a Bad SSL client certificate request. The load website is 'https://egov.privasphere.com/'. When api clearClientCertPreferences() is called it will clear any client certificate preferences stored in response to proceeding/cancelling client cert requests."
+        android:id="@+id/textView" />
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Clear ClientCert Preferences"
+        android:id="@+id/clear_button"
+        android:layout_below="@+id/textView"
+        android:layout_alignParentStart="true" />
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Reload"
+        android:id="@+id/reload_button"
+        android:layout_below="@+id/textView"
+        android:layout_toRightOf="@+id/clear_button"
+        android:layout_marginLeft="5dp" />
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textColor="#00ff00"
+        android:id="@+id/client_request"
+        android:layout_below="@+id/reload_button"/>
+
+    <org.xwalk.core.XWalkView
+        android:id="@+id/xwalk_view"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/client_request">
+    </org.xwalk.core.XWalkView>
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
@@ -121,5 +121,6 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_with_clear_ssl_preferences">XWalkViewWithClearSslPreferences</string>
     <string name="title_activity_xwalk_view_with_theme_color">XWalkViewWithThemeColor</string>
     <string name="title_activity_xwalk_view_with_shouldinterceptloadrequest">XWalkViewWithShouldInterceptLoadRequest</string>
+    <string name="title_activity_xwalk_view_with_clear_clientcert_preferences">XWalkViewWithClearClientCertPreferences</string>
 
 </resources>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -861,3 +861,14 @@ This usecase covers following interface and methods:
 
 * XWalkView interface: load, setResourceClient methods
 * ResourceClient interface: shouldInterceptLoadRequest method
+
+
+
+### 84. The [XWalkViewWithClearClientCertPreferences](basic/XWalkViewWithClearClientCertPreferences.java) sample demonstrates XWalkView can clear client certificate preferences, include:
+
+* XWalkView can clear client certificate preferences
+
+This usecase covers following interface and methods:
+
+* XWalkView interface: load, clearClientCertPreferences methods
+* ResourceClient interface: onReceivedClientCertRequest method

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/basic/XWalkViewWithClearClientCertPreferences.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/basic/XWalkViewWithClearClientCertPreferences.java
@@ -1,0 +1,86 @@
+package org.xwalk.embedded.api.sample.basic;
+
+import org.xwalk.core.ClientCertRequest;
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkView;
+import org.xwalk.embedded.api.sample.R;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.Button;
+import android.widget.TextView;
+
+public class XWalkViewWithClearClientCertPreferences extends XWalkActivity {
+    private XWalkView mXWalkView;
+    private TextView mClientCertRequest;
+    private static final String BAD_SSL_WEBSITE = "https://egov.privasphere.com/";
+
+    class ResourceClient extends XWalkResourceClient {
+
+        public ResourceClient(XWalkView xwalkView) {
+            super(xwalkView);
+        }
+
+        public void onReceivedClientCertRequest(XWalkView view,
+                ClientCertRequest handler) {
+            // TODO Auto-generated method stub
+            mClientCertRequest.setText("ClientCert Request: " + handler + "\n");
+            handler.cancel();
+        }
+    }
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_xwalk_view_with_clear_clientcert_preferences);
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mClientCertRequest = (TextView) findViewById(R.id.client_request);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+        .append("Verifies XWalkView can clear client certificate preferences.\n\n")
+        .append("Test Step:\n\n")
+        .append("1. Load the url defautly and ClientCertRequest info will show.\n")
+        .append("2. Click 'Reload' button and the info will disapper.\n")
+        .append("3. Click 'Clear ClientCert Preferences' button.\n")
+        .append("4. Click 'Reload' button and the info will show again.\n")
+        .append("Expected Result:\n\n")
+        .append("Test passes if XWalkView can clear client certificate preferences.");
+        new  AlertDialog.Builder(this)
+        .setTitle("Info" )
+        .setMessage(mess.toString())
+        .setPositiveButton("confirm" ,  null )
+        .show();
+
+        mXWalkView.setResourceClient(new ResourceClient(mXWalkView));
+        mXWalkView.load(BAD_SSL_WEBSITE, null);
+
+        Button clear = (Button) findViewById(R.id.clear_button);
+        clear.setOnClickListener(new OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                // TODO Auto-generated method stub
+                mXWalkView.clearClientCertPreferences(null);
+            }
+        });
+
+        Button reload = (Button) findViewById(R.id.reload_button);
+        reload.setOnClickListener(new OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                // TODO Auto-generated method stub
+                mClientCertRequest.setText("");
+                mXWalkView.load(BAD_SSL_WEBSITE, null);
+            }
+        });
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -1029,6 +1029,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithClearClientCertPreferences" purpose="XWalkViewWithClearClientCertPreferences Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" purpose="XWalkView UI inflation Test With XWalkInitializer">
@@ -2048,6 +2060,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithShouldInterceptLoadRequestAsync" purpose="XWalkViewWithShouldInterceptLoadRequestAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithClearClientCertPreferencesAsync" purpose="XWalkViewWithClearClientCertPreferencesAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -1128,6 +1128,18 @@
           <test_script_entry test_script_expected_result="0" />
         </description>
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithClearClientCertPreferences" purpose="XWalkViewWithClearClientCertPreferences Test With XWalkActivity">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
     </set>
     <set name="XWalkView-Async">
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithLayoutActivityAsync" platform="android" priority="P0" purpose="XWalkView UI inflation Test With XWalkInitializer" status="approved" type="functional_positive">
@@ -2142,6 +2154,18 @@
         </description>
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithShouldInterceptLoadRequestAsync" purpose="XWalkViewWithShouldInterceptLoadRequestAsync Test With XWalkInitializer">
+        <description>
+          <pre_condition />
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0" />
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithClearClientCertPreferencesAsync" purpose="XWalkViewWithClearClientCertPreferencesAsync Test With XWalkInitializer">
         <description>
           <pre_condition />
           <steps>


### PR DESCRIPTION
-Add usecase for API clearClientCertPreferences
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6439