### PR TITLE
[Crosswalk-18][usecase] Add WRITE_EXTERNAL_STORAGE permission for Camera

### DIFF
--- a/usecase/usecase-webapi-xwalk-tests/manifest.json
+++ b/usecase/usecase-webapi-xwalk-tests/manifest.json
@@ -20,7 +20,8 @@
     "CHANGE_WIFI_STATE",
     "CHANGE_NETWORK_STATE",
     "BILLING",
-    "READ_EXTERNAL_STORAGE"
+    "READ_EXTERNAL_STORAGE",
+    "WRITE_EXTERNAL_STORAGE"
   ],
   "xwalk_app_version": "0.1"
 }

--- a/webapi/tct-mediacapture-w3c-tests/manifest.json
+++ b/webapi/tct-mediacapture-w3c-tests/manifest.json
@@ -3,7 +3,9 @@
   "start_url": "index.html",
   "xwalk_package_id": "org.xwalk.tct_mediacapture_w3c_tests",
   "xwalk_android_permissions": [
-    "CAMERA"
+    "CAMERA",
+    "READ_EXTERNAL_STORAGE",
+    "WRITE_EXTERNAL_STORAGE"
   ],
   "icons": [
     {


### PR DESCRIPTION
Camera need save image to external storage, add this permission for it.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android 18.48.475.0
Unit test result summary: pass 1, fail 0, block 0