### PR TITLE
[usecase-webapi] Fix a FingerPrint extension directory typo

### DIFF
--- a/usecase/usecase-webapi-xwalk-tests/manifest.json
+++ b/usecase/usecase-webapi-xwalk-tests/manifest.json
@@ -24,6 +24,6 @@
     "WRITE_EXTERNAL_STORAGE",
     "USE_FINGERPRINT"
   ],
-  "xwalk_extensions": ["samples/Fingerprint/fingerprint"],
+  "xwalk_extensions": ["samples/FingerPrint/fingerprint"],
   "xwalk_app_version": "0.1"
 }


### PR DESCRIPTION
[usecase-webapi] Fix a FingerPrint extension directory typo.
    
FingerPrint example is copied from demo-express, so keep the
extension directory same as manifest.json in demo-express.
