### PR TITLE
[usecase-wrt] Change remote debugging test

### DIFF
--- a/usecase/usecase-wrt-android-tests/suite.json
+++ b/usecase/usecase-wrt-android-tests/suite.json
@@ -88,10 +88,10 @@
           "apk-type": "MANIFEST"
         },
         "samples/RemoteDebugging/res/debugging": {
-          "apk-common-opt": "--enable-remote-debugging",
           "apk-type": "MANIFEST"
         },
         "samples/RemoteDebugging/res/nodebugging": {
+          "apk-common-opt": "--release",
           "apk-type": "MANIFEST"
         },
         "samples/SchemeContent/res": {


### PR DESCRIPTION
Default is remote debugging mode by app tools.
Another is release mode, no debug port open.