### PR TITLE
[windows] Update the released_suites list

### DIFF
--- a/tools/build/released_suites/Android-Platform
+++ b/tools/build/released_suites/Android-Platform
@@ -113,14 +113,14 @@ wrt-coreshellmanu-android-tests
 wrt-googleplay-android-tests
 wrt-internetstdmanu-android-tests
 wrt-packagemgt-android-tests
-wrt-packagemgtmanu-android-tests
-wrt-rtcoremanu-android-tests
+wrt-packagemgtmanu-tests
+wrt-rtcoremanu-tests
 wrt-security-android-tests
-wrt-securitymanu-android-tests
+wrt-securitymanu-tests
 wrt-sharedmode-android-tests
 wrt-sharedmodemanu-android-tests
 wrt-upgrademanu-android-tests
-wrt-uxmanu-android-tests
+wrt-uxmanu-tests
 "
 
 CORDOVALIST="cordova-feature-android-tests
@@ -131,6 +131,7 @@ tct-sandbox-html5-tests
 tct-webstorage-w3c-tests
 usecase-cordova-android-tests
 usecase-webapi-xwalk-tests
+webapi-appsecurity-external-tests
 "
 
 EMBEDDINGLIST="embedding-api-android-tests

--- a/tools/build/released_suites/Windows-Platform
+++ b/tools/build/released_suites/Windows-Platform
@@ -78,4 +78,10 @@ webapi-simd-nonw3c-tests
 webapi-usertiming-w3c-tests
 webapi-webrtc-w3c-tests
 webapi-webspeech-w3c-tests
+webapi-appsecurity-external-tests
+wrt-packagemgtmanu-tests
+wrt-packagemgt-windows-tests
+wrt-rtcoremanu-tests
+wrt-securitymanu-tests
+wrt-uxmanu-tests
 "


### PR DESCRIPTION
- Since the windows wrt suites have been merged,  need to add the suites to this release list
- Since the webapi-appsecurityapi-external-tests suite is ready, need to add the suite to cordova and windows release list 