### PR TITLE
[Crosswalk-19][usecase-cordova] Remove shared mode in DefaultCrosswalkVersion

### DIFF
--- a/usecase/usecase-cordova-android-tests/samples/DefaultCrosswalkVersion/index.html
+++ b/usecase/usecase-cordova-android-tests/samples/DefaultCrosswalkVersion/index.html
@@ -52,13 +52,14 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <h4>Test Steps</h4>
   <ol>
     <li>Create cordova project<br/>
-        $ cordova create foo</li>
+        $ cordova create foo org.xwalk.foo foo</li>
     <li>Copy [test-package]/res/DefaultCrosswalkVersion/index.html to foo/www</li>
     <li>Config project<br/>
+        $ cd foo<br/>
         $ cordova platform add android<br/>
         $ cordova plugin add https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview<br/>
-        (1. For npm release testing, plugin should be https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview/tree/release-testing)<br/>
-        (2. For shared mode, need add "--variable XWALK_MODE=shared" after cordova-plugin-crosswalk-webview)</li>
+        (1. For npm release testing, plugin should be https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview#release-testing)<br/>
+        (2. No need build shared mode for default version, only for embedded mode)</li>
     <li>Build test app<br/>
         $ cordova build android</li>
     <li>Find test app in foo/platforms/android/build/outputs/apk</li>

--- a/usecase/usecase-cordova-android-tests/steps/DefaultCrosswalkVersion/step.js
+++ b/usecase/usecase-cordova-android-tests/steps/DefaultCrosswalkVersion/step.js
@@ -1,6 +1,6 @@
 var step = '<font class="fontSize">'
             +'<p>Purpose:</p>'
-            +'<p>Verify the webview plugin support default crosswalk version</p>'
+            +'<p>Verify the webview plugin should default to crosswalk latest stable version</p>'
             +'<p>Expected Result:</p>'
-            +'<li>The crosswalk version is the same with the latest version in https://download.01.org/crosswalk/releases/crosswalk/android/maven2/org/xwalk/xwalk_core_library_beta/(shared mode should be https://download.01.org/crosswalk/releases/crosswalk/android/maven2/org/xwalk/xwalk_shared_library_beta/)</li>'
+            +'<li>The crosswalk version is the same with the latest version in https://download.01.org/crosswalk/releases/crosswalk/android/maven2/org/xwalk/xwalk_core_library_beta/</li>'
           +'</font>';


### PR DESCRIPTION
For default crosswalk version for webview plugin, no need shared
mode testing, it will use local runtime lib verison. default version
should be testing in embedded mode only.

Failure Analysis:
XWALK 6879 Webview plugin default crosswalk version is not 19
even if crosswalk is 19 in maven2/org/xwalk/xwalk_core_library_beta.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: WebView Plugin 1.7.0
Unit test result summary: pass 0, fail 1, block 0