### PR TITLE
[Windows] Drop the media capture related cases from windows test

### DIFF
--- a/tools/build/released_suites/Windows-Platform
+++ b/tools/build/released_suites/Windows-Platform
@@ -29,7 +29,6 @@ tct-geodeny-w3c-tests
 tct-gumallow-w3c-tests
 tct-indexeddb-w3c-tests
 tct-jsenhance-html5-tests
-tct-mediacapture-w3c-tests
 tct-mediaqueries-css3-tests
 tct-multicolumn-css3-tests
 tct-navigationtiming-w3c-tests

--- a/usecase/usecase-webapi-xwalk-tests/tests.windows.xml
+++ b/usecase/usecase-webapi-xwalk-tests/tests.windows.xml
@@ -88,8 +88,6 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/WebAPI" execution_type="auto" id="BrowserState" purpose="Browser State">
       </testcase>
-      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="Camera" purpose="Camera">
-      </testcase>
       <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="CameraViaUserMedia" purpose="Camera via UserMedia">
         <capability name="cameraFront"/>
       </testcase>

--- a/webapi/tct-mediacapture-w3c-tests/suite.json
+++ b/webapi/tct-mediacapture-w3c-tests/suite.json
@@ -32,23 +32,6 @@
         "PACK-TOOL-ROOT/resources/testharness": "resources",
         "PACK-TOOL-ROOT/resources/webrunner": "webrunner"
       }
-    },
-    "msi": {
-      "blacklist": [
-        "*"
-      ],
-      "copylist": {
-        "PACK-TOOL-ROOT/resources/inst/inst.msi.py": "inst.py",
-        "tests.full.xml": "tests.full.xml",
-        "tests.xml": "tests.xml"
-      },
-      "pkg-app": {
-        "copylist": {
-          "PACK-TOOL-ROOT/resources/testharness": "resources",
-          "PACK-TOOL-ROOT/resources/webrunner": "webrunner",
-          "icon.png": "icon.ico"
-        }
-      }
     }
   },
   "pkg-name": "tct-mediacapture-w3c-tests"


### PR DESCRIPTION
- Since media capture is not supported, remove the media capture related cases on windows test

BUG=https://crosswalk-project.org/jira/browse/XWALK-6511