### PR TITLE
[build-script]Remove all the unusual characters from the xwalk_packag…

### DIFF
--- a/tools/build/build_deb.py
+++ b/tools/build/build_deb.py
@@ -58,6 +58,9 @@ def packDeb(build_json=None, app_src=None, app_dest=None, app_name=None):
     DEFAULT_CMD_TIMEOUT= varshop.getValue("DEFAULT_CMD_TIMEOUT")
     app_name = app_name.replace("-", "_")
 
+    if '_' in app_name:
+        app_name = app_name.replace('_', '')
+
     files = glob.glob(os.path.join(BUILD_ROOT, "*.deb"))
     if files:
         if not utils.doRemove(files):


### PR DESCRIPTION
…e_id

Crosswalk-app-tools requires the xwalk_package_id not containing any unusual
characters like hyphen or underscore strictly. So remove them before building
the deb packages.

BUG=https://crosswalk-project/jira/browse/XWALK-6837