### PR TITLE
[apptools-windows] Add tests to test d3dcompiler_47.dll exist for apptools windows

### DIFF
--- a/apptools/apptools-windows-tests/apptools/check_d3dcompiler_47.py
+++ b/apptools/apptools-windows-tests/apptools/check_d3dcompiler_47.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2016 Intel Corporation.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of works must retain the original copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the original copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of Intel Corporation nor the names of its contributors
+#   may be used to endorse or promote products derived from this work without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Authors:
+#         Liu, Yun <yunx.liu@intel.com>
+
+import unittest
+import os
+import comm
+
+
+class TestCrosswalkApptoolsFunctions(unittest.TestCase):
+
+    def test_file_exist(self):
+        comm.setUp()
+        os.chdir(comm.XwalkPath)
+        comm.clear("org.xwalk.test")
+        os.mkdir("org.xwalk.test")
+        os.chdir('org.xwalk.test')
+        cmd = comm.HOST_PREFIX + comm.PackTools + \
+            "crosswalk-pkg --platforms=windows --crosswalk=" + comm.XwalkPath + comm.windowsCrosswalk + " --keep " + comm.ConstPath + "/../testapp/create_package_basic/"
+        (return_code, output) = comm.getstatusoutput(cmd)
+        apks = os.listdir(os.getcwd())
+        apkLength = 0
+        for i in range(len(apks)):
+            if apks[i].endswith(".msi"):
+                apkLength = apkLength + 1
+        projectDir = output[0].split(" * " + os.linesep)[-1].split(' ')[-1].strip(os.linesep)
+        comm.clear("org.xwalk.test")
+        self.assertEquals(return_code, 0)
+        self.assertEquals(apkLength, 1)
+        self.assertIn("d3dcompiler_47.dll", os.listdir(os.path.join(os.path.join(projectDir, "prj"), "windows")))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apptools/apptools-windows-tests/tests.full.xml
+++ b/apptools/apptools-windows-tests/tests.full.xml
@@ -98,6 +98,11 @@
           <test_script_entry>/opt/apptools-windows-tests/apptools/check_wxsfile.py</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_check_d3dcompiler_47" priority="P2" purpose="Windows - Validate if d3dcompiler_47.dll is exist in the installation folder when packaging Crosswalk" status="approved" type="Functional">
+        <description>
+          <test_script_entry>/opt/apptools-windows-tests/apptools/check_d3dcompiler_47.py</test_script_entry>
+        </description>
+      </testcase>
     </set>
     <set name="common_module" type="nodeunit">
       <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" priority="P1" purpose="Windows - Validate if the config and log message are correct when create a new project" status="approved" type="Functional" subcase="11">

--- a/apptools/apptools-windows-tests/tests.xml
+++ b/apptools/apptools-windows-tests/tests.xml
@@ -98,6 +98,11 @@
           <test_script_entry>/opt/apptools-windows-tests/apptools/check_wxsfile.py</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_check_d3dcompiler_47" purpose="Windows - Validate if d3dcompiler_47.dll is exist in the installation folder when packaging Crosswalk">
+        <description>
+          <test_script_entry>/opt/apptools-windows-tests/apptools/check_d3dcompiler_47.py</test_script_entry>
+        </description>
+      </testcase>
     </set>
     <set name="common_module" type="nodeunit">
       <testcase component="Crosswalk App Tools/Common Module" execution_type="auto" id="Crosswalk_application" purpose="Windows - Validate if the config and log message are correct when create a new project" subcase="11">


### PR DESCRIPTION
Failure analysis:
https://crosswalk-project.org/jira/browse/XWALK-5661

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Windows]
Unit test result summary: pass 0, fail 1, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-6646