### PR TITLE
[Crosswalk-18][usecase-wrt]Copy jquery.js to sub app for manual packing

### DIFF
--- a/usecase/usecase-wrt-android-tests/suite.json
+++ b/usecase/usecase-wrt-android-tests/suite.json
@@ -12,6 +12,7 @@
       "copylist": {
         "PACK-TOOL-ROOT/atip/tests/environment.py": "testscripts/environment.py",
         "PACK-TOOL-ROOT/resources/bdd/bddrunner": "bddrunner",
+        "PACK-TOOL-ROOT/bootstrap-fw/js/jquery-2.1.3.min.js": "samples/ApplicationlocalStorage/res/res/js/jquery.js",
         "inst.apk.py": "inst.py",
         "tests.android.xml": "tests.xml",
         "tests.full.xml": "tests.full.xml",


### PR DESCRIPTION
Tester need copy jquery.js to ApplicationlocalStorage/res/res/js/
manually everytime, let's copy it to source code when packing.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android 18.48.475.0
Unit test result summary: pass 1, fail 0, block 0