### PR TITLE
[EmbeddingAPI] Fix unable to install multiple applications due to con…

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/AndroidManifest.xml
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/AndroidManifest.xml
@@ -39,8 +39,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <provider android:name="org.xwalk.embedding.base.TestContentProvider"
-            android:authorities="org.xwalk.embedding.base.TestContentProvider" />
+        <provider android:name="org.xwalk.embedding.base.TestContentProvider" android:authorities="org.xwalk.embedding.base.TestContentProvider" />
 
         <uses-library android:name="android.test.runner" />
     </application>

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/AndroidManifest.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/AndroidManifest.xml
@@ -39,8 +39,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <provider android:name="org.xwalk.embedding.base.TestContentProvider"
-            android:authorities="org.xwalk.embedding.base.TestContentProvider" />
+        <provider android:name="org.xwalk.embedding.base.TestContentProvider" android:authorities="org.xwalk.embedding.base.TestContentProvider" />
 
         <uses-library android:name="android.test.runner" />
     </application>

--- a/tools/build/pack.py
+++ b/tools/build/pack.py
@@ -229,6 +229,13 @@ def packAPP(build_json=None, app_src=None, app_dest=None, app_name=None):
                 'EmbeddingApiTestUnit',
                 "EmbeddingApiTestUnit" +
                 app_version)
+            if app_version != "v6":
+                utils.replaceUserString(
+                    app_src,
+                    'AndroidManifest.xml',
+                    '<provider android:name=\"org.xwalk.embedding.base.TestContentProvider\"' +
+                    ' android:authorities=\"org.xwalk.embedding.base.TestContentProvider\" />',
+                    "")
             main_dest = os.path.join(app_src, "src/org/xwalk/embedding")
             utils.replaceUserString(
                 main_dest,
@@ -257,7 +264,7 @@ def packAPP(build_json=None, app_src=None, app_dest=None, app_name=None):
             return False
     elif utils.checkContains(BUILD_PARAMETERS.pkgtype, "ios"):
         if not build_ios.packIOS(build_json, app_src, app_dest, app_name):
-            return False            
+            return False
     else:
         LOG.error("Got wrong pkg type: %s" % BUILD_PARAMETERS.pkgtype)
         return False


### PR DESCRIPTION
…flicting provider

-Fix unable to install multiple applications due to conflicting provider
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 0, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 0, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6556