### PR TITLE
Correct the Windows-Platform

### DIFF
--- a/tools/build/released_suites/Windows-Platform
+++ b/tools/build/released_suites/Windows-Platform
@@ -28,7 +28,6 @@ tct-geodeny-w3c-tests
 tct-gumallow-w3c-tests
 tct-indexeddb-w3c-tests
 tct-jsenhance-html5-tests
-tct-mediacapture-w3c-tests
 tct-mediaqueries-css3-tests
 tct-multicolumn-css3-tests
 tct-navigationtiming-w3c-tests


### PR DESCRIPTION
Since webapi/tct-mediacapture-w3c-tests already remove support for
Windows before last update the gap test suites, so remove this test suite
from the list of Windows.