### PR TITLE
[EmbeddingAPI] Update usecase for API isFirstAttempt

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_on_received_httpauth_request_async.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_with_on_received_httpauth_request_async.xml
@@ -16,7 +16,7 @@
     <TextView
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:text="If onReceivedHttpAuthRequest is invoked, below will show the 'onReceivedHttpAuthRequest is invoked. Host is '"
+        android:text="If onReceivedHttpAuthRequest is invoked, below will show the 'onReceivedHttpAuthRequest is invoked. Host and isFirstAttempt is '"
         android:id="@+id/textView" />
 
     <TextView

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/client/XWalkViewWithOnReceivedHttpAuthRequestAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/client/XWalkViewWithOnReceivedHttpAuthRequestAsync.java
@@ -49,7 +49,7 @@ public class XWalkViewWithOnReceivedHttpAuthRequestAsync extends Activity implem
         mess.append("Test Purpose: \n\n")
             .append("Verifies OnReceivedHttpAuthRequest API can be invoked in XWalkResourceClient.\n\n")
             .append("Expected Result:\n\n")
-            .append("Test passes if the host name will be shown and it is 'httpbin.org'");
+            .append("Test passes if the host name and isFirstAttempt will be shown and it is 'httpbin.org' and 'true'");
         new AlertDialog.Builder(this)
             .setTitle("Info")
             .setMessage(mess.toString())
@@ -66,7 +66,11 @@ public class XWalkViewWithOnReceivedHttpAuthRequestAsync extends Activity implem
                     XWalkHttpAuthHandler handler, String host, String realm) {
                 // TODO Auto-generated method stub
                 super.onReceivedHttpAuthRequest(view, handler, host, realm);
-                mTextView.setText(host);
+                String isFirst = " isFirstAttempt is ";
+                if (handler != null) {
+                    isFirst += handler.isFirstAttempt();
+                }
+                mTextView.setText(host + isFirst);
             }
         });
     }

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_on_received_httpauth_request.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_with_on_received_httpauth_request.xml
@@ -16,7 +16,7 @@
     <TextView
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:text="If onReceivedHttpAuthRequest is invoked, below will show the 'onReceivedHttpAuthRequest is invoked. Host is '"
+        android:text="If onReceivedHttpAuthRequest is invoked, below will show the 'onReceivedHttpAuthRequest is invoked. Host and isFirstAttempt is '"
         android:id="@+id/textView" />
 
     <TextView

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/client/XWalkViewWithOnReceivedHttpAuthRequest.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/client/XWalkViewWithOnReceivedHttpAuthRequest.java
@@ -29,7 +29,7 @@ public class XWalkViewWithOnReceivedHttpAuthRequest extends XWalkActivity{
         mess.append("Test Purpose: \n\n")
             .append("Verifies OnReceivedHttpAuthRequest API can be invoked in XWalkResourceClient.\n\n")
             .append("Expected Result:\n\n")
-            .append("Test passes if the host name will be shown and it is 'httpbin.org'");
+            .append("Test passes if the host name and isFirstAttempt will be shown and it is 'httpbin.org' and 'true'");
         new AlertDialog.Builder(this)
             .setTitle("Info")
             .setMessage(mess.toString())
@@ -46,7 +46,11 @@ public class XWalkViewWithOnReceivedHttpAuthRequest extends XWalkActivity{
                     XWalkHttpAuthHandler handler, String host, String realm) {
                 // TODO Auto-generated method stub
                 super.onReceivedHttpAuthRequest(view, handler, host, realm);
-                mTextView.setText(host);
+                String isFirst = " isFirstAttempt is ";
+                if (handler != null) {
+                    isFirst += handler.isFirstAttempt();
+                }
+                mTextView.setText(host + isFirst);
             }
         });
     }


### PR DESCRIPTION
-Update usecase for API isFirstAttempt as part of public XWalkHttpAuthHandler
-Cover the XWalkActivity and XWalkInitializer two ways

Impacted tests(approved): new 0, update 2, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6609