### PR TITLE
[Crosswalk-18][Cordova] Use XWALKMULTIPLEAPK instead of xwalkMultipleApk

### DIFF
--- a/cordova/cordova-feature-android-tests/feature/app_multiple_apk_false.py
+++ b/cordova/cordova-feature-android-tests/feature/app_multiple_apk_false.py
@@ -54,8 +54,8 @@ class TestAppMultipleApkFalse(unittest.TestCase):
         comm.build(app_name, False, self, True, False)
         comm.app_install(app_name, pkg_name, self)
         comm.app_launch(app_name, pkg_name, self)
-        comm.app_uninstall(pkg_name, self)
         comm.app_stop(pkg_name, self)
+        comm.app_uninstall(pkg_name, self)
 
 if __name__ == '__main__':
     unittest.main()

--- a/cordova/cordova-feature-android-tests/feature/app_multiple_apk_true.py
+++ b/cordova/cordova-feature-android-tests/feature/app_multiple_apk_true.py
@@ -54,8 +54,8 @@ class TestAppMultipleApkTrue(unittest.TestCase):
         comm.build(app_name, False, self, True)
         comm.app_install(app_name, pkg_name, self)
         comm.app_launch(app_name, pkg_name, self)
-        comm.app_uninstall(pkg_name, self)
         comm.app_stop(pkg_name, self)
+        comm.app_uninstall(pkg_name, self)
 
 if __name__ == '__main__':
     unittest.main()

--- a/cordova/cordova-feature-android-tests/feature/comm.py
+++ b/cordova/cordova-feature-android-tests/feature/comm.py
@@ -122,7 +122,7 @@ def installWebviewPlugin(pkg_mode, self, multiple_apks = None):
                 " --variable XWALK_VERSION=\"%s\"" % (plugin_crosswalk_source, pkg_mode, xwalk_version)
 
     if multiple_apks is not None:
-        plugin_install_cmd = plugin_install_cmd + " --variable xwalkMultipleApk=\"%s\"" % multiple_apks
+        plugin_install_cmd = plugin_install_cmd + " --variable XWALKMULTIPLEAPK=\"%s\"" % multiple_apks
 
     print plugin_install_cmd
 

--- a/cordova/cordova-sampleapp-android-tests/sampleapp/comm.py
+++ b/cordova/cordova-sampleapp-android-tests/sampleapp/comm.py
@@ -122,7 +122,7 @@ def installWebviewPlugin(pkg_mode, self, multiple_apks = None):
                 " --variable XWALK_VERSION=\"%s\"" % (plugin_crosswalk_source, pkg_mode, xwalk_version)
 
     if multiple_apks is not None:
-        plugin_install_cmd = plugin_install_cmd + " --variable xwalkMultipleApk=\"%s\"" % multiple_apks
+        plugin_install_cmd = plugin_install_cmd + " --variable XWALKMULTIPLEAPK=\"%s\"" % multiple_apks
 
     print plugin_install_cmd
 

--- a/cordova/cordova-webapp-android-tests/webapp/comm.py
+++ b/cordova/cordova-webapp-android-tests/webapp/comm.py
@@ -122,7 +122,7 @@ def installWebviewPlugin(pkg_mode, self, multiple_apks = None):
                 " --variable XWALK_VERSION=\"%s\"" % (plugin_crosswalk_source, pkg_mode, xwalk_version)
 
     if multiple_apks is not None:
-        plugin_install_cmd = plugin_install_cmd + " --variable xwalkMultipleApk=\"%s\"" % multiple_apks
+        plugin_install_cmd = plugin_install_cmd + " --variable XWALKMULTIPLEAPK=\"%s\"" % multiple_apks
 
     print plugin_install_cmd
 


### PR DESCRIPTION
- update app_multiple_apk_false/true to make the uninstall be executed after the app has been stoped

Impacted tests(approved): new 0, update 2, delete 0
Unit test platform: Crosswalk Project for Android 18.48.477.11
Unit test result summary: pass 2, fail 0, block 0

https://crosswalk-project.org/jira/browse/XWALK-6487