### PR TITLE
[EmbeddingAPI] Add usecase for API getPrincipals and getKeyTypes for …

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/client/XWalkViewWithOnReceivedLoadErrorAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/client/XWalkViewWithOnReceivedLoadErrorAsync.java
@@ -13,6 +13,7 @@ import org.xwalk.core.XWalkResourceClient;
 import org.xwalk.core.XWalkView;
 
 import android.app.AlertDialog;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.TextView;
@@ -43,8 +44,11 @@ public class XWalkViewWithOnReceivedLoadErrorAsync extends Activity implements X
             // TODO Auto-generated method stub
             Log.d(TAG, "ClientCert Request:" + handler);
             super.onReceivedClientCertRequest(view, handler);
-            mTextView.setText(mTextView.getText().toString() + "ClientCert Request: " + handler
-            		+ "\n");
+            String request = "ClientCert Request Host: " + handler.getHost() + "\n"
+                           + "ClientCert Request Port: " + handler.getPort() + "\n"
+                           + "ClientCert Request KeyTypes: " + handler.getKeyTypes()[0] + " " + handler.getKeyTypes()[1] + "\n"
+                           + "ClientCert Request Principals: " + handler.getPrincipals() + "\n";
+            mTextView.setText(mTextView.getText().toString() + request);
         }
     }
 
@@ -87,6 +91,7 @@ public class XWalkViewWithOnReceivedLoadErrorAsync extends Activity implements X
         setContentView(R.layout.version_layout);
         mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
         mTextView = (TextView) findViewById(R.id.text1);
+        mTextView.setTextColor(Color.GREEN);
         mTextView.setText("XWalkView is handling a Bad SSL client certificate request. The load website is "
         		+ BAD_SSL_WEBSITE + "\n\n");
 

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/client/XWalkViewWithOnReceivedLoadError.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/client/XWalkViewWithOnReceivedLoadError.java
@@ -12,6 +12,7 @@ import org.xwalk.core.XWalkResourceClient;
 import org.xwalk.core.XWalkView;
 
 import android.app.AlertDialog;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.TextView;
@@ -42,8 +43,11 @@ public class XWalkViewWithOnReceivedLoadError extends XWalkActivity {
             // TODO Auto-generated method stub
             Log.d(TAG, "ClientCert Request:" + handler);
             super.onReceivedClientCertRequest(view, handler);
-            mTextView.setText(mTextView.getText().toString() + "ClientCert Request: " + handler
-            		+ "\n");
+            String request = "ClientCert Request Host: " + handler.getHost() + "\n"
+                           + "ClientCert Request Port: " + handler.getPort() + "\n"
+                           + "ClientCert Request KeyTypes: " + handler.getKeyTypes()[0] + " " + handler.getKeyTypes()[1] + "\n"
+                           + "ClientCert Request Principals: " + handler.getPrincipals() + "\n";
+            mTextView.setText(mTextView.getText().toString() + request);
         }
     }
 
@@ -54,6 +58,7 @@ public class XWalkViewWithOnReceivedLoadError extends XWalkActivity {
         setContentView(R.layout.version_layout);
         mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
         mTextView = (TextView) findViewById(R.id.text1);
+        mTextView.setTextColor(Color.GREEN);
         mTextView.setText("XWalkView is handling a Bad SSL client certificate request. The load website is "
         		+ BAD_SSL_WEBSITE + "\n\n");
     }


### PR DESCRIPTION
…ClientCertRequest

-Add usecase for API getPrincipals and getKeyTypes for ClientCertRequest
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 0, update 2, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6431