### PR TITLE
[apptools] Stop setting the Length variables in the global scope.

### DIFF
--- a/apptools/apptools-android-tests/apptools/CI/crosswalk_pkg_basic.py
+++ b/apptools/apptools-android-tests/apptools/CI/crosswalk_pkg_basic.py
@@ -38,11 +38,6 @@ import sys
 sys.path.append("../")
 import comm
 
-x86Length = 0
-x86_64Length = 0
-armLength = 0
-arm_64Length = 0
-apkLength = 0
 
 class TestCrosswalkApptoolsFunctions(unittest.TestCase):
 
@@ -303,6 +298,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
                 "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + " --crosswalk=" + comm.crosswalkzip + ' --targets="armeabi-v7a x86" ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -345,6 +344,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + ' --targets="a x" -c canary ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:

--- a/apptools/apptools-android-tests/apptools/create_package_target.py
+++ b/apptools/apptools-android-tests/apptools/create_package_target.py
@@ -36,11 +36,6 @@ import shutil
 from xml.etree import ElementTree
 import json
 
-x86Length = 0
-x86_64Length = 0
-armLength = 0
-arm_64Length = 0
-apkLength = 0
 
 class TestCrosswalkApptoolsFunctions(unittest.TestCase):
 
@@ -54,6 +49,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + " --crosswalk=" + comm.crosswalkzip + ' --targets="32 64" ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -100,6 +99,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + " --crosswalk=" + comm.crosswalkzip[:comm.crosswalkzip.index(".zip")] + ' --targets="32 64" ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -143,6 +146,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + ' --targets="' + comm.BIT + '"  -c canary ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -185,6 +192,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + ' --targets="ar x8" -c canary ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -220,6 +231,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + ' --targets="arm x86" -c canary ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -255,6 +270,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + ' --targets="arm" -c canary ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -290,6 +309,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + ' --targets="invalid" -c canary ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -325,6 +348,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + ' -t "armeabi-v7a x8" -c canary ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -360,6 +387,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + ' -t "arm invalid" -c canary ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -395,6 +426,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + ' -t "x86 invalid" -c canary ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -430,6 +465,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + ' --targets="arm 32" -c canary ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -465,6 +504,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             "crosswalk-pkg --platforms=android --android=" + comm.ANDROID_MODE + ' --targets="x86 64" -c canary ' + comm.ConstPath + "/../testapp/create_package_basic/"
         return_code = os.system(cmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:

--- a/apptools/apptools-android-tests/apptools/crosswalk_app_targets.py
+++ b/apptools/apptools-android-tests/apptools/crosswalk_app_targets.py
@@ -33,11 +33,6 @@ import os
 import comm
 import shutil
 
-x86Length = 0
-x86_64Length = 0
-armLength = 0
-arm_64Length = 0
-apkLength = 0
 
 class TestCrosswalkApptoolsFunctions(unittest.TestCase):
 
@@ -56,6 +51,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
         return_code = os.system(buildcmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -95,6 +94,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
         return_code = os.system(buildcmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -134,6 +137,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
         return_code = os.system(buildcmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -173,6 +180,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
         return_code = os.system(buildcmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -212,6 +223,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build"
         return_code = os.system(buildcmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -257,6 +272,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build --android-targets=armeabi-v7a ./"
         return_code = os.system(buildcmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -292,6 +311,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build --android-targets=x86 ./"
         return_code = os.system(buildcmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -327,6 +350,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + 'crosswalk-app build --android-targets="armeabi-v7a x86" ./'
         return_code = os.system(buildcmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -362,6 +389,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + 'crosswalk-app build --android-targets="armeabi-v7a x86_64" ./'
         return_code = os.system(buildcmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -397,6 +428,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build --android-targets=arm64-v8a ./"
         return_code = os.system(buildcmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -432,6 +467,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + "crosswalk-app build --android-targets=x86_64 ./"
         return_code = os.system(buildcmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -467,6 +506,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + 'crosswalk-app build --android-targets="arm64-v8a x86_64" ./'
         return_code = os.system(buildcmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:
@@ -502,6 +545,10 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         buildcmd = comm.HOST_PREFIX + comm.PackTools + 'crosswalk-app build --android-targets="arm64-v8a x86_64" ./'
         return_code = os.system(buildcmd)
         apks = os.listdir(os.getcwd())
+        x86Length = 0
+        x86_64Length = 0
+        armLength = 0
+        arm_64Length = 0
         if comm.MODE != " --android-shared":
             for i in range(len(apks)):
                 if apks[i].endswith(".apk") and "x86" in apks[i]:


### PR DESCRIPTION
This partially reverts commit 501e71ca ("[apptools] Add extension file
for apptools").

Setting variables such as `x86Length` in the global scope is wrong, as
they will not be available in the test methods unless one uses a
`global` statement. If that is not done, we end up with failures like
this:

    ======================================================================
    ERROR: test_target_arch (__main__.TestCrosswalkApptoolsFunctions)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "crosswalk_pkg_basic.py", line 312, in test_target_arch
        x86Length = x86Length + 1
    UnboundLocalError: local variable 'x86Length' referenced before assignment