### PR TITLE
[Cordova] Use XWALKMULTIPLEAPK instead of xwalkMultipleApk in config.xml

### DIFF
--- a/cordova/cordova-feature-android-tests/feature/app_multiple_apk_false.py
+++ b/cordova/cordova-feature-android-tests/feature/app_multiple_apk_false.py
@@ -51,11 +51,12 @@ class TestAppMultipleApkFalse(unittest.TestCase):
             None,
             replace_index_list,
             self, None, "false")
-        comm.build(app_name, False, self, True, False)
+        comm.build(app_name, 0, self, True, False)
+        comm.checkFileSize(os.path.join(comm.testapp_path, "%s.apk" % app_name), 40, 50, self)
         comm.app_install(app_name, pkg_name, self)
         comm.app_launch(app_name, pkg_name, self)
-        comm.app_uninstall(pkg_name, self)
         comm.app_stop(pkg_name, self)
+        comm.app_uninstall(pkg_name, self)
 
 if __name__ == '__main__':
     unittest.main()

--- a/cordova/cordova-feature-android-tests/feature/app_multiple_apk_true.py
+++ b/cordova/cordova-feature-android-tests/feature/app_multiple_apk_true.py
@@ -51,11 +51,12 @@ class TestAppMultipleApkTrue(unittest.TestCase):
             None,
             replace_index_list,
             self, None, "true")
-        comm.build(app_name, False, self, True)
+        comm.build(app_name, 0, self, True)
+        comm.checkFileSize(os.path.join(comm.testapp_path, "%s.apk" % app_name), 20, 30, self)
         comm.app_install(app_name, pkg_name, self)
         comm.app_launch(app_name, pkg_name, self)
-        comm.app_uninstall(pkg_name, self)
         comm.app_stop(pkg_name, self)
+        comm.app_uninstall(pkg_name, self)
 
 if __name__ == '__main__':
     unittest.main()

--- a/cordova/cordova-feature-android-tests/feature/remotedebugging_pack.py
+++ b/cordova/cordova-feature-android-tests/feature/remotedebugging_pack.py
@@ -41,7 +41,7 @@ class TestRemoteDebuggingAppBuild(unittest.TestCase):
         app_name = "remotedebugging"
         pkg_name = " com.example." + app_name.lower()
         comm.create(app_name, pkg_name, comm.MODE, None, None, self)
-        comm.build(app_name, True, self)
+        comm.build(app_name, 1, self)
 
 if __name__ == '__main__':
     unittest.main()

--- a/cordova/cordova-lite-android-tests/lite/comm.py
+++ b/cordova/cordova-lite-android-tests/lite/comm.py
@@ -130,10 +130,8 @@ def installWebviewPlugin(pkg_mode, self, multiple_apks = None):
     if PACK_TYPE == "npm":
         plugin_crosswalk_source = "cordova-plugin-crosswalk-webview"
 
-    version_parameter = "XWALK_VERSION"
-
     plugin_install_cmd = "cordova plugin add %s --variable XWALK_MODE=\"%s\"" \
-                " --variable %s=\"%s\"" % (plugin_crosswalk_source, pkg_mode, version_parameter, xwalk_version)
+                " --variable XWALK_VERSION=\"%s\"" % (plugin_crosswalk_source, pkg_mode, xwalk_version)
 
     if multiple_apks is not None:
         plugin_install_cmd = plugin_install_cmd + " --variable XWALKMULTIPLEAPK=\"%s\"" % multiple_apks

--- a/cordova/cordova-sampleapp-android-tests/sampleapp/privateNotes_build.py
+++ b/cordova/cordova-sampleapp-android-tests/sampleapp/privateNotes_build.py
@@ -44,7 +44,7 @@ class TestPrivateNotesAppBuild(unittest.TestCase):
         sample_src_pref = "/tmp/crosswalk-demos/sample-my-private-notes/www"
         extra_plugin = "https://github.com/01org/AppSecurityApi"
         comm.create(app_name, pkg_name, comm.MODE, sample_src_pref, None, self, extra_plugin)
-        comm.build(app_name, False, self)
+        comm.build(app_name, 0, self)
 
 if __name__ == '__main__':
     unittest.main()

--- a/cordova/cordova-sampleapp-android-tests/sampleapp/spacedodge_build.py
+++ b/cordova/cordova-sampleapp-android-tests/sampleapp/spacedodge_build.py
@@ -43,7 +43,7 @@ class TestSpacedodgeAppBuild(unittest.TestCase):
         pkg_name = " com.example." + app_name.lower()
         sample_src_pref = "/tmp/crosswalk-demos/space-dodge-game/base"
         comm.create(app_name, pkg_name, comm.MODE, sample_src_pref, None, self)
-        comm.build(app_name, False, self)
+        comm.build(app_name, 0, self)
 
 if __name__ == '__main__':
     unittest.main()

--- a/cordova/cordova-webapp-android-tests/webapp/webapp_build.py
+++ b/cordova/cordova-webapp-android-tests/webapp/webapp_build.py
@@ -51,7 +51,7 @@ class TestWebAppBuild(unittest.TestCase):
             None,
             replace_index_list,
             self)
-        comm.build(app_name, False, self)
+        comm.build(app_name, 0, self)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Use the same comm.py for cordova feature cases

Impacted tests(approved): new 0, update 6, delete 0
Unit test platform: Crosswalk Project for android 18.48.477.8
Unit test result summary: pass 6, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6487
BUG=https://crosswalk-project.org/jira/browse/XWALK-6601