### PR TITLE
[Cordova] Enable lite mode for the pack script

### DIFF
--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -32,7 +32,7 @@ pack_cordova_sample.py is used for auto build Cordova sample apps, including mob
 
 * ```./pack_cordova_sample.py -n <pkg-name> --cordova-version <cordova-version> [-m <pkg-mode>] [-a <pkg-arch>] [--tools=<tools-path>]```  
 **pkg-name**: mobilespec, helloworld, remotedebugging, spacedodge, CIRC, statusbar, renamePkg, setBackgroundColor, xwalkCommandLine, privateNotes, setUserAgent, LoadExtension  
-**pkg-mode**: embedded(default), shared  
+**pkg-mode**: embedded(default), shared, lite  
 **pkg-arch**: arm(default), x86, arm64, x86_64  
 **Note**: if no --tools argument, please run script under the path where it is.
 

--- a/tools/build/build_cordova.py
+++ b/tools/build/build_cordova.py
@@ -124,9 +124,9 @@ def packCordova(
         os.chdir(orig_dir)
         return False
 
-    pkg_mode_tmp = "shared"
-    if BUILD_PARAMETERS.pkgmode == "embedded":
-        pkg_mode_tmp = "core"
+    pkg_mode_tmp = "core"
+    if BUILD_PARAMETERS.pkgmode == "shared":
+        pkg_mode_tmp = "shared"
 
     xwalk_version = "%s" % CROSSWALK_VERSION
     if CROSSWALK_BRANCH == "beta":
@@ -141,8 +141,13 @@ def packCordova(
         if i_dir == webview_plugin_name:
             if BUILD_PARAMETERS.packtype == "npm":
                 plugin_crosswalk_source = webview_plugin_name
-            install_variable_cmd = "--variable XWALK_MODE=\"%s\" --variable XWALK_VERSION=\"%s\"" \
-                    % (BUILD_PARAMETERS.pkgmode, xwalk_version)
+
+            version_parameter = "XWALK_VERSION"
+            if BUILD_PARAMETERS.pkgmode == "lite":
+                version_parameter = "XWALK_LITE_VERSION"
+
+            install_variable_cmd = "--variable XWALK_MODE=\"%s\" --variable %s=\"%s\"" \
+                    % (BUILD_PARAMETERS.pkgmode, version_parameter, xwalk_version)
 
         plugin_install_cmd = "cordova plugin add %s %s" % (plugin_crosswalk_source, install_variable_cmd)
         if not utils.doCMD(plugin_install_cmd, DEFAULT_CMD_TIMEOUT):

--- a/tools/build/pack_cordova_sample.py
+++ b/tools/build/pack_cordova_sample.py
@@ -54,7 +54,7 @@ TOOL_VERSION = "v0.1"
 VERSION_FILE = "VERSION"
 DEFAULT_CMD_TIMEOUT = 600
 PKG_NAMES = ["spacedodge", "helloworld", "remotedebugging", "mobilespec", "CIRC", "Eh", "statusbar", "renamePkg", "setBackgroundColor", "xwalkCommandLine", "privateNotes", "setUserAgent", "loadExtension"]
-PKG_MODES = ["shared", "embedded"]
+PKG_MODES = ["shared", "embedded", "lite"]
 PKG_ARCHS = ["x86", "arm", "x86_64", "arm64"]
 CORDOVA_PACK_TYPES = ["npm", "local"]
 CROSSWALK_VERSION = ""
@@ -341,9 +341,10 @@ def copySampleSource(app_name, target_path):
 
 def installPlugins(plugin_tool, app_name):
     project_root = os.path.join(BUILD_ROOT, app_name)
-    pkg_mode_tmp = "shared"
-    if BUILD_PARAMETERS.pkgmode == "embedded":
-        pkg_mode_tmp = "core"
+
+    pkg_mode_tmp = "core"
+    if BUILD_PARAMETERS.pkgmode == "shared":
+        pkg_mode_tmp = "shared"
 
     xwalk_version = "%s" % CROSSWALK_VERSION
     if CROSSWALK_BRANCH == "beta":
@@ -359,8 +360,12 @@ def installPlugins(plugin_tool, app_name):
             if i_dir == webview_plugin_name:
                 if BUILD_PARAMETERS.packtype == "npm":
                     plugin_crosswalk_source = webview_plugin_name
-                install_variable_cmd = "--variable XWALK_MODE=\"%s\" --variable XWALK_VERSION=\"%s\"" \
-                        % (BUILD_PARAMETERS.pkgmode, xwalk_version)
+
+                version_parameter = "XWALK_VERSION"
+                if BUILD_PARAMETERS.pkgmode == "lite":
+                    version_parameter = "XWALK_LITE_VERSION"
+                install_variable_cmd = "--variable XWALK_MODE=\"%s\" --variable %s=\"%s\"" \
+                        % (BUILD_PARAMETERS.pkgmode, version_parameter, xwalk_version)
 
                 if checkContains(app_name, "xwalkCommandLine"):
                     install_variable_cmd = install_variable_cmd + " --variable XWALK_COMMANDLINE" \


### PR DESCRIPTION
- It's fine to pack helloworld, mobilespec, cordova usecase pkgs for lite mode
- It's fine to pack helloworld, mobilespec, cordova usecase pkgs for embedded mode
- It's fine to pack helloworld, mobilespec, cordova usecase pkgs for shared mode

https://crosswalk-project.org/jira/browse/XWALK-6503