### PR TITLE
[Crosswalk-19][usecase-wrt]Fix incorrect execution_type in tests.xml

### DIFF
--- a/usecase/usecase-wrt-android-tests/tests.android.xml
+++ b/usecase/usecase-wrt-android-tests/tests.android.xml
@@ -19,7 +19,7 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="WebAppHWKey" purpose="WebAppHWKey Test">
       </testcase>
-      <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="WebAppTaskManager" purpose="WebAppTaskManager Test">
+      <testcase component="Crosswalk Use Cases/WRT" execution_type="auto" id="WebAppTaskManager" purpose="WebAppTaskManager Test">
       </testcase>
       <testcase component="Crosswalk Use Cases/WRT" execution_type="auto" id="WebAppXwalkHost" purpose="WebAppXwalkHost Test">
       </testcase>
@@ -33,7 +33,7 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="LZMACompressionUI" purpose="LZMACompressionUI Test">
       </testcase>
-      <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="ApplicationlocalStorage" purpose="ApplicationlocalStorage Test" subcase="3">
+      <testcase component="Crosswalk Use Cases/WRT" execution_type="auto" id="ApplicationlocalStorage" purpose="ApplicationlocalStorage Test" subcase="3">
       </testcase>
       <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="NormalizingDialogs" purpose="NormalizingDialogs Test" subcase="3">
       </testcase>

--- a/usecase/usecase-wrt-android-tests/tests.full.xml
+++ b/usecase/usecase-wrt-android-tests/tests.full.xml
@@ -25,7 +25,7 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="WebAppHWKey" platform="all" priority="P0" purpose="WebAppHWKey Test" status="approved" type="functional_positive">
       </testcase>
-      <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="WebAppTaskManager" platform="all" priority="P0" purpose="WebAppTaskManager Test" status="approved" type="functional_positive">
+      <testcase component="Crosswalk Use Cases/WRT" execution_type="auto" id="WebAppTaskManager" platform="all" priority="P0" purpose="WebAppTaskManager Test" status="approved" type="functional_positive">
         <description>
           <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-wrt-android-tests/testscripts/WebAppTaskManager.feature</bdd_test_script_entry>
         </description>
@@ -45,7 +45,7 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="LZMACompressionUI" platform="all" priority="P1" purpose="LZMACompressionUI Test" status="approved" type="functional_positive">
       </testcase>
-      <testcase component="Crosswalk Use Cases/WRT" execution_type="manual" id="ApplicationlocalStorage" platform="all" priority="P1" purpose="ApplicationlocalStorage Test" status="approved" type="functional_positive" subcase="3">
+      <testcase component="Crosswalk Use Cases/WRT" execution_type="auto" id="ApplicationlocalStorage" platform="all" priority="P1" purpose="ApplicationlocalStorage Test" status="approved" type="functional_positive" subcase="3">
         <description>
           <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-wrt-android-tests/testscripts/ApplicationlocalStorage.feature</bdd_test_script_entry>
         </description>


### PR DESCRIPTION
execution_type should be auto if it's a bdd/ref test.