### PR TITLE
[usecase-wrt] Add File Chooser language test

### DIFF
--- a/usecase/usecase-wrt-android-tests/samples/FileChooserLanguage/README.md
+++ b/usecase/usecase-wrt-android-tests/samples/FileChooserLanguage/README.md
@@ -1,0 +1,5 @@
+## Usecase Design
+
+This sample demonstrates the File Chooser label should assume the device language settings.
+
+* https://crosswalk-project.org/jira/browse/XWALK-5208

--- a/usecase/usecase-wrt-android-tests/samples/FileChooserLanguage/index.html
+++ b/usecase/usecase-wrt-android-tests/samples/FileChooserLanguage/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2016 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<meta charset="utf-8">
+<meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, width=device-width">
+<title>File Chooser Label Language</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Li Hao" href="mailto:haox.li@intel.com">
+<link rel="stylesheet" type="text/css" href="../../css/bootstrap.css">
+<link rel="stylesheet" type="text/css" href="../../css/main.css">
+<script src="../../js/jquery-2.1.3.min.js"></script>
+<script src="../../js/bootstrap.min.js"></script>
+<script src="../../js/common.js"></script>
+<script src="../../js/tests.js"></script>
+<script src="./js/main.js"></script>
+
+<div id="header">
+  <h3 id="main_page_title"></h3>
+</div>
+<div class="content">
+  <h4>This sample demonstrates the File Chooser label should assume the device language settings.</h4>
+  <p>Device Language: <span id="language">Null</span></p>
+  <p><input type="file"/></p>
+</div>
+<div class="footer">
+  <div id="footer"></div>
+</div>
+<div class="modal fade" id="popup_info">
+</div>

--- a/usecase/usecase-wrt-android-tests/samples/FileChooserLanguage/js/main.js
+++ b/usecase/usecase-wrt-android-tests/samples/FileChooserLanguage/js/main.js
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2016 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Li, Hao <haox.li@intel.com>
+
+*/
+
+window.onload = function() {
+    document.getElementById("language").innerHTML = navigator.language;
+} 

--- a/usecase/usecase-wrt-android-tests/steps/FileChooserLanguage/step.js
+++ b/usecase/usecase-wrt-android-tests/steps/FileChooserLanguage/step.js
@@ -1,0 +1,8 @@
+var step = '<font class="fontSize">'
+            +'<p>Purpose:</p>'
+            +'  <p>Verifies that the File Chooser label should assume the device language settings.</p>'
+            +'<p>Expected Result:</p>'
+            +'<ol>'
+            +'  <li>The label on the File Chooser button assume device language settings.</li>'
+            +'</ol>'
+          +'</font>';

--- a/usecase/usecase-wrt-android-tests/tests.android.xml
+++ b/usecase/usecase-wrt-android-tests/tests.android.xml
@@ -47,6 +47,8 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="WebPassword" purpose="WebPassword Test">
       </testcase>
+      <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="FileChooserLanguage" purpose="File Chooser Language Test">
+      </testcase>
     </set>
     <set background="brand-info3" icon="glyphicon-tasks" name="Third Party Framework">
       <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="PDFjs" purpose="PDFjs">

--- a/usecase/usecase-wrt-android-tests/tests.full.xml
+++ b/usecase/usecase-wrt-android-tests/tests.full.xml
@@ -62,6 +62,8 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="WebPassword" platform="andorid" priority="P1" purpose="WebPassword Test" status="approved" type="functional_positive">
       </testcase>
+      <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="FileChooserLanguage" platform="andorid" priority="P1" purpose="File Chooser Language Test" status="approved" type="functional_positive">
+      </testcase>
     </set>
     <set name="Third Party Framework" background="brand-info3" icon="glyphicon-tasks">
       <testcase component="Crosswalk Use Cases/WRT" type="functional_positive" status="approved" execution_type="manual" platform="android" priority="P0" id="PDFjs" purpose="PDFjs">

--- a/usecase/usecase-wrt-android-tests/tests.shared.xml
+++ b/usecase/usecase-wrt-android-tests/tests.shared.xml
@@ -17,6 +17,8 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/WRT" execution_type="auto" id="WebAppXwalkHost" purpose="WebAppXwalkHost Test">
       </testcase>
+      <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="FileChooserLanguage" purpose="File Chooser Language Test">
+      </testcase>
     </set>
     <set background="bs-purple3" icon="glyphicon-fire" name="Scheme">
       <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="SchemesCheck" purpose="SchemesCheck">


### PR DESCRIPTION
Failure reason:

XWALK 5178 'File chooser' object does not assume device language settings and remains without translation.

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: Crosswalk Project for Android 19.48.503.0
Unit test result summary: pass 0, fail 1, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-5208