### PR TITLE
[wrt] Rename package name in .feature

### DIFF
--- a/wrt/wrt-packagemgtmanu-tests/wrt-packagemgt-app/testscripts/Crosswalk_WebApp_Icon_Launcher.feature
+++ b/wrt/wrt-packagemgtmanu-tests/wrt-packagemgt-app/testscripts/Crosswalk_WebApp_Icon_Launcher.feature
@@ -1,6 +1,6 @@
 Feature: wrt-packagemgt-app
  Scenario: Crosswalk WebApp Icon Launcher
-  When launch "wrt_packagemgtmanu_android_tests"
+  When launch "wrt_packagemgtmanu_tests"
     And I click app icon "text=wrt_packagemgt_app" in all apps
     And I wait for 2 seconds
    Then I should see view "description=hello"


### PR DESCRIPTION
The suite name has been renamed to wrt-packagemgtmanu-tests,
but not updated in Crosswalk_WebApp_Icon_Launcher.feature.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android 19.48.497.0
Unit test result summary: pass 1, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6489