### PR TITLE
[EmbeddingAPI] Add autocase for API getPrincipals and getKeyTypes for…

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkResourceClientTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkResourceClientTest.java
@@ -4,7 +4,7 @@
 
 package org.xwalk.embedding.test.v5;
 
-
+import org.xwalk.core.ClientCertRequest;
 import org.xwalk.core.ClientCertRequestHandler;
 import org.xwalk.embedding.base.OnDocumentLoadedInFrameHelper;
 import org.xwalk.embedding.base.OnReceivedClientCertRequestHelper;
@@ -38,7 +38,14 @@ public class XWalkResourceClientTest extends XWalkViewTestBase {
         try {
             loadUrlAsync(url);
             mOnReceivedClientCertRequestHelper.waitForCallback(onReceivedClientCertRequestCallCount);
-            assertEquals(ClientCertRequestHandler.class.getName(), mOnReceivedClientCertRequestHelper.getHandler().getClass().getName());
+            ClientCertRequest request = mOnReceivedClientCertRequestHelper.getHandler();
+            assertEquals(ClientCertRequestHandler.class.getName(), request.getClass().getName());
+            // Following parameters just for host: "egov.privasphere.com".
+            assertEquals("egov.privasphere.com", request.getHost());
+            assertEquals(443, request.getPort());
+            assertEquals("RSA", request.getKeyTypes()[0]);
+            assertEquals("ECDSA", request.getKeyTypes()[1]);
+            assertNull(request.getPrincipals());
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkResourceClientTestAsync.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v5/XWalkResourceClientTestAsync.java
@@ -5,6 +5,7 @@
 package org.xwalk.embedding.test.v5;
 
 
+import org.xwalk.core.ClientCertRequest;
 import org.xwalk.core.ClientCertRequestHandler;
 import org.xwalk.embedding.base.OnDocumentLoadedInFrameHelper;
 import org.xwalk.embedding.base.OnReceivedClientCertRequestHelper;
@@ -32,17 +33,24 @@ public class XWalkResourceClientTestAsync extends XWalkViewTestBase {
 
     @MediumTest
     public void testClientCertRequest() throws Throwable {
-    	OnReceivedClientCertRequestHelper mOnReceivedClientCertRequestHelper = mTestHelperBridge.getOnReceivedClientCertRequestHelper();
-    	final String url = "https://egov.privasphere.com/";
-    	int onReceivedClientCertRequestCallCount = mOnReceivedClientCertRequestHelper.getCallCount();
-    	try {
-    	    loadUrlAsync(url);
-    	    mOnReceivedClientCertRequestHelper.waitForCallback(onReceivedClientCertRequestCallCount);
-    	    assertEquals(ClientCertRequestHandler.class.getName(), mOnReceivedClientCertRequestHelper.getHandler().getClass().getName());
+        OnReceivedClientCertRequestHelper mOnReceivedClientCertRequestHelper = mTestHelperBridge.getOnReceivedClientCertRequestHelper();
+        final String url = "https://egov.privasphere.com/";
+        int onReceivedClientCertRequestCallCount = mOnReceivedClientCertRequestHelper.getCallCount();
+        try {
+            loadUrlAsync(url);
+            mOnReceivedClientCertRequestHelper.waitForCallback(onReceivedClientCertRequestCallCount);
+            ClientCertRequest request = mOnReceivedClientCertRequestHelper.getHandler();
+            assertEquals(ClientCertRequestHandler.class.getName(), request.getClass().getName());
+            // Following parameters just for host: "egov.privasphere.com".
+            assertEquals("egov.privasphere.com", request.getHost());
+            assertEquals(443, request.getPort());
+            assertEquals("RSA", request.getKeyTypes()[0]);
+            assertEquals("ECDSA", request.getKeyTypes()[1]);
+            assertNull(request.getPrincipals());
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);
-    	}
+        }
     }
     @SmallTest
     public void testOnReceivedHttpAuthRequest() {


### PR DESCRIPTION
… ClientCertRequest

-Add autocase for API getPrincipals and getKeyTypes for ClientCertRequest
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 0, update 2, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6431