### PR TITLE
[webapi-iap]Remove the unsupported packing type

### DIFF
--- a/webapi/webapi-iap-xwalk-tests/README.md
+++ b/webapi/webapi-iap-xwalk-tests/README.md
@@ -3,24 +3,19 @@
 ## Introduction
 
 This test suite is for checking In App Purchase support in Crosswalk Project:
-* https://github.com/crosswalk-project/crosswalk-website/wiki/in-app-purchase
-* https://crosswalk-project.org/jira/browse/XWALK-594
+* https://github.com/crosswalk-project/ios-extensions-crosswalk/blob/master/extensions/InAppPurchase/spec/iap.html
+* https://crosswalk-project.org/jira/browse/XWALK-5695
 
 ## Pre-conditions
 
-To build an IAP application (e.g. this test suite), one needs to build IAP
-extension `iap.jar` following the wiki page
-[Manually Build IAP Extension](https://github.com/crosswalk-project/crosswalk-android-extensions/wiki/Manually-Build-IAP-Extension)
+Get IAP extension iap.zip from [crosswalk-android-extensions/iap](https://github.com/crosswalk-project/crosswalk-android-extensions/releases). Then unzip the iap.zip file and copy all the files to `webapi-iap-xwalk-tests/iap`
 
-And one needs also to copy the `iap.js` and `iap.json` files to
-`webapi-iap-xwalk-tests/iap` from
-[crosswalk-android-extensions/iap](https://github.com/crosswalk-project/crosswalk-android-extensions/tree/master/iap).
+Please login an account for Google Play or Xiaomi Store and make sure you can purchase products before the test.
 
-Please login an account for Google Play or Xiaomi Store and make sure you can purchase products before the test. 
-Specially for Google Play, please make sure 
-1. You can connect to Google Play server
-2. Your credit card had been bound to your Google account.
-3. You Google account must be added to the testing group of iapdemo app in the Google Play Developer Console.
+Specially for Google Play, please make sure
+* You device can connect to Google Play server successfully.
+* Your credit card had been bound to your Google account.
+* You Google account must be added to the testing group of iapdemo app in the Google Play Developer Console.
 
 All the test cases are required to test on the Android 4.4.2 system.
 

--- a/webapi/webapi-iap-xwalk-tests/suite.json
+++ b/webapi/webapi-iap-xwalk-tests/suite.json
@@ -9,7 +9,7 @@
     "inst.*"
   ],
   "pkg-list": {
-    "apk,cordova": {
+    "apk": {
       "blacklist": [
         "*"
       ],
@@ -57,7 +57,7 @@
       }
 
     },
-    "apk-aio, cordova-aio": {
+    "apk-aio": {
       "blacklist": [],
       "copylist": {
         "PACK-TOOL-ROOT/resources/testharness": "resources",


### PR DESCRIPTION
Webapi-iap-xwalk-tests currently only supports apk type when packing
the test suite. Remove the cordova and cordova-aio packing type from
suite.json.

BUG=https://crosswalk-project.org/jira/browse/CTS-732