### PR TITLE
[Webapi] Add requestPermission method before create a notification on

### DIFF
--- a/wrt/wrt-uxmanu-tests/testapp/web_feature_notification_tests/index.html
+++ b/wrt/wrt-uxmanu-tests/testapp/web_feature_notification_tests/index.html
@@ -52,6 +52,7 @@ Authors:
                 window.webkitNotifications.requestPermission();
             }
         } else if (typeof Notification != "undefined") {
+            Notification.requestPermission()
             notification = new Notification("New Email Received", {body: "content msg"});
         }
         return notification;
@@ -59,12 +60,6 @@ Authors:
 
     function showNotification() {
         var notification = getNotification();
-        if (notification) {
-            notification.onshow = function () {
-                setTimeout(notification.cancel(), 1500);
-            };
-            notification.show();
-        }
     }
   </script>
 </body>


### PR DESCRIPTION
Windows
Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Windows 20.49.527.0
Unit test result summary: pass 1, fail 0, block 0

Android
Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Windows 20.49.527.0
Unit test result summary: pass 1, fail 0, block 0

BUG=CTS-1548