### PR TITLE
[apptools] Fix all failing crosswalk_pkg_basic tests.

### DIFF
--- a/apptools/apptools-android-tests/apptools/comm.py
+++ b/apptools/apptools-android-tests/apptools/comm.py
@@ -49,7 +49,6 @@ def setUp():
 
     device_x86 = ""
     device_arm = ""
-    cachedir = os.environ.get('CROSSWALK_APP_TOOLS_CACHE_DIR')
     Skip_Emulator = os.environ.get('SKIP_EMULATOR')
 
     fp = open(ConstPath + "/../arch.txt", 'r')
@@ -313,14 +312,10 @@ def check_crosswalk_version(self, channel):
         version = aEle['href'].strip('/')
         if re.search('[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*', version):
             break
+    if BIT == "64":
+        version += '-64bit'
     print "-----------" + version
     crosswalk = 'crosswalk-{}.zip'.format(version)
-    if not cachedir:
-        namelist = os.listdir(os.getcwd())
-    else:
-        newcachedir = os.environ.get('CROSSWALK_APP_TOOLS_CACHE_DIR')
-        os.chdir(newcachedir)
-        namelist = os.listdir(os.getcwd())
-        os.chdir(XwalkPath + 'org.xwalk.test')
-    self.assertIn(crosswalk, namelist)
+    crosswalk_dir = os.environ.get('CROSSWALK_APP_TOOLS_CACHE_DIR', '')
+    self.assertTrue(os.path.isfile(os.path.join(crosswalk_dir, crosswalk)))
     return version


### PR DESCRIPTION
Tests such as `test_keep_project` were needlessly relying on app-tools'
output format to determine the directory where the build tree was
created. app-tools has changed its output months ago and the test was
failing. On Windows, this also depends on app-tools pull request #129 to
work.

Other tests were failing in 64-bits mode, either because comm.py guessed
the wrong file name for the 64-bits zip files, and several tests failed
there because by default app-tools will only produce 32-bit APKs and the
test were not passing `--targets` to it.

`invokeCrosswalkPkg()` was also added to make invoking crosswalk-pkg and
checking its return code easier. `comm.getstatusoutput()` was left
intact because other tests depend on it, but it definitely should be
rewritten.