### PR TITLE
[usecase] Add READ_EXTERNAL_STORAGE permission

### DIFF
--- a/usecase/usecase-webapi-xwalk-tests/manifest.json
+++ b/usecase/usecase-webapi-xwalk-tests/manifest.json
@@ -19,7 +19,8 @@
     "VIBRATE",
     "CHANGE_WIFI_STATE",
     "CHANGE_NETWORK_STATE",
-    "BILLING"
+    "BILLING",
+    "READ_EXTERNAL_STORAGE"
   ],
   "xwalk_app_version": "0.1"
 }


### PR DESCRIPTION
- Camera, FileReader,FileSystem also need this permission for external storage.
This permission is added default in make_apk.py before.
- Failure reason: XWALK-6430 html5 capture api always use camcoder even for images

Impacted tests(approved): new 0, update 3, delete 0
Unit test platform: Crosswalk Project for Android 19.48.497.0
Unit test result summary: pass 2, fail 1, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6032