### PR TITLE
[Crosswalk-17][usecase-wrt]Copy jquery.js to sub app for manual packing

### DIFF
--- a/usecase/usecase-wrt-android-tests/samples/ApplicationlocalStorage/res/upgradeapp/index.html
+++ b/usecase/usecase-wrt-android-tests/samples/ApplicationlocalStorage/res/upgradeapp/index.html
@@ -46,7 +46,7 @@ Authors:
   <h4>Test Steps</h4>
   <ol>
     <li>Pack a test app using below command line with lower than current Crosswalk version:<br/>
-        $ python make_apk.py --package=org.xwalk.localStorage --manifest=res/res/manifest.json<br/>
+        $ python make_apk.py --package=org.xwalk.localStorage --manifest=/path/to/samples/ApplicationlocalStorage/res/res/manifest.json<br/>
         then install it</li>
     <li>Launch the app and click "Set LocalStorage"</li>
     <li>Click "Get LocalStorage"</li>

--- a/usecase/usecase-wrt-android-tests/suite.json
+++ b/usecase/usecase-wrt-android-tests/suite.json
@@ -12,6 +12,7 @@
       "copylist": {
         "PACK-TOOL-ROOT/atip/tests/environment.py": "testscripts/environment.py",
         "PACK-TOOL-ROOT/resources/bdd/bddrunner": "bddrunner",
+        "PACK-TOOL-ROOT/bootstrap-fw/js/jquery-2.1.3.min.js": "samples/ApplicationlocalStorage/res/res/js/jquery.js",
         "inst.apk.py": "inst.py",
         "tests.android.xml": "tests.xml",
         "tests.full.xml": "tests.full.xml",


### PR DESCRIPTION
Tester need copy jquery.js to ApplicationlocalStorage/res/res/js/
manually everytime, let's copy it to source code when packing.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android 17.46.448.10
Unit test result summary: pass 1, fail 0, block 0