### PR TITLE
[tools] Add lint tool for catching common mistakes in test files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+
+language: python
+
+python:
+  - "2.7"
+
+before_script:
+  - sudo apt-get install python-demjson
+  - sudo apt-get install libxml2-utils
+  - pip install html5lib
+
+script: python ./tools/lint/lint.py -p

--- a/tools/lint/COPYING
+++ b/tools/lint/COPYING
@@ -1,0 +1,12 @@
+This test suite comes from
+https://github.com/w3c/wpt-tools/
+with modification for catching common mistakes in submitted pull request,
+all crosswalk-test-suite, or specified folder.
+
+These tests are copyright by W3C and/or the author listed in the test
+file. The tests are dual-licensed under the W3C Test Suite License:
+http://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+and the BSD 3-clause License:
+http://www.w3.org/Consortium/Legal/2008/03-bsd-license
+under W3C's test suite licensing policy:
+http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright

--- a/tools/lint/README.md
+++ b/tools/lint/README.md
@@ -1,0 +1,133 @@
+## Introduction
+
+We have a lint tool for catching common mistakes in test files. Now it can
+check html, htm, xhtml, xhtm, json and xml files.
+- You can run it manually by starting the `lint.py` executable from the root of your local
+crosswalk-test-suite working directory like this:
+
+```
+./tools/lint/lint.py
+```
+
+The lint tool is also run automatically for every submitted pull request,
+and reviewers will not merge branches with tests that have lint errors, so
+you must either [fix all lint errors](#fixing-lint-errors), or you must
+[white-list test files] (#updating-the-whitelist) to suppress the errors.
+
+## Usage of lint tool
+
+1. If check all crosswalk-test-suite:</br>
+<code>
+./tools/lint/lint.py
+</code>
+1. If check submitted pull request:</br>
+<code>
+./tools/lint/lint.py -p
+</code>
+1. If check specified folder, the specified folder must be relative path of
+crosswalk-test-suite:</br>
+<code>
+./tools/lint/lint.py -d apptools/apptools-android-tests
+</code>
+
+## Setup Environment
+
+1. Install jsonlint: `sudo apt-get install python-demjson`
+1. Install xmllint: `sudo apt-get install libxml2-utils`
+1. Install html5lib: `pip install html5lib`
+
+## Fixing lint errors
+
+You must fix any errors the lint tool reports, unless an error is for
+something essential to a certain test or that for some other exceptional
+reason shouldn't prevent the test from being merged. In those cases you can
+[white-list test files](#updating-the-whiteslist) to suppress the errors.
+Otherwise, use the details in this section to fix all errors reported.
+
+* **CR AT EOL**: Test-file line ends with CR (U+000D) character; **fix**:
+  reformat file so each line just has LF (U+000A) line ending (standard,
+  cross-platform "Unix" line endings instead of, e.g., DOS line endings).
+
+* **EARLY-TESTHARNESSREPORT**: Test file has an instance of
+  `<script src='/resources/testharnessreport.js'>` prior to
+  `<script src='/resources/testharness.js'>`; **fix**: flip the order.
+
+* **INDENT TABS**: Test-file line starts with one or more tab characters;
+  **fix**: use spaces to replace any tab characters at beginning of lines.
+
+* **MISSING-TESTHARNESS**: Test file is missing an instance of
+  `<script src='/resources/testharness.js'>`; **fix**: ensure each
+  test file contains `<script src='/resources/testharness.js'>`.
+
+* **MISSING-TESTHARNESSREPORT**: Test file is missing an instance of
+  `<script src='/resources/testharnessreport.js'>`; **fix**: ensure each
+  test file contains `<script src='/resources/testharnessreport.js'>`.
+
+* **MULTIPLE-TESTHARNESS**: Test file with multiple instances of
+  `<script src='/resources/testharness.js'>`; **fix**: ensure each test
+  has only one `<script src='/resources/testharness.js'>` instance.
+
+* **MULTIPLE-TESTHARNESSREPORT**: Test file with multiple instances of
+  `<script src='/resources/testharnessreport.js'>`; **fix**: ensure each test
+  has only one `<script src='/resources/testharnessreport.js'>` instance.
+
+* **TRAILING WHITESPACE**: Test-file line has trailing whitespace; **fix**:
+  remove trailing whitespace from all lines in the file.
+
+* **UNNECESSARY EXECUTABLE PERMISSION**: Test file contains unnecessary executable permission; **fix**:
+  remove unnecessary executable permission of the file.
+
+* **INVALID JSON FORMAT**: Test file contains invalid json format; **fix**:
+  errors from `jsonlint -v *.json`, update invalid json format of the file.
+
+* **INVALID XML FORMAT**: Test file contains invalid xml format; **fix**:
+  errors from `xmllint --noout *.xml`, update invalid xml format of the file.
+
+## Updating the whitelist
+
+Normally you must [fix all lint errors](#fixing-lint-errors). But in the
+unusual case of error reports for things essential to certain tests or that
+for other exceptional reasons shouldn't prevent a merge of a test, you can
+update and commit the `lint.whitelist` file in the crosswalk-test-suite/tools/lint/
+directory to suppress errors the lint tool would report for a test file.
+
+To add a test file or directory to the whitelist, use the following format:
+
+```
+ERROR TYPE:file/name/pattern
+```
+
+For example, to whitelist the file `example/file.html` such that all
+`TRAILING WHITESPACE` errors the lint tool would report for it are
+suppressed, add the following line to the `lint.whitelist` file.
+
+```
+TRAILING WHITESPACE:example/file.html
+```
+
+To whitelist an entire directory rather than just one file, use the `*`
+wildcard. For example, to whitelist the `example` directory such that all
+`TRAILING WHITESPACE` errors the lint tool would report for any files in it
+are suppressed, add the following line to the `lint.whitelist` file.
+
+```
+TRAILING WHITESPACE:example/*
+```
+
+If needed, you can also use the `*` wildcard to express other filename
+patterns or directory-name patterns (just as you would when, e.g.,
+executing shell commands from the command line).
+
+Finally, to whitelist just one line in a file, use the following format:
+
+```
+ERROR TYPE:file/name/pattern:line_number
+```
+
+For example, to whitelist just line 128 of the file `example/file.html`
+such that any `TRAILING WHITESPACE` error the lint tool would report for
+that line is suppressed, add the following to the `lint.whitelist` file.
+
+```
+TRAILING WHITESPACE:example/file.html:128
+```

--- a/tools/lint/item.py
+++ b/tools/lint/item.py
@@ -1,0 +1,175 @@
+import urlparse
+from abc import ABCMeta, abstractmethod, abstractproperty
+
+item_types = ["testharness", "reftest", "manual", "stub", "wdspec"]
+
+def get_source_file(source_files, tests_root, manifest, path):
+    def make_new():
+        from sourcefile import SourceFile
+
+        return SourceFile(tests_root, path, manifest.url_base)
+
+    if source_files is None:
+        return make_new()
+
+    if path not in source_files:
+        source_files[path] = make_new()
+
+    return source_files[path]
+
+class ManifestItem(object):
+    __metaclass__ = ABCMeta
+
+    item_type = None
+
+    def __init__(self, source_file, manifest=None):
+        self.manifest = manifest
+        self.source_file = source_file
+
+    @abstractproperty
+    def id(self):
+        """The test's id (usually its url)"""
+        pass
+
+    @property
+    def path(self):
+        """The test path relative to the test_root"""
+        return self.source_file.rel_path
+
+    @property
+    def https(self):
+        return "https" in self.source_file.meta_flags
+
+    def key(self):
+        """A unique identifier for the test"""
+        return (self.item_type, self.id)
+
+    def meta_key(self):
+        """Extra metadata that doesn't form part of the test identity, but for
+        which changes mean regenerating the manifest (e.g. the test timeout."""
+        return ()
+
+    def __eq__(self, other):
+        if not hasattr(other, "key"):
+            return False
+        return self.key() == other.key()
+
+    def __hash__(self):
+        return hash(self.key() + self.meta_key())
+
+    def to_json(self):
+        return {"path": self.path}
+
+    @classmethod
+    def from_json(self, manifest, tests_root, obj, source_files=None):
+        raise NotImplementedError
+
+
+class URLManifestItem(ManifestItem):
+    def __init__(self, source_file, url, url_base="/", manifest=None):
+        ManifestItem.__init__(self, source_file, manifest=manifest)
+        self._url = url
+        self.url_base = url_base
+
+    @property
+    def id(self):
+        return self.url
+
+    @property
+    def url(self):
+        return urlparse.urljoin(self.url_base, self._url)
+
+    def to_json(self):
+        rv = ManifestItem.to_json(self)
+        rv["url"] = self._url
+        return rv
+
+    @classmethod
+    def from_json(cls, manifest, tests_root, obj, source_files=None):
+        source_file = get_source_file(source_files, tests_root, manifest, obj["path"])
+        return cls(source_file,
+                   obj["url"],
+                   url_base=manifest.url_base,
+                   manifest=manifest)
+
+
+class TestharnessTest(URLManifestItem):
+    item_type = "testharness"
+
+    def __init__(self, source_file, url, url_base="/", timeout=None, manifest=None):
+        URLManifestItem.__init__(self, source_file, url, url_base=url_base, manifest=manifest)
+        self.timeout = timeout
+
+    def meta_key(self):
+        return (self.timeout,)
+
+    def to_json(self):
+        rv = URLManifestItem.to_json(self)
+        if self.timeout is not None:
+            rv["timeout"] = self.timeout
+        return rv
+
+    @classmethod
+    def from_json(cls, manifest, tests_root, obj, source_files=None):
+        source_file = get_source_file(source_files, tests_root, manifest, obj["path"])
+        return cls(source_file,
+                   obj["url"],
+                   url_base=manifest.url_base,
+                   timeout=obj.get("timeout"),
+                   manifest=manifest)
+
+
+class RefTest(URLManifestItem):
+    item_type = "reftest"
+
+    def __init__(self, source_file, url, references, url_base="/", timeout=None,
+                 manifest=None):
+        URLManifestItem.__init__(self, source_file, url, url_base=url_base, manifest=manifest)
+        for _, ref_type in references:
+            if ref_type not in ["==", "!="]:
+                raise ValueError, "Unrecognised ref_type %s" % ref_type
+        self.references = tuple(references)
+        self.timeout = timeout
+
+    @property
+    def is_reference(self):
+        return self.source_file.name_is_reference
+
+    def meta_key(self):
+        return (self.timeout,)
+
+    def to_json(self):
+        rv = URLManifestItem.to_json(self)
+        rv["references"] = self.references
+        if self.timeout is not None:
+            rv["timeout"] = self.timeout
+        return rv
+
+    @classmethod
+    def from_json(cls, manifest, tests_root, obj, source_files=None):
+        source_file = get_source_file(source_files, tests_root, manifest, obj["path"])
+        return cls(source_file,
+                   obj["url"],
+                   obj["references"],
+                   url_base=manifest.url_base,
+                   timeout=obj.get("timeout"),
+                   manifest=manifest)
+
+
+class ManualTest(URLManifestItem):
+    item_type = "manual"
+
+class Stub(URLManifestItem):
+    item_type = "stub"
+
+class WebdriverSpecTest(ManifestItem):
+    item_type = "wdspec"
+
+    @property
+    def id(self):
+        return self.path
+
+    @classmethod
+    def from_json(cls, manifest, tests_root, obj, source_files=None):
+        source_file = get_source_file(source_files, tests_root, manifest, obj["path"])
+        return cls(source_file, manifest=manifest)

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -1,0 +1,271 @@
+#! /usr/bin/env python
+import os
+import subprocess
+import re
+import sys
+import fnmatch
+import commands
+
+from collections import defaultdict
+
+from sourcefile import SourceFile
+
+from optparse import OptionParser
+
+lint_root = os.path.dirname(os.path.abspath(__file__))
+repo_root = os.path.dirname(os.path.dirname(lint_root))
+
+
+def git(command, *args):
+    args = list(args)
+
+    proc_kwargs = {"cwd": repo_root}
+    command_line = ["git", command] + args
+
+    try:
+        return subprocess.check_output(command_line, **proc_kwargs)
+    except subprocess.CalledProcessError:
+        raise
+
+
+def iter_files(flag=False, floder=""):
+    if floder != "" and floder != None:
+        os.chdir(repo_root)
+        for pardir, subdir, files in os.walk(floder):
+            for item in subdir + files:
+                if not os.path.isdir(os.path.join(pardir, item)):
+                    yield os.path.join(pardir, item)
+        os.chdir(lint_root)
+    else:
+        if not flag:
+            os.chdir(repo_root)
+            for pardir, subdir, files in os.walk(repo_root):
+                for item in subdir + files:
+                    if not os.path.isdir(os.path.join(pardir, item)[os.path.join(pardir, item).index("crosswalk-test-suite/") + 21:]):
+                        yield os.path.join(pardir, item)[os.path.join(pardir, item).index("crosswalk-test-suite/") + 21:]
+            os.chdir(lint_root)
+        else:
+            for item in git("diff", "--name-status", "HEAD~1").strip().split("\n"):
+                status = item.split("\t")
+                if status[0].strip() != "D":
+                    yield status[1]
+
+
+def check_path_length(path):
+    if len(path) + 1 > 150:
+        return [("PATH LENGTH", "%s longer than maximum path length (%d > 150)" % (path, len(path) + 1), None)]
+    return []
+
+
+def check_filename_space(path):
+    bname = os.path.basename(path)
+    if re.compile(" ").search(bname):
+        return [("FILENAME WHITESPACE", "Filename of %s contain white space" % path, None)]
+    return []
+
+
+def check_format(path):
+    bname = os.path.basename(path)
+    lints = {#"python": ["pylint", "-r no --disable=all --enable=E *.py"],
+             "json": ["jsonlint", "-v *.json"],
+             "xml": ["xmllint", "--noout *.xml"]}
+
+    for key in lints:
+        if fnmatch.fnmatch(bname, lints[key][1][lints[key][1].index("*"):]):
+            returncode = commands.getstatusoutput("%s " % lints[key][0] + lints[key][1][:lints[key][1].index("*")] + os.path.join(repo_root, path))
+            if returncode[0] != 0:
+                return [("INVALID %s FORMAT" % key.upper(), "%s contain invalid %s format" % (path, key), None)]
+    return []
+
+
+def check_permission(path):
+    bname = os.path.basename(path)
+    if not re.compile('\.py$|\.sh$').search(bname):
+        if os.access(os.path.join(repo_root, path), os.X_OK):
+            return [("UNNECESSARY EXECUTABLE PERMISSION", "%s contain unnecessary executable permission" % path, None)]
+    return []
+
+
+def parse_whitelist_file(filename):
+    data = defaultdict(lambda:defaultdict(set))
+
+    with open(filename) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = [item.strip() for item in line.split(":")]
+            if len(parts) == 2:
+                parts.append(None)
+            else:
+                parts[-1] = int(parts[-1])
+
+            error_type, file_match, line_number = parts
+            data[file_match][error_type].add(line_number)
+
+    def inner(path, errors):
+        whitelisted = [False for item in xrange(len(errors))]
+
+        for file_match, whitelist_errors in data.iteritems():
+            if fnmatch.fnmatch(path, file_match):
+                for i, (error_type, msg, line) in enumerate(errors):
+                    if "*" in whitelist_errors:
+                        whitelisted[i] = True
+                    elif error_type in whitelist_errors:
+                        allowed_lines = whitelist_errors[error_type]
+                        if None in allowed_lines or line in allowed_lines:
+                            whitelisted[i] = True
+
+        return [item for i, item in enumerate(errors) if not whitelisted[i]]
+    return inner
+
+
+_whitelist_fn = None
+def whitelist_errors(path, errors):
+    global _whitelist_fn
+
+    if _whitelist_fn is None:
+        _whitelist_fn = parse_whitelist_file(os.path.join(lint_root, "lint.whitelist"))
+    return _whitelist_fn(path, errors)
+
+
+class Regexp(object):
+    pattern = None
+    file_extensions = None
+    error = None
+    _re = None
+
+    def __init__(self):
+        self._re = re.compile(self.pattern)
+
+    def applies(self, path):
+        return (self.file_extensions is None or
+                os.path.splitext(path)[1] in self.file_extensions)
+
+    def search(self, line):
+        return self._re.search(line)
+
+
+class TrailingWhitespaceRegexp(Regexp):
+    pattern = " $"
+    error = "TRAILING WHITESPACE"
+
+
+class TabsRegexp(Regexp):
+    pattern = "^\t"
+    error = "INDENT TABS"
+
+
+class CRRegexp(Regexp):
+    pattern = "\r$"
+    error = "CR AT EOL"
+
+regexps = [item() for item in
+           [TrailingWhitespaceRegexp,
+            TabsRegexp,
+            CRRegexp]]
+
+
+def check_regexp_line(path, f):
+    errors = []
+
+    applicable_regexps = [regexp for regexp in regexps if regexp.applies(path)]
+
+    for i, line in enumerate(f):
+        for regexp in applicable_regexps:
+            if regexp.search(line):
+                errors.append((regexp.error, "%s line %i" % (path, i+1), i+1))
+
+    return errors
+
+
+def check_parsed(path, f):
+    source_file = SourceFile(repo_root, path, "/")
+
+    errors = []
+    if source_file.root is None:
+        return [("PARSE-FAILED", "Unable to parse file %s" % path, None)]
+
+    if source_file.testharness_nodes:
+        if len(source_file.testharness_nodes) > 1:
+            errors.append(("MULTIPLE-TESTHARNESS",
+                           "%s more than one <script src='/resources/testharness.js'>" % path, None))
+        if not source_file.testharnessreport_nodes:
+            errors.append(("MISSING-TESTHARNESSREPORT",
+                            "%s missing <script src='/resources/testharnessreport.js'>" % path, None))
+
+    if source_file.testharnessreport_nodes:
+        if len(source_file.testharnessreport_nodes) > 1:
+            errors.append(("MULTIPLE-TESTHARNESSREPORT",
+                           "%s more than one <script src='/resources/testharnessreport.js'>" % path, None))
+        if not source_file.testharness_nodes:
+            errors.append(("MISSING-TESTHARNESS",
+                            "%s missing <script src='/resources/TESTHARNESS.js'>" % path, None))
+
+    return errors
+
+
+def output_errors(errors):
+    for error_type, error, line_number in errors:
+        print "%s: %s" % (error_type, error)
+
+
+def output_error_count(error_count):
+    if not error_count:
+        return
+
+    by_type = " ".join("%s: %d" % item for item in error_count.iteritems())
+    count = sum(error_count.values())
+    if count == 1:
+        print "There was 1 error (%s)" % (by_type,)
+    else:
+        print "There were %d errors (%s)" % (count, by_type)
+
+
+def main():
+    error_count = defaultdict(int)
+
+    parser = OptionParser()
+    parser.add_option('-p', '--pull', dest="pull_request", action='store_true', default=False)
+    parser.add_option("-d", '--dir', dest="dir", help="specify the checking dir, e.g. tools")
+    options, args = parser.parse_args()
+
+    def run_lint(path, fn, *args):
+        errors = whitelist_errors(path, fn(path, *args))
+        output_errors(errors)
+        for error_type, error, line in errors:
+            error_count[error_type] += 1
+
+    for path in iter_files(options.pull_request, options.dir):
+        abs_path = os.path.join(repo_root, path)
+        if not os.path.exists(abs_path):
+            continue
+        for path_fn in file_path_lints:
+            run_lint(path, path_fn)
+
+        for format_fn in file_format_lints:
+            run_lint(path, format_fn)
+
+        for state_fn in file_state_lints:
+            run_lint(path, state_fn)
+
+        if not os.path.isdir(abs_path):
+            if re.compile('\.html$|\.htm$|\.xhtml$|\.xhtm$').search(abs_path):
+                with open(abs_path) as f:
+                    for file_fn in file_content_lints:
+                        run_lint(path, file_fn, f)
+                        f.seek(0)
+
+    output_error_count(error_count)
+    return sum(error_count.itervalues())
+
+#file_path_lints = [check_path_length, check_filename_space]
+file_path_lints = [check_filename_space]
+file_content_lints = [check_regexp_line, check_parsed]
+file_format_lints = [check_format]
+file_state_lints = [check_permission]
+
+if __name__ == "__main__":
+    error_count = main()
+    if error_count > 0:
+        sys.exit(1)

--- a/tools/lint/lint.whitelist
+++ b/tools/lint/lint.whitelist
@@ -1,0 +1,31 @@
+# File containing whiteslist for lint errors
+# Format is:
+# ERROR TYPE:file/name/pattern[:line number]
+# e.g.
+# TRAILING WHITESPACE:example/file.html:128
+# to allow trailing whitespace on example/file.html line 128
+
+## File types that should never be checked ##
+
+*:*.pdf
+*:*.jpg
+*:*.png
+*:*.gif
+*:*.pdf
+*:*.wav
+*:*.mp3
+*:*.m4a
+*:*.oga
+*:*.ogv
+*:*.webm
+*:*.mp4
+*:*.m4v
+*:*.ttf
+*:*.woff
+*:*.eot
+*:*.sfd
+*:*.swf
+*:*.md
+*:README
+*:COPYING
+*:*.txt

--- a/tools/lint/sourcefile.py
+++ b/tools/lint/sourcefile.py
@@ -1,0 +1,297 @@
+import os
+import urlparse
+from fnmatch import fnmatch
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    from xml.etree import ElementTree
+
+import html5lib
+
+import vcs
+from item import Stub, ManualTest, WebdriverSpecTest, RefTest, TestharnessTest
+from utils import rel_path_to_url, ContextManagerStringIO, cached_property
+
+wd_pattern = "*.py"
+
+
+class SourceFile(object):
+    parsers = {"html":lambda x:html5lib.parse(x, treebuilder="etree"),
+               "xhtml":ElementTree.parse,
+               "svg":ElementTree.parse}
+
+    def __init__(self, tests_root, rel_path, url_base, use_committed=False):
+        """Object representing a file in a source tree.
+
+        :param tests_root: Path to the root of the source tree
+        :param rel_path: File path relative to tests_root
+        :param url_base: Base URL used when converting file paths to urls
+        :param use_committed: Work with the last committed version of the file
+                              rather than the on-disk version.
+        """
+
+        self.tests_root = tests_root
+        self.rel_path = rel_path
+        self.url_base = url_base
+        self.use_committed = use_committed
+
+        self.url = rel_path_to_url(rel_path, url_base)
+        self.path = os.path.join(tests_root, rel_path)
+
+        self.dir_path, self.filename = os.path.split(self.path)
+        self.name, self.ext = os.path.splitext(self.filename)
+
+        self.type_flag = None
+        if "-" in self.name:
+            self.type_flag = self.name.rsplit("-", 1)[1]
+
+        self.meta_flags = self.name.split(".")[1:]
+
+    def __getstate__(self):
+        # Remove computed properties if we pickle this class
+        rv = self.__dict__.copy()
+
+        if "__cached_properties__" in rv:
+            cached_properties = rv["__cached_properties__"]
+            for key in rv.keys():
+                if key in cached_properties:
+                    del rv[key]
+            del rv["__cached_properties__"]
+        return rv
+
+    def name_prefix(self, prefix):
+        """Check if the filename starts with a given prefix
+
+        :param prefix: The prefix to check"""
+        return self.filename.startswith(prefix)
+
+    def open(self):
+        """Return a File object opened for reading the file contents,
+        or the contents of the file when last committed, if
+        use_comitted is true."""
+
+        if self.use_committed:
+            git = vcs.get_git_func(os.path.dirname(__file__))
+            blob = git("show", "HEAD:%s" % self.rel_path)
+            file_obj = ContextManagerStringIO(blob)
+        else:
+            file_obj = open(self.path)
+        return file_obj
+
+    @property
+    def name_is_non_test(self):
+        """Check if the file name matches the conditions for the file to
+        be a non-test file"""
+        return (os.path.isdir(self.path) or
+                self.name_prefix("MANIFEST") or
+                self.filename.startswith("."))
+
+    @property
+    def name_is_stub(self):
+        """Check if the file name matches the conditions for the file to
+        be a stub file"""
+        return self.name_prefix("stub-")
+
+    @property
+    def name_is_manual(self):
+        """Check if the file name matches the conditions for the file to
+        be a manual test file"""
+        return self.type_flag == "manual"
+
+    @property
+    def name_is_worker(self):
+        """Check if the file name matches the conditions for the file to
+        be a worker js test file"""
+        return "worker" in self.meta_flags and self.ext == ".js"
+
+    @property
+    def name_is_webdriver(self):
+        """Check if the file name matches the conditions for the file to
+        be a webdriver spec test file"""
+        # wdspec tests are in subdirectories of /webdriver excluding __init__.py
+        # files.
+        rel_dir_tree = self.rel_path.split(os.path.sep)
+        return (rel_dir_tree[0] == "webdriver" and
+                len(rel_dir_tree) > 2 and
+                self.filename != "__init__.py" and
+                fnmatch(self.filename, wd_pattern))
+
+    @property
+    def name_is_reference(self):
+        """Check if the file name matches the conditions for the file to
+        be a reference file (not a reftest)"""
+        return self.type_flag in ("ref", "notref")
+
+    @property
+    def markup_type(self):
+        """Return the type of markup contained in a file, based on its extension,
+        or None if it doesn't contain markup"""
+        ext = self.ext
+
+        if not ext:
+            return None
+        if ext[0] == ".":
+            ext = ext[1:]
+        if ext in ["html", "htm"]:
+            return "html"
+        if ext in ["xhtml", "xht"]:
+            return "xhtml"
+        if ext == "svg":
+            return "svg"
+        return None
+
+    @cached_property
+    def root(self):
+        """Return an ElementTree Element for the root node of the file if it contains
+        markup, or None if it does not"""
+        if not self.markup_type:
+            return None
+
+        parser = self.parsers[self.markup_type]
+
+        with self.open() as f:
+            try:
+                tree = parser(f)
+            except Exception:
+                return None
+
+        if hasattr(tree, "getroot"):
+            root = tree.getroot()
+        else:
+            root = tree
+
+        return root
+
+    @cached_property
+    def timeout_nodes(self):
+        """List of ElementTree Elements corresponding to nodes in a test that
+        specify timeouts"""
+        return self.root.findall(".//{http://www.w3.org/1999/xhtml}meta[@name='timeout']")
+
+    @cached_property
+    def timeout(self):
+        """The timeout of a test or reference file. "long" if the file has an extended timeout
+        or None otherwise"""
+        if not self.root:
+            return
+
+        if self.timeout_nodes:
+            timeout_str = self.timeout_nodes[0].attrib.get("content", None)
+            if timeout_str and timeout_str.lower() == "long":
+                return timeout_str
+
+    @cached_property
+    def testharness_nodes(self):
+        """List of ElementTree Elements corresponding to nodes representing a
+        testharness.js script"""
+        nodes = []
+        lists =  self.root.findall(".//{http://www.w3.org/1999/xhtml}script[@src]")
+        for item in lists:
+            if item.attrib['src'].endswith('testharness.js'):
+                nodes.append(item)
+        return nodes
+
+
+    @cached_property
+    def content_is_testharness(self):
+        """Boolean indicating whether the file content represents a
+        testharness.js test"""
+        if not self.root:
+            return None
+        return bool(self.testharness_nodes)
+
+    @cached_property
+    def testharnessreport_nodes(self):
+        """List of ElementTree Elements corresponding to nodes representing a
+        testharnessreport.js script"""
+        nodes = []
+        lists =  self.root.findall(".//{http://www.w3.org/1999/xhtml}script[@src]")
+        for item in lists:
+            if item.attrib['src'].endswith('testharnessreport.js'):
+                nodes.append(item)
+        return nodes
+
+    @cached_property
+    def variant_nodes(self):
+        """List of ElementTree Elements corresponding to nodes representing a
+        test variant"""
+        return self.root.findall(".//{http://www.w3.org/1999/xhtml}meta[@name='variant']")
+
+    @cached_property
+    def test_variants(self):
+        rv = []
+        for element in self.variant_nodes:
+            if "content" in element.attrib:
+                variant = element.attrib["content"]
+                assert variant == "" or variant[0] in ["#", "?"]
+                rv.append(variant)
+
+        if not rv:
+            rv = [""]
+
+        return rv
+
+    @cached_property
+    def reftest_nodes(self):
+        """List of ElementTree Elements corresponding to nodes representing a
+        to a reftest <link>"""
+        if not self.root:
+            return []
+
+        match_links = self.root.findall(".//{http://www.w3.org/1999/xhtml}link[@rel='match']")
+        mismatch_links = self.root.findall(".//{http://www.w3.org/1999/xhtml}link[@rel='mismatch']")
+        return match_links + mismatch_links
+
+    @cached_property
+    def references(self):
+        """List of (ref_url, relation) tuples for any reftest references specified in
+        the file"""
+        rv = []
+        rel_map = {"match": "==", "mismatch": "!="}
+        for item in self.reftest_nodes:
+            if "href" in item.attrib:
+                ref_url = urlparse.urljoin(self.url, item.attrib["href"])
+                ref_type = rel_map[item.attrib["rel"]]
+                rv.append((ref_url, ref_type))
+        return rv
+
+    @cached_property
+    def content_is_ref_node(self):
+        """Boolean indicating whether the file is a non-leaf node in a reftest
+        graph (i.e. if it contains any <link rel=[mis]match>"""
+        return bool(self.references)
+
+    def manifest_items(self):
+        """List of manifest items corresponding to the file. There is typically one
+        per test, but in the case of reftests a node may have corresponding manifest
+        items without being a test itself."""
+
+        if self.name_is_non_test:
+            rv = []
+
+        elif self.name_is_stub:
+            rv = [Stub(self, self.url)]
+
+        elif self.name_is_manual:
+            rv = [ManualTest(self, self.url)]
+
+        elif self.name_is_worker:
+            rv = [TestharnessTest(self, self.url[:-3])]
+
+        elif self.name_is_webdriver:
+            rv = [WebdriverSpecTest(self)]
+
+        elif self.content_is_testharness:
+            rv = []
+            for variant in self.test_variants:
+                url = self.url + variant
+                rv.append(TestharnessTest(self, url, timeout=self.timeout))
+
+        elif self.content_is_ref_node:
+            rv = [RefTest(self, self.url, self.references, timeout=self.timeout)]
+
+        else:
+            # If nothing else it's a helper file, which we don't have a specific type for
+            rv = []
+
+        return rv

--- a/tools/lint/utils.py
+++ b/tools/lint/utils.py
@@ -1,0 +1,44 @@
+import os
+import urlparse
+from StringIO import StringIO
+
+blacklist = ["/", "/tools/", "/doc/"]
+
+def rel_path_to_url(rel_path, url_base="/"):
+    assert not os.path.isabs(rel_path)
+    if url_base[0] != "/":
+        url_base = "/" + url_base
+    if url_base[-1] != "/":
+        url_base += "/"
+    return url_base + rel_path.replace(os.sep, "/")
+
+def is_blacklisted(url):
+    for item in blacklist:
+        if item == "/":
+            if "/" not in url[1:]:
+                return True
+        elif url.startswith(item):
+            return True
+    return False
+
+class ContextManagerStringIO(StringIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+
+class cached_property(object):
+    def __init__(self, func):
+        self.func = func
+        self.__doc__ = getattr(func, "__doc__")
+        self.name = func.__name__
+
+    def __get__(self, obj, cls=None):
+        if obj is None:
+            return self
+
+        if self.name not in obj.__dict__:
+            obj.__dict__[self.name] = self.func(obj)
+            obj.__dict__.setdefault("__cached_properties__", set()).add(self.name)
+        return obj.__dict__[self.name]

--- a/tools/lint/vcs.py
+++ b/tools/lint/vcs.py
@@ -1,0 +1,25 @@
+import os
+import subprocess
+
+def get_git_func(repo_path):
+    def git(cmd, *args):
+        full_cmd = ["git", cmd] + list(args)
+        return subprocess.check_output(full_cmd, cwd=repo_path, stderr=subprocess.STDOUT)
+    return git
+
+
+def is_git_repo(tests_root):
+    return os.path.exists(os.path.join(tests_root, ".git"))
+
+
+_repo_root = None
+def get_repo_root(initial_dir=None):
+    global _repo_root
+
+    if initial_dir is None:
+        initial_dir = os.path.dirname(__file__)
+
+    if _repo_root is None:
+        git = get_git_func(initial_dir)
+        _repo_root = git("rev-parse", "--show-toplevel").rstrip()
+    return _repo_root


### PR DESCRIPTION
- The lint tool can catch common mistakes in test files. Now it can check html, htm, xhtml, xhtm, json and xml files.

https://crosswalk-project.org/jira/browse/CTS-258