### PR TITLE
[WebAPI] Make the test results' numbers on WTS be consistent with the ones by testkit-lite.

### DIFF
--- a/webapi/webapi-webcl-nonw3c-tests/tests.full.xml
+++ b/webapi/webapi-webcl-nonw3c-tests/tests.full.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite category="Supplementary APIs" name="webapi-webcl-nonw3c-tests">
     <set name="contextAndCreate" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLBuffer_createSubBuffer" priority="P1" purpose="Check if WebCLBuffer.createSubBuffer function works" status="approved" type="compliance" subcase="11">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLBuffer_createSubBuffer" priority="P1" purpose="Check if WebCLBuffer.createSubBuffer function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_buffer_createSubBuffer.html</test_script_entry>
         </description>
@@ -14,7 +14,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer" priority="P1" purpose="Check if WebCLContext.createBuffer function works" status="approved" type="compliance" subcase="10">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer" priority="P1" purpose="Check if WebCLContext.createBuffer function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createBuffer.html</test_script_entry>
         </description>
@@ -25,7 +25,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createCommandQueue" priority="P1" purpose="Check if WebCLContext.createCommandQueue function works" status="approved" type="compliance" subcase="9">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createCommandQueue" priority="P1" purpose="Check if WebCLContext.createCommandQueue function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createCommandQueue.html</test_script_entry>
         </description>
@@ -36,7 +36,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createEvent" priority="P1" purpose="Check if WebCLEvent can be new success" status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createEvent" priority="P1" purpose="Check if WebCLEvent can be new success" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createEvent.html</test_script_entry>
         </description>
@@ -47,7 +47,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage" priority="P1" purpose="Check if WebCLContext.createImage function works" status="approved" type="compliance" subcase="35">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage" priority="P1" purpose="Check if WebCLContext.createImage function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createImage.html</test_script_entry>
         </description>
@@ -58,7 +58,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createProgram" priority="P1" purpose="Check if WebCLContext.createProgram function works" status="approved" type="compliance" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createProgram" priority="P1" purpose="Check if WebCLContext.createProgram function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createProgram.html</test_script_entry>
         </description>
@@ -69,7 +69,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createSampler" priority="P1" purpose="Check if WebCLContext.createSampler function works" status="approved" type="compliance" subcase="16">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createSampler" priority="P1" purpose="Check if WebCLContext.createSampler function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createSampler.html</test_script_entry>
         </description>
@@ -80,7 +80,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createUserEvent" priority="P1" purpose="Check if WebCLContext.createUserEvent function works" status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createUserEvent" priority="P1" purpose="Check if WebCLContext.createUserEvent function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createUserEvent.html</test_script_entry>
         </description>
@@ -93,7 +93,7 @@
       </testcase>
     </set>
     <set name="eventsAndCallbacks" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback" priority="P1" purpose="Check if WebCLEvent.setCallback function works" status="approved" type="compliance" subcase="7">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback" priority="P1" purpose="Check if WebCLEvent.setCallback function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/eventsAndCallbacks/cl_event_setCallback.html</test_script_entry>
         </description>
@@ -104,7 +104,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLUserEvent_setStatus" priority="P1" purpose="Check if WebCLUserEvent.setStatus function works" status="approved" type="compliance" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLUserEvent_setStatus" priority="P1" purpose="Check if WebCLUserEvent.setStatus function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/eventsAndCallbacks/cl_event_setStatus.html</test_script_entry>
         </description>
@@ -115,7 +115,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_waitForEvents" priority="P1" purpose="Check if WebCL.waitForEvents function works" status="approved" type="compliance" subcase="13">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_waitForEvents" priority="P1" purpose="Check if WebCL.waitForEvents function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/eventsAndCallbacks/cl_webcl_waitForEvents.html</test_script_entry>
         </description>
@@ -128,7 +128,7 @@
       </testcase>
     </set>
     <set name="fetchInfo" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_getInfo" priority="P1" purpose="Check if WebCLCommandQueue.getInfo function works" status="approved" type="compliance" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_getInfo" priority="P1" purpose="Check if WebCLCommandQueue.getInfo function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_commandqueue_getinfo.html</test_script_entry>
         </description>
@@ -139,7 +139,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_getInfo" priority="P1" purpose="Check if WebCLContext.getInfo function works" status="approved" type="compliance" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_getInfo" priority="P1" purpose="Check if WebCLContext.getInfo function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_context_getinfo.html</test_script_entry>
         </description>
@@ -150,7 +150,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_getSupportedImageFormats" priority="P1" purpose="Check if WebCLContext.getSupportedImageFormats function works" status="approved" type="compliance" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_getSupportedImageFormats" priority="P1" purpose="Check if WebCLContext.getSupportedImageFormats function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_context_getSupportedImageFormats.html</test_script_entry>
         </description>
@@ -161,7 +161,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLDevice_getInfo" priority="P1" purpose="Check if WebCLDevice.getInfo function works" status="approved" type="compliance" subcase="56">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLDevice_getInfo" priority="P1" purpose="Check if WebCLDevice.getInfo function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_device_getinfo.html</test_script_entry>
         </description>
@@ -172,7 +172,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_getInfo" priority="P1" purpose="Check if WebCLEvent.getInfo function works" status="approved" type="compliance" subcase="14">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_getInfo" priority="P1" purpose="Check if WebCLEvent.getInfo function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_event_getinfo.html</test_script_entry>
         </description>
@@ -183,7 +183,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_getProfilingInfo" priority="P1" purpose="Check if WebCLEvent.getProfilingInfo function works" status="approved" type="compliance" subcase="12">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_getProfilingInfo" priority="P1" purpose="Check if WebCLEvent.getProfilingInfo function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_event_getProfilingInfo.html</test_script_entry>
         </description>
@@ -194,7 +194,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLImage_getInfo" priority="P1" purpose="Check if webCLImage.getInfo function works" status="approved" type="compliance" subcase="6">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLImage_getInfo" priority="P1" purpose="Check if webCLImage.getInfo function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_image_getinfo.html</test_script_entry>
         </description>
@@ -205,7 +205,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getInfo_async" priority="P1" purpose="Check if WebCLKernel.getInfo with async function works" status="approved" type="compliance" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getInfo_async" priority="P1" purpose="Check if WebCLKernel.getInfo with async function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_kernel_getinfo_async.html</test_script_entry>
         </description>
@@ -216,7 +216,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getInfo_sync" priority="P1" purpose="Check if WebCLKernel.getInfo with sync function works" status="approved" type="compliance" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getInfo_sync" priority="P1" purpose="Check if WebCLKernel.getInfo with sync function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_kernel_getinfo_sync.html</test_script_entry>
         </description>
@@ -227,7 +227,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getWorkGroupInfo" priority="P1" purpose="Check if WebCLKernel.getWorkGroupInfo function works" status="approved" type="compliance" subcase="14">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getWorkGroupInfo" priority="P1" purpose="Check if WebCLKernel.getWorkGroupInfo function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_kernel_getWorkGroupInfo.html</test_script_entry>
         </description>
@@ -238,7 +238,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLMemoryObject_getInfo" priority="P1" purpose="Check if WebCLMemoryObject.getInfo function works" status="approved" type="compliance" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLMemoryObject_getInfo" priority="P1" purpose="Check if WebCLMemoryObject.getInfo function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_memoryObject_getinfo.html</test_script_entry>
         </description>
@@ -249,7 +249,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLPlatform_getInfo" priority="P1" purpose="Check if WebCLPlatform.getInfo function works" status="approved" type="compliance" subcase="6">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLPlatform_getInfo" priority="P1" purpose="Check if WebCLPlatform.getInfo function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_platform_getinfo.html</test_script_entry>
         </description>
@@ -260,7 +260,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_getBuildInfo_async" priority="P1" purpose="Check if WebCLProgram.getBuildInfo with async function works" status="approved" type="compliance" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_getBuildInfo_async" priority="P1" purpose="Check if WebCLProgram.getBuildInfo with async function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_program_getBuildInfo_async.html</test_script_entry>
         </description>
@@ -271,7 +271,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_getBuildInfo_sync" priority="P1" purpose="Check if WebCLProgram.getBuildInfo with sync function works" status="approved" type="compliance" subcase="6">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_getBuildInfo_sync" priority="P1" purpose="Check if WebCLProgram.getBuildInfo with sync function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_program_getBuildInfo_sync.html</test_script_entry>
         </description>
@@ -282,7 +282,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_getInfo" priority="P1" purpose="Check if WebCLProgram.getInfo function works" status="approved" type="compliance" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_getInfo" priority="P1" purpose="Check if WebCLProgram.getInfo function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_program_getinfo.html</test_script_entry>
         </description>
@@ -293,7 +293,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLSampler_getInfo" priority="P1" purpose="Check if webCLSampler.getInfo function works" status="approved" type="compliance" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLSampler_getInfo" priority="P1" purpose="Check if webCLSampler.getInfo function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_sampler_getinfo.html</test_script_entry>
         </description>
@@ -306,7 +306,7 @@
       </testcase>
     </set>
     <set name="globalObject" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLPlatform_getDevices" priority="P1" purpose="Check if WebCLPlatform.getDevices function works" status="approved" type="compliance" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLPlatform_getDevices" priority="P1" purpose="Check if WebCLPlatform.getDevices function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/globalObject/cl_platform_getDevices.html</test_script_entry>
         </description>
@@ -317,7 +317,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_constants" priority="P1" purpose="Check if constants of WebCL are valid" status="approved" type="compliance" subcase="240">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_constants" priority="P1" purpose="Check if constants of WebCL are valid" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/globalObject/cl_webcl_constants_check.html</test_script_entry>
         </description>
@@ -328,7 +328,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_CreateContext" priority="P1" purpose="Check if WebCL.CreateContext function works" status="approved" type="compliance" subcase="21">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_CreateContext" priority="P1" purpose="Check if WebCL.CreateContext function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/globalObject/cl_webcl_createContext.html</test_script_entry>
         </description>
@@ -339,7 +339,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_enableExtension" priority="P1" purpose="Check if WebCL.enableExtension function works" status="approved" type="compliance" subcase="6">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_enableExtension" priority="P1" purpose="Check if WebCL.enableExtension function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/globalObject/cl_webcl_enableExtension.html</test_script_entry>
         </description>
@@ -350,7 +350,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_getPlatforms" priority="P1" purpose="Check if WebCL.getPlatforms function works" status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_getPlatforms" priority="P1" purpose="Check if WebCL.getPlatforms function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/globalObject/cl_webcl_getPlatforms.html</test_script_entry>
         </description>
@@ -361,7 +361,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_getSupportedExtensions" priority="P1" purpose="Check if WebCL.getSupportedExtensions function works" status="approved" type="compliance" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_getSupportedExtensions" priority="P1" purpose="Check if WebCL.getSupportedExtensions function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/globalObject/cl_webcl_getSupportedExtensions.html</test_script_entry>
         </description>
@@ -374,7 +374,7 @@
       </testcase>
     </set>
     <set name="programAndKernel" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getArgInf_async" priority="P1" purpose="Check if WebCLKernel.getArgInfo with async function works" status="approved" type="compliance" subcase="11">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getArgInf_async" priority="P1" purpose="Check if WebCLKernel.getArgInfo with async function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_kernel_getArgInfo_async.html</test_script_entry>
         </description>
@@ -385,7 +385,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getArgInfo_sync" priority="P1" purpose="Check if WebCLKernel.getArgInfo with sync function works" status="approved" type="compliance" subcase="11">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getArgInfo_sync" priority="P1" purpose="Check if WebCLKernel.getArgInfo with sync function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_kernel_getArgInfo_sync.html</test_script_entry>
         </description>
@@ -396,7 +396,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg" priority="P1" purpose="Check if WebCLKernel.setArg function works" status="approved" type="compliance" subcase="85">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg" priority="P1" purpose="Check if WebCLKernel.setArg function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_kernel_setArg.html</test_script_entry>
         </description>
@@ -407,7 +407,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_build" priority="P1" purpose="Check if WebCLProgram.build function works" status="approved" type="compliance" subcase="37">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_build" priority="P1" purpose="Check if WebCLProgram.build function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_program_build.html</test_script_entry>
         </description>
@@ -418,7 +418,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernel_async" priority="P1" purpose="Check if WebCLProgram.createKernel with async function works" status="approved" type="compliance" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernel_async" priority="P1" purpose="Check if WebCLProgram.createKernel with async function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_program_createKernel_async.html</test_script_entry>
         </description>
@@ -429,7 +429,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernel_sync" priority="P1" purpose="Check if WebCLProgram.createKernel with sync function works" status="approved" type="compliance" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernel_sync" priority="P1" purpose="Check if WebCLProgram.createKernel with sync function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_program_createKernel_sync.html</test_script_entry>
         </description>
@@ -440,7 +440,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernelsInProgram_async" priority="P1" purpose="Check if WebCLProgram.createKernelsInProgram with async function works" status="approved" type="compliance" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernelsInProgram_async" priority="P1" purpose="Check if WebCLProgram.createKernelsInProgram with async function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_program_createKernelsInProgram_async.html</test_script_entry>
         </description>
@@ -451,7 +451,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernelsInProgram_sync" priority="P1" purpose="Check if WebCLProgram.createKernelsInProgram with sync function works" status="approved" type="compliance" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernelsInProgram_sync" priority="P1" purpose="Check if WebCLProgram.createKernelsInProgram with sync function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_program_createKernelsInProgram_sync.html</test_script_entry>
         </description>
@@ -464,7 +464,7 @@
       </testcase>
     </set>
     <set name="queues" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueBarrier" priority="P1" purpose="Check if WebCLCommandQueue.enqueueBarrier function works" status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueBarrier" priority="P1" purpose="Check if WebCLCommandQueue.enqueueBarrier function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueBarrier.html</test_script_entry>
         </description>
@@ -475,7 +475,7 @@
           </spec>
         </specs>
       </testcase>    
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyBuffer" priority="P1" purpose="Check if WebCLCommandQueue.enqueueCopyBuffer function works" status="approved" type="compliance" subcase="38">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyBuffer" priority="P1" purpose="Check if WebCLCommandQueue.enqueueCopyBuffer function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueCopyBuffer.html</test_script_entry>
         </description>
@@ -486,7 +486,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyBufferRect" priority="P1" purpose="Check if WebCLCommandQueue.enqueueCopyBufferRect function works" status="approved" type="compliance" subcase="64">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyBufferRect" priority="P1" purpose="Check if WebCLCommandQueue.enqueueCopyBufferRect function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueCopyBufferRect.html</test_script_entry>
         </description>
@@ -497,7 +497,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyBufferToImage" priority="P1" purpose="Check if WebCLCommandQueue.enqueueCopyBufferToImage function works" status="approved" type="compliance" subcase="38">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyBufferToImage" priority="P1" purpose="Check if WebCLCommandQueue.enqueueCopyBufferToImage function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueCopyBufferToImage.html</test_script_entry>
         </description>
@@ -508,7 +508,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyImage" priority="P1" purpose="Check if WebCLCommandQueue.enqueueCopyImage function works" status="approved" type="compliance" subcase="49">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyImage" priority="P1" purpose="Check if WebCLCommandQueue.enqueueCopyImage function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueCopyImage.html</test_script_entry>
         </description>
@@ -519,7 +519,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyImageToBuffer" priority="P1" purpose="Check if WebCLCommandQueue.enqueueCopyImageToBuffer function works" status="approved" type="compliance" subcase="38">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyImageToBuffer" priority="P1" purpose="Check if WebCLCommandQueue.enqueueCopyImageToBuffer function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueCopyImageToBuffer.html</test_script_entry>
         </description>
@@ -530,7 +530,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueMarker" priority="P1" purpose="Check if WebCLCommandQueue.enqueueMarker function works" status="approved" type="compliance" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueMarker" priority="P1" purpose="Check if WebCLCommandQueue.enqueueMarker function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueMarker.html</test_script_entry>
         </description>
@@ -541,7 +541,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueNDRangeKernel" priority="P1" purpose="Check if WebCLCommandQueue.enqueueNDRangeKernel function works" status="approved" type="compliance" subcase="39">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueNDRangeKernel" priority="P1" purpose="Check if WebCLCommandQueue.enqueueNDRangeKernel function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueNDRangeKernel.html</test_script_entry>
         </description>
@@ -552,7 +552,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBuffer" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReadBuffer function works" status="approved" type="compliance" subcase="32">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBuffer" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReadBuffer function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueReadBuffer.html</test_script_entry>
         </description>
@@ -563,7 +563,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBufferRect" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReadBufferRect function works" status="approved" type="compliance" subcase="59">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBufferRect" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReadBufferRect function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueReadBufferRect.html</test_script_entry>
         </description>
@@ -574,7 +574,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadImage" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReadImage function works" status="approved" type="compliance" subcase="46">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadImage" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReadImage function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueReadImage.html</test_script_entry>
         </description>
@@ -585,7 +585,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWaitForEvents" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWaitForEvents function works" status="approved" type="compliance" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWaitForEvents" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWaitForEvents function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueWaitForEvents.html</test_script_entry>
         </description>
@@ -596,7 +596,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer function works" status="approved" type="compliance" subcase="32">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueWriteBuffer.html</test_script_entry>
         </description>
@@ -607,7 +607,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect function works" status="approved" type="compliance" subcase="59">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueWriteBufferRect.html</test_script_entry>
         </description>
@@ -618,7 +618,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteImage function works" status="approved" type="compliance" subcase="45">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteImage function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueWriteImage.html</test_script_entry>
         </description>
@@ -629,7 +629,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_finish" priority="P1" purpose="Check if WebCLCommandQueue.finish function works" status="approved" type="compliance" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_finish" priority="P1" purpose="Check if WebCLCommandQueue.finish function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_finish.html</test_script_entry>
         </description>
@@ -640,7 +640,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_flush" priority="P1" purpose="Check if WebCLCommandQueue.flush function works" status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_flush" priority="P1" purpose="Check if WebCLCommandQueue.flush function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_flush.html</test_script_entry>
         </description>
@@ -653,7 +653,7 @@
       </testcase>
     </set>
     <set name="release" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_release" priority="P1" purpose="Check if release function works" status="approved" type="compliance" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_release" priority="P1" purpose="Check if release function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/release/cl_release.html</test_script_entry>
         </description>
@@ -664,7 +664,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_releaseAll" priority="P1" purpose="Check if releaseAll function works" status="approved" type="compliance" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_releaseAll" priority="P1" purpose="Check if releaseAll function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/release/cl_releaseAll.html</test_script_entry>
         </description>
@@ -677,7 +677,7 @@
       </testcase>
     </set>
     <set name="KHR_fp16" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLDevice_getInfo_KHR_fp16" priority="P1" purpose="Check if WebCLDevice.getInfo function works in extension KHR_fp16" status="approved" type="compliance" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLDevice_getInfo_KHR_fp16" priority="P1" purpose="Check if WebCLDevice.getInfo function works in extension KHR_fp16" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp16/bindingTesting/cl_device_getinfo.html</test_script_entry>
         </description>
@@ -688,7 +688,7 @@
           </spec>
         </specs>
       </testcase>     
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_build_KHR_fp16" priority="P1" purpose="Check if WebCLProgram.build function works in extension KHR_fp16" status="approved" type="compliance" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_build_KHR_fp16" priority="P1" purpose="Check if WebCLProgram.build function works in extension KHR_fp16" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp16/bindingTesting/cl_program_build.html</test_script_entry>
         </description>
@@ -699,7 +699,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_constants_KHR_fp16" priority="P1" purpose="Check if constants of WebCL function works in extension KHR_fp16" status="approved" type="compliance" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_constants_KHR_fp16" priority="P1" purpose="Check if constants of WebCL function works in extension KHR_fp16" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp16/bindingTesting/cl_webcl_khr_fp16_constants_check.html</test_script_entry>
         </description>
@@ -710,7 +710,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLKernel_enqueueNDRangeKernel_KHR_fp16" priority="P1" purpose="Check if running a kernel to copy half value in KHR_fp16 extension works" status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLKernel_enqueueNDRangeKernel_KHR_fp16" priority="P1" purpose="Check if running a kernel to copy half value in KHR_fp16 extension works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp16/functionalityTesting/buildingInExtnKHR_fp16.html</test_script_entry>
         </description>
@@ -723,7 +723,7 @@
       </testcase>
     </set>
     <set name="KHR_fp64" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLDevice_getInfo_KHR_fp64" priority="P1" purpose="Check if WebCLDevice.getInfo works in KHR_fp64 extension" status="approved" type="compliance" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLDevice_getInfo_KHR_fp64" priority="P1" purpose="Check if WebCLDevice.getInfo works in KHR_fp64 extension" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp64/bindingTesting/cl_device_getinfo.html</test_script_entry>
         </description>
@@ -734,7 +734,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_build_KHR_fp64" priority="P1" purpose="Check if WebCLProgram.build works in KHR_fp64 extension" status="approved" type="compliance" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_build_KHR_fp64" priority="P1" purpose="Check if WebCLProgram.build works in KHR_fp64 extension" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp64/bindingTesting/cl_program_build.html</test_script_entry>
         </description>
@@ -745,7 +745,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_constants_KHR_fp64" priority="P1" purpose="Check if constants of WebCL function works in extension KHR_fp64" status="approved" type="compliance" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_constants_KHR_fp64" priority="P1" purpose="Check if constants of WebCL function works in extension KHR_fp64" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp64/bindingTesting/cl_webcl_khr_fp64_constants_check.html</test_script_entry>
         </description>
@@ -756,7 +756,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLKernel_enqueueNDRangeKernel_KHR_fp64" priority="P1" purpose="Check if running a kernel to copy half value in KHR_fp64 extension works" status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLKernel_enqueueNDRangeKernel_KHR_fp64" priority="P1" purpose="Check if running a kernel to copy half value in KHR_fp64 extension works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp64/functionalityTesting/buildingInExtnKHR_fp64.html</test_script_entry>
         </description>
@@ -769,7 +769,7 @@
       </testcase>
     </set>
     <set name="KHR_gl_sharing" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueAcquireGLObjects" priority="P1" purpose="Check if WebCLCommandQueue.enqueueAcquireGLObjects function works " status="approved" type="compliance" subcase="13">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueAcquireGLObjects" priority="P1" purpose="Check if WebCLCommandQueue.enqueueAcquireGLObjects function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_commandQueue_enqueueAcquireGLObjects.html</test_script_entry>
         </description>
@@ -780,7 +780,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReleaseGLObjects" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReleaseGLObjects function works " status="approved" type="compliance" subcase="13">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReleaseGLObjects" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReleaseGLObjects function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_commandQueue_enqueueReleaseGLObjects.html</test_script_entry>
         </description>
@@ -791,7 +791,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createFromGLBuffer" priority="P1" purpose="Check if WebCLContext.createFromGLBuffer function works " status="approved" type="compliance" subcase="7">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createFromGLBuffer" priority="P1" purpose="Check if WebCLContext.createFromGLBuffer function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_context_createFromGLBuffer.html</test_script_entry>
         </description>
@@ -802,7 +802,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createFromGLRenderbuffer" priority="P1" purpose="Check if WebCLContext.createFromGLRenderbuffer function works " status="approved" type="compliance" subcase="7">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createFromGLRenderbuffer" priority="P1" purpose="Check if WebCLContext.createFromGLRenderbuffer function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_context_createFromGLRenderbuffer.html</test_script_entry>
         </description>
@@ -813,7 +813,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createFromGLTexture" priority="P1" purpose="Check if WebCLContext.createFromGLTexture function works " status="approved" type="compliance" subcase="28">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createFromGLTexture" priority="P1" purpose="Check if WebCLContext.createFromGLTexture function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_context_createFromGLTexture.html</test_script_entry>
         </description>
@@ -824,7 +824,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_getGLContext" priority="P1" purpose="Check if WebCLContext.getGLContext function works " status="approved" type="compliance" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_getGLContext" priority="P1" purpose="Check if WebCLContext.getGLContext function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_context_getGLContext.html</test_script_entry>
         </description>
@@ -835,7 +835,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLMemoryObject_getGLObjectInfo" priority="P1" purpose="Check if WebCLMemoryObject.getGLObjectInfo function works " status="approved" type="compliance" subcase="15">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLMemoryObject_getGLObjectInfo" priority="P1" purpose="Check if WebCLMemoryObject.getGLObjectInfo function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_memoryObject_getGLObjectInfo.html</test_script_entry>
         </description>
@@ -846,7 +846,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_CLGL" priority="P1" purpose="Check if CLGL contants of WebCL is vaild" status="approved" type="compliance" subcase="18">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_CLGL" priority="P1" purpose="Check if CLGL contants of WebCL is vaild" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_webcl_clgl_constants_check.html</test_script_entry>
         </description>
@@ -857,7 +857,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_createContext_WebGLRenderingContext" priority="P1" purpose="Check if WebCL.createContext with WebGLRenderingContext function works " status="approved" type="compliance" subcase="23">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_createContext_WebGLRenderingContext" priority="P1" purpose="Check if WebCL.createContext with WebGLRenderingContext function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_webcl_createContext_with_WebGLRenderingContext.html</test_script_entry>
         </description>
@@ -868,7 +868,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_bufferFromGLBuffer" priority="P1" purpose="Check if bufferFromGLBuffer is valid " status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_bufferFromGLBuffer" priority="P1" purpose="Check if bufferFromGLBuffer is valid " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/functionalityTesting/bufferFromGLBuffer.html</test_script_entry>
         </description>
@@ -881,7 +881,7 @@
       </testcase>
     </set>
     <set name="WEBCL_html_image" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBufferRect_Canvas" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReadBufferRect with HTML Canvas element function works " status="approved" type="compliance" subcase="46">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBufferRect_Canvas" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReadBufferRect with HTML Canvas element function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueReadBufferRect_with_HTMLCanvasElement.html</test_script_entry>
         </description>
@@ -892,7 +892,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBuffer_Canvas" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReadBuffer with HTML Canvas element function works " status="approved" type="compliance" subcase="27">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBuffer_Canvas" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReadBuffer with HTML Canvas element function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueReadBuffer_with_HTMLCanvasElement.html</test_script_entry>
         </description>
@@ -903,7 +903,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadImage_Canvas" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReadImage with HTML Canvas element function works " status="approved" type="compliance" subcase="31">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadImage_Canvas" priority="P1" purpose="Check if WebCLCommandQueue.enqueueReadImage with HTML Canvas element function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueReadImage_with_HTMLCanvasElement.html</test_script_entry>
         </description>
@@ -914,7 +914,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect_Canvas" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect with HTML Canvas element function works " status="approved" type="compliance" subcase="47">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect_Canvas" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect with HTML Canvas element function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteBufferRect_with_HTMLCanvasElement.html</test_script_entry>
         </description>
@@ -925,7 +925,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect_Image" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect with HTML Image element function works " status="approved" type="compliance" subcase="47">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect_Image" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect with HTML Image element function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteBufferRect_with_HTMLImageElement.html</test_script_entry>
         </description>
@@ -936,7 +936,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect_imageData" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect with imageData function works " status="approved" type="compliance" subcase="27">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect_imageData" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect with imageData function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteBufferRect_with_imageData.html</test_script_entry>
         </description>
@@ -947,7 +947,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer_Canvas" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer with HTML Canvas Element function works " status="approved" type="compliance" subcase="47">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer_Canvas" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer with HTML Canvas Element function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteBuffer_with_HTMLCanvasElement.html</test_script_entry>
         </description>
@@ -958,7 +958,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer_Image" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer with HTML Image Element function works " status="approved" type="compliance" subcase="47">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer_Image" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer with HTML Image Element function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteBuffer_with_HTMLImageElement.html</test_script_entry>
         </description>
@@ -969,7 +969,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer_ImageData" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer with imageData function works " status="approved" type="compliance" subcase="27">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer_ImageData" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer with imageData function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteBuffer_with_imageData.html</test_script_entry>
         </description>
@@ -980,7 +980,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_Canvas" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteImage with canvas Element function works " status="approved" type="compliance" subcase="27">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_Canvas" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteImage with canvas Element function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteImage_with_HTMLCanvasElement.html</test_script_entry>
         </description>
@@ -991,7 +991,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_Image" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteImage with imageElement function works " status="approved" type="compliance" subcase="32">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_Image" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteImage with imageElement function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteImage_with_HTMLImageElement.html</test_script_entry>
         </description>
@@ -1002,7 +1002,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_ImageData" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteImage with imageData function works " status="approved" type="compliance" subcase="32">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_ImageData" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteImage with imageData function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteImage_with_imageData.html</test_script_entry>
         </description>
@@ -1013,7 +1013,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_Canvas" priority="P1" purpose="Check if WebCLContext.createBuffer with HTMLCanvasElement function works " status="approved" type="compliance" subcase="7">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_Canvas" priority="P1" purpose="Check if WebCLContext.createBuffer with HTMLCanvasElement function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_context_createBuffer_with_HTMLCanvasElement.html</test_script_entry>
         </description>
@@ -1024,7 +1024,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_Image" priority="P1" purpose="Check if WebCLContext.createBuffer with HTMLImageElement function works " status="approved" type="compliance" subcase="9">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_Image" priority="P1" purpose="Check if WebCLContext.createBuffer with HTMLImageElement function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_context_createBuffer_with_HTMLImageElement.html</test_script_entry>
         </description>
@@ -1035,7 +1035,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_ImageData" priority="P1" purpose="Check if WebCLContext.createBuffer with imageData function works " status="approved" type="compliance" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_ImageData" priority="P1" purpose="Check if WebCLContext.createBuffer with imageData function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_context_createBuffer_with_imageData.html</test_script_entry>
         </description>
@@ -1046,7 +1046,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_Canvas" priority="P1" purpose="Check if WebCLContext.createImage with HTMLCanvasElement function works " status="approved" type="compliance" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_Canvas" priority="P1" purpose="Check if WebCLContext.createImage with HTMLCanvasElement function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_context_createImage_with_HTMLCanvasElement.html</test_script_entry>
         </description>
@@ -1057,7 +1057,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_Image" priority="P1" purpose="Check if WebCLContext.createImage with HTMLImageElement function works " status="approved" type="compliance" subcase="10">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_Image" priority="P1" purpose="Check if WebCLContext.createImage with HTMLImageElement function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_context_createImage_with_HTMLImageElement.html</test_script_entry>
         </description>
@@ -1068,7 +1068,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_ImageData" priority="P1" purpose="Check if WebCLContext.createImage with imageData function works " status="approved" type="compliance" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_ImageData" priority="P1" purpose="Check if WebCLContext.createImage with imageData function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_context_createImage_with_imageData.html</test_script_entry>
         </description>
@@ -1079,7 +1079,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_ImageTypes" priority="P1" purpose="Check if WebCLContext.createBuffer with html image types function works " status="approved" type="compliance" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_ImageTypes" priority="P1" purpose="Check if WebCLContext.createBuffer with html image types function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/createBufferValidation.html</test_script_entry>
         </description>
@@ -1090,7 +1090,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_ImageTypes" priority="P1" purpose="Check if WebCLContext.createImage with html image types function works " status="approved" type="compliance" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_ImageTypes" priority="P1" purpose="Check if WebCLContext.createImage with html image types function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/createImageValidation.html</test_script_entry>
         </description>
@@ -1103,7 +1103,7 @@
       </testcase>
     </set>
     <set name="WEBCL_html_video" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_Video" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteImage with HTMLVideoElement function works " status="approved" type="compliance" subcase="19">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_Video" priority="P1" purpose="Check if WebCLCommandQueue.enqueueWriteImage with HTMLVideoElement function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_video/cl_commandQueue_enqueueWriteImage_with_HTMLVideoElement.html</test_script_entry>
         </description>
@@ -1114,7 +1114,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_Video" priority="P1" purpose="Check if WebCLContext.createImage with HTMLVideoElement function works " status="approved" type="compliance" subcase="7">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_Video" priority="P1" purpose="Check if WebCLContext.createImage with HTMLVideoElement function works " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_video/cl_context_createImage_with_HTMLVideoElement.html</test_script_entry>
         </description>
@@ -1127,7 +1127,7 @@
       </testcase>
     </set>
     <set name="functionalityTesting" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_function" priority="P1" purpose="Check if WebCLContext.createBuffer is functionality" status="approved" type="compliance" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_function" priority="P1" purpose="Check if WebCLContext.createBuffer is functionality" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createBuffer.html</test_script_entry>
         </description>
@@ -1138,7 +1138,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_valid" priority="P1" purpose="Check if WebCLContext.createBuffer is valid " status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_valid" priority="P1" purpose="Check if WebCLContext.createBuffer is valid " status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createBufferValidation.html</test_script_entry>
         </description>
@@ -1149,7 +1149,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateCommandQueue_function" priority="P1" purpose="Check if WebCLContext.CreateCommandQueue is functionality" status="approved" type="compliance" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateCommandQueue_function" priority="P1" purpose="Check if WebCLContext.CreateCommandQueue is functionality" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createCommandQueue.html</test_script_entry>
         </description>
@@ -1160,7 +1160,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_CreateContext_function" priority="P1" purpose="Check if WebCL.CreateContext is functionality" status="approved" type="compliance" subcase="17">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_CreateContext_function" priority="P1" purpose="Check if WebCL.CreateContext is functionality" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createContext.html</test_script_entry>
         </description>
@@ -1171,7 +1171,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateImage_function" priority="P1" purpose="Check if WebCLContext.CreateImage is functionality" status="approved" type="compliance" subcase="49">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateImage_function" priority="P1" purpose="Check if WebCLContext.CreateImage is functionality" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createImage.html</test_script_entry>
         </description>
@@ -1182,7 +1182,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateImage_Valid" priority="P1" purpose="Check if WebCLContext.CreateImage is valid" status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateImage_Valid" priority="P1" purpose="Check if WebCLContext.CreateImage is valid" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createImageValidation.html</test_script_entry>
         </description>
@@ -1193,7 +1193,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernelsInProgram_function" priority="P1" purpose="Check if WebCLProgram.createKernelsInProgram is functionality" status="approved" type="compliance" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernelsInProgram_function" priority="P1" purpose="Check if WebCLProgram.createKernelsInProgram is functionality" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createKernelsInProgram.html</test_script_entry>
         </description>
@@ -1204,7 +1204,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createProgram_function" priority="P1" purpose="Check if WebCLContext.createProgram is functionality" status="approved" type="compliance" subcase="6">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createProgram_function" priority="P1" purpose="Check if WebCLContext.createProgram is functionality" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createProgram.html</test_script_entry>
         </description>
@@ -1215,7 +1215,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateSampler_function" priority="P1" purpose="Check if WebCLContext.CreateSampler is functionality" status="approved" type="compliance" subcase="12">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateSampler_function" priority="P1" purpose="Check if WebCLContext.CreateSampler is functionality" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createSampler.html</test_script_entry>
         </description>
@@ -1226,7 +1226,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLProgram_build_Callback" priority="P1" purpose="Check if webCLProgram.build with Callback function works" status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLProgram_build_Callback" priority="P1" purpose="Check if webCLProgram.build with Callback function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/buildingAndRunning/buildCallback.html</test_script_entry>
         </description>
@@ -1237,7 +1237,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLProgram_getBuildInfo_Option" priority="P1" purpose="Check if webCLProgram.getBuildInfo with Option function works" status="approved" type="compliance" subcase="12">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLProgram_getBuildInfo_Option" priority="P1" purpose="Check if webCLProgram.getBuildInfo with Option function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/buildingAndRunning/buildOptions.html</test_script_entry>
         </description>
@@ -1248,7 +1248,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg_basic" priority="P1" purpose="Check if WebCLKernel.setArg basic type is valid" status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg_basic" priority="P1" purpose="Check if WebCLKernel.setArg basic type is valid" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/buildingAndRunning/setArg_basic.html</test_script_entry>
         </description>
@@ -1259,7 +1259,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg_local" priority="P1" purpose="Check if WebCLKernel.setArg with local type function works" status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg_local" priority="P1" purpose="Check if WebCLKernel.setArg with local type function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/buildingAndRunning/setArg_local.html</test_script_entry>
         </description>
@@ -1270,7 +1270,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg_Vector" priority="P1" purpose="Check if WebCLKernel.setArg basic function works" status="approved" type="compliance" subcase="50">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg_Vector" priority="P1" purpose="Check if WebCLKernel.setArg basic function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/buildingAndRunning/setArg_Vector.html</test_script_entry>
         </description>
@@ -1281,7 +1281,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyBuffer_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueCopyBuffer functionality works" status="approved" type="compliance" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyBuffer_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueCopyBuffer functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueCopyBuffer.html</test_script_entry>
         </description>
@@ -1292,7 +1292,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyBufferRect_function" priority="P1" purpose="Check if enqueueCopyBufferRect.enqueueCopyBuffer functionality works" status="approved" type="compliance" subcase="12">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyBufferRect_function" priority="P1" purpose="Check if enqueueCopyBufferRect.enqueueCopyBuffer functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueCopyBufferRect.html</test_script_entry>
         </description>
@@ -1303,7 +1303,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyBufferToImage_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueCopyBufferToImage functionality works" status="approved" type="compliance" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyBufferToImage_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueCopyBufferToImage functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueCopyBufferToImage.html</test_script_entry>
         </description>
@@ -1314,7 +1314,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyImage_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueCopyImage functionality works" status="approved" type="compliance" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyImage_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueCopyImage functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueCopyImage.html</test_script_entry>
         </description>
@@ -1325,7 +1325,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyImageToBuffer_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueCopyImageToBuffer functionality works" status="approved" type="compliance" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyImageToBuffer_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueCopyImageToBuffer functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueCopyImageToBuffer.html</test_script_entry>
         </description>
@@ -1336,7 +1336,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueReadBuffer_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueReadBuffer functionality works" status="approved" type="compliance" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueReadBuffer_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueReadBuffer functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueReadBuffer.html</test_script_entry>
         </description>
@@ -1347,7 +1347,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueReadBufferRect_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueReadBufferRect functionality works" status="approved" type="compliance" subcase="12">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueReadBufferRect_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueReadBufferRect functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueReadBufferRect.html</test_script_entry>
         </description>
@@ -1358,7 +1358,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueReadImage_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueReadImage functionality works" status="approved" type="compliance" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueReadImage_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueReadImage functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueReadImage.html</test_script_entry>
         </description>
@@ -1369,7 +1369,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueWriteBuffer_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueWriteBuffer functionality works" status="approved" type="compliance" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueWriteBuffer_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueWriteBuffer functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueWriteBuffer.html</test_script_entry>
         </description>
@@ -1380,7 +1380,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueWriteBufferRect_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueWriteBufferRect functionality works" status="approved" type="compliance" subcase="12">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueWriteBufferRect_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueWriteBufferRect functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueWriteBufferRect.html</test_script_entry>
         </description>
@@ -1391,7 +1391,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueWriteImage_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueWriteImage functionality works" status="approved" type="compliance" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueWriteImage_function" priority="P1" purpose="Check if webCLCommandQueue.enqueueWriteImage functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueWriteImage.html</test_script_entry>
         </description>
@@ -1402,7 +1402,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_finish_function" priority="P1" purpose="Check if webCLCommandQueue.finish functionality works" status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_finish_function" priority="P1" purpose="Check if webCLCommandQueue.finish functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/finish.html</test_script_entry>
         </description>
@@ -1413,7 +1413,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback_function" priority="P1" purpose="Check if WebCLEvent.setCallback functionality works" status="approved" type="compliance" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback_function" priority="P1" purpose="Check if WebCLEvent.setCallback functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/events/setCallback.html</test_script_entry>
         </description>
@@ -1424,7 +1424,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback_release" priority="P1" purpose="Check if WebCLEvent.setCallback and ReleaseEvent functionality works" status="approved" type="compliance" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback_release" priority="P1" purpose="Check if WebCLEvent.setCallback and ReleaseEvent functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/events/setCallback_andReleaseEvent.html</test_script_entry>
         </description>
@@ -1435,7 +1435,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback_multipleCalls" priority="P1" purpose="Check if WebCLEvent.setCallback with multipleCalls functionality works" status="approved" type="compliance" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback_multipleCalls" priority="P1" purpose="Check if WebCLEvent.setCallback with multipleCalls functionality works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/events/setCallback_multipleCalls.html</test_script_entry>
         </description>
@@ -1446,7 +1446,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLObject_release_function" priority="P1" purpose="Check if WebCLObject.release function works" status="approved" type="compliance" subcase="9">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLObject_release_function" priority="P1" purpose="Check if WebCLObject.release function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/release/release.html</test_script_entry>
         </description>
@@ -1457,7 +1457,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLObject_releaseAll_function" priority="P1" purpose="Check if WebCLObject.releaseAll function works" status="approved" type="compliance" subcase="9">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLObject_releaseAll_function" priority="P1" purpose="Check if WebCLObject.releaseAll function works" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/release/releaseAll.html</test_script_entry>
         </description>

--- a/webapi/webapi-webcl-nonw3c-tests/tests.xml
+++ b/webapi/webapi-webcl-nonw3c-tests/tests.xml
@@ -3,681 +3,681 @@
 <test_definition>
   <suite category="Supplementary APIs" name="webapi-webcl-nonw3c-tests">
     <set name="contextAndCreate" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLBuffer_createSubBuffer" purpose="Check if WebCLBuffer.createSubBuffer function works" subcase="11">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLBuffer_createSubBuffer" purpose="Check if WebCLBuffer.createSubBuffer function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_buffer_createSubBuffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer" purpose="Check if WebCLContext.createBuffer function works" subcase="10">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer" purpose="Check if WebCLContext.createBuffer function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createBuffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createCommandQueue" purpose="Check if WebCLContext.createCommandQueue function works" subcase="9">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createCommandQueue" purpose="Check if WebCLContext.createCommandQueue function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createCommandQueue.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createEvent" purpose="Check if WebCLEvent can be new success" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createEvent" purpose="Check if WebCLEvent can be new success">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createEvent.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage" purpose="Check if WebCLContext.createImage function works" subcase="35">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage" purpose="Check if WebCLContext.createImage function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createImage.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createProgram" purpose="Check if WebCLContext.createProgram function works" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createProgram" purpose="Check if WebCLContext.createProgram function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createProgram.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createSampler" purpose="Check if WebCLContext.createSampler function works" subcase="16">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createSampler" purpose="Check if WebCLContext.createSampler function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createSampler.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createUserEvent" purpose="Check if WebCLContext.createUserEvent function works" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createUserEvent" purpose="Check if WebCLContext.createUserEvent function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/contextAndCreate/cl_context_createUserEvent.html</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="eventsAndCallbacks" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback" purpose="Check if WebCLEvent.setCallback function works" subcase="7">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback" purpose="Check if WebCLEvent.setCallback function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/eventsAndCallbacks/cl_event_setCallback.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLUserEvent_setStatus" purpose="Check if WebCLUserEvent.setStatus function works" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLUserEvent_setStatus" purpose="Check if WebCLUserEvent.setStatus function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/eventsAndCallbacks/cl_event_setStatus.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_waitForEvents" purpose="Check if WebCL.waitForEvents function works" subcase="13">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_waitForEvents" purpose="Check if WebCL.waitForEvents function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/eventsAndCallbacks/cl_webcl_waitForEvents.html</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="fetchInfo" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_getInfo" purpose="Check if WebCLCommandQueue.getInfo function works" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_getInfo" purpose="Check if WebCLCommandQueue.getInfo function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_commandqueue_getinfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_getInfo" purpose="Check if WebCLContext.getInfo function works" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_getInfo" purpose="Check if WebCLContext.getInfo function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_context_getinfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_getSupportedImageFormats" purpose="Check if WebCLContext.getSupportedImageFormats function works" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_getSupportedImageFormats" purpose="Check if WebCLContext.getSupportedImageFormats function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_context_getSupportedImageFormats.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLDevice_getInfo" purpose="Check if WebCLDevice.getInfo function works" subcase="56">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLDevice_getInfo" purpose="Check if WebCLDevice.getInfo function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_device_getinfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_getInfo" purpose="Check if WebCLEvent.getInfo function works" subcase="14">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_getInfo" purpose="Check if WebCLEvent.getInfo function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_event_getinfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_getProfilingInfo" purpose="Check if WebCLEvent.getProfilingInfo function works" subcase="12">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_getProfilingInfo" purpose="Check if WebCLEvent.getProfilingInfo function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_event_getProfilingInfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLImage_getInfo" purpose="Check if webCLImage.getInfo function works" subcase="6">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLImage_getInfo" purpose="Check if webCLImage.getInfo function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_image_getinfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getInfo_async" purpose="Check if WebCLKernel.getInfo with async function works" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getInfo_async" purpose="Check if WebCLKernel.getInfo with async function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_kernel_getinfo_async.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getInfo_sync" purpose="Check if WebCLKernel.getInfo with sync function works" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getInfo_sync" purpose="Check if WebCLKernel.getInfo with sync function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_kernel_getinfo_sync.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getWorkGroupInfo" purpose="Check if WebCLKernel.getWorkGroupInfo function works" subcase="14">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getWorkGroupInfo" purpose="Check if WebCLKernel.getWorkGroupInfo function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_kernel_getWorkGroupInfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLMemoryObject_getInfo" purpose="Check if WebCLMemoryObject.getInfo function works" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLMemoryObject_getInfo" purpose="Check if WebCLMemoryObject.getInfo function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_memoryObject_getinfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLPlatform_getInfo" purpose="Check if WebCLPlatform.getInfo function works" subcase="6">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLPlatform_getInfo" purpose="Check if WebCLPlatform.getInfo function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_platform_getinfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_getBuildInfo_async" purpose="Check if WebCLProgram.getBuildInfo with async function works" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_getBuildInfo_async" purpose="Check if WebCLProgram.getBuildInfo with async function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_program_getBuildInfo_async.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_getBuildInfo_sync" purpose="Check if WebCLProgram.getBuildInfo with sync function works" subcase="6">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_getBuildInfo_sync" purpose="Check if WebCLProgram.getBuildInfo with sync function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_program_getBuildInfo_sync.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_getInfo" purpose="Check if WebCLProgram.getInfo function works" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_getInfo" purpose="Check if WebCLProgram.getInfo function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_program_getinfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLSampler_getInfo" purpose="Check if webCLSampler.getInfo function works" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLSampler_getInfo" purpose="Check if webCLSampler.getInfo function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/fetchInfo/cl_sampler_getinfo.html</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="globalObject" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLPlatform_getDevices" purpose="Check if WebCLPlatform.getDevices function works" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLPlatform_getDevices" purpose="Check if WebCLPlatform.getDevices function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/globalObject/cl_platform_getDevices.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_constants" purpose="Check if constants of WebCL are valid" subcase="240">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_constants" purpose="Check if constants of WebCL are valid">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/globalObject/cl_webcl_constants_check.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_CreateContext" purpose="Check if WebCL.CreateContext function works" subcase="21">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_CreateContext" purpose="Check if WebCL.CreateContext function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/globalObject/cl_webcl_createContext.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_enableExtension" purpose="Check if WebCL.enableExtension function works" subcase="6">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_enableExtension" purpose="Check if WebCL.enableExtension function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/globalObject/cl_webcl_enableExtension.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_getPlatforms" purpose="Check if WebCL.getPlatforms function works" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_getPlatforms" purpose="Check if WebCL.getPlatforms function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/globalObject/cl_webcl_getPlatforms.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_getSupportedExtensions" purpose="Check if WebCL.getSupportedExtensions function works" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_getSupportedExtensions" purpose="Check if WebCL.getSupportedExtensions function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/globalObject/cl_webcl_getSupportedExtensions.html</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="programAndKernel" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getArgInf_async" purpose="Check if WebCLKernel.getArgInfo with async function works" subcase="11">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getArgInf_async" purpose="Check if WebCLKernel.getArgInfo with async function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_kernel_getArgInfo_async.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getArgInfo_sync" purpose="Check if WebCLKernel.getArgInfo with sync function works" subcase="11">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_getArgInfo_sync" purpose="Check if WebCLKernel.getArgInfo with sync function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_kernel_getArgInfo_sync.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg" purpose="Check if WebCLKernel.setArg function works" subcase="85">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg" purpose="Check if WebCLKernel.setArg function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_kernel_setArg.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_build" purpose="Check if WebCLProgram.build function works" subcase="37">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_build" purpose="Check if WebCLProgram.build function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_program_build.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernel_async" purpose="Check if WebCLProgram.createKernel with async function works" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernel_async" purpose="Check if WebCLProgram.createKernel with async function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_program_createKernel_async.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernel_sync" purpose="Check if WebCLProgram.createKernel with sync function works" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernel_sync" purpose="Check if WebCLProgram.createKernel with sync function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_program_createKernel_sync.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernelsInProgram_async" purpose="Check if WebCLProgram.createKernelsInProgram with async function works" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernelsInProgram_async" purpose="Check if WebCLProgram.createKernelsInProgram with async function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_program_createKernelsInProgram_async.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernelsInProgram_sync" purpose="Check if WebCLProgram.createKernelsInProgram with sync function works" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernelsInProgram_sync" purpose="Check if WebCLProgram.createKernelsInProgram with sync function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/programAndKernel/cl_program_createKernelsInProgram_sync.html</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="queues" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueBarrier" purpose="Check if WebCLCommandQueue.enqueueBarrier function works" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueBarrier" purpose="Check if WebCLCommandQueue.enqueueBarrier function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueBarrier.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyBuffer" purpose="Check if WebCLCommandQueue.enqueueCopyBuffer function works" subcase="38">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyBuffer" purpose="Check if WebCLCommandQueue.enqueueCopyBuffer function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueCopyBuffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyBufferRect" purpose="Check if WebCLCommandQueue.enqueueCopyBufferRect function works" subcase="64">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyBufferRect" purpose="Check if WebCLCommandQueue.enqueueCopyBufferRect function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueCopyBufferRect.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyBufferToImage" purpose="Check if WebCLCommandQueue.enqueueCopyBufferToImage function works" subcase="38">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyBufferToImage" purpose="Check if WebCLCommandQueue.enqueueCopyBufferToImage function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueCopyBufferToImage.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyImage" purpose="Check if WebCLCommandQueue.enqueueCopyImage function works" subcase="49">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyImage" purpose="Check if WebCLCommandQueue.enqueueCopyImage function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueCopyImage.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyImageToBuffer" purpose="Check if WebCLCommandQueue.enqueueCopyImageToBuffer function works" subcase="38">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueCopyImageToBuffer" purpose="Check if WebCLCommandQueue.enqueueCopyImageToBuffer function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueCopyImageToBuffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueMarker" purpose="Check if WebCLCommandQueue.enqueueMarker function works" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueMarker" purpose="Check if WebCLCommandQueue.enqueueMarker function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueMarker.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueNDRangeKernel" purpose="Check if WebCLCommandQueue.enqueueNDRangeKernel function works" subcase="39">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueNDRangeKernel" purpose="Check if WebCLCommandQueue.enqueueNDRangeKernel function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueNDRangeKernel.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBuffer" purpose="Check if WebCLCommandQueue.enqueueReadBuffer function works" subcase="32">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBuffer" purpose="Check if WebCLCommandQueue.enqueueReadBuffer function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueReadBuffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBufferRect" purpose="Check if WebCLCommandQueue.enqueueReadBufferRect function works" subcase="59">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBufferRect" purpose="Check if WebCLCommandQueue.enqueueReadBufferRect function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueReadBufferRect.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadImage" purpose="Check if WebCLCommandQueue.enqueueReadImage function works" subcase="46">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadImage" purpose="Check if WebCLCommandQueue.enqueueReadImage function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueReadImage.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWaitForEvents" purpose="Check if WebCLCommandQueue.enqueueWaitForEvents function works" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWaitForEvents" purpose="Check if WebCLCommandQueue.enqueueWaitForEvents function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueWaitForEvents.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer function works" subcase="32">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueWriteBuffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect function works" subcase="59">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueWriteBufferRect.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage" purpose="Check if WebCLCommandQueue.enqueueWriteImage function works" subcase="45">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage" purpose="Check if WebCLCommandQueue.enqueueWriteImage function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_enqueueWriteImage.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_finish" purpose="Check if WebCLCommandQueue.finish function works" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_finish" purpose="Check if WebCLCommandQueue.finish function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_finish.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_flush" purpose="Check if WebCLCommandQueue.flush function works" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_flush" purpose="Check if WebCLCommandQueue.flush function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/queues/cl_commandQueue_flush.html</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="release" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_release" purpose="Check if release function works" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_release" purpose="Check if release function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/release/cl_release.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_releaseAll" purpose="Check if releaseAll function works" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_releaseAll" purpose="Check if releaseAll function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/bindingTesting/release/cl_releaseAll.html</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="KHR_fp16" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLDevice_getInfo_KHR_fp16" purpose="Check if WebCLDevice.getInfo function works in extension KHR_fp16" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLDevice_getInfo_KHR_fp16" purpose="Check if WebCLDevice.getInfo function works in extension KHR_fp16">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp16/bindingTesting/cl_device_getinfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_build_KHR_fp16" purpose="Check if WebCLProgram.build function works in extension KHR_fp16" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_build_KHR_fp16" purpose="Check if WebCLProgram.build function works in extension KHR_fp16">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp16/bindingTesting/cl_program_build.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_constants_KHR_fp16" purpose="Check if constants of WebCL function works in extension KHR_fp16" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_constants_KHR_fp16" purpose="Check if constants of WebCL function works in extension KHR_fp16">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp16/bindingTesting/cl_webcl_khr_fp16_constants_check.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLKernel_enqueueNDRangeKernel_KHR_fp16" purpose="Check if running a kernel to copy half value in KHR_fp16 extension works" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLKernel_enqueueNDRangeKernel_KHR_fp16" purpose="Check if running a kernel to copy half value in KHR_fp16 extension works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp16/functionalityTesting/buildingInExtnKHR_fp16.html</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="KHR_fp64" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLDevice_getInfo_KHR_fp64" purpose="Check if WebCLDevice.getInfo works in KHR_fp64 extension" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLDevice_getInfo_KHR_fp64" purpose="Check if WebCLDevice.getInfo works in KHR_fp64 extension">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp64/bindingTesting/cl_device_getinfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_build_KHR_fp64" purpose="Check if WebCLProgram.build works in KHR_fp64 extension" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_build_KHR_fp64" purpose="Check if WebCLProgram.build works in KHR_fp64 extension">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp64/bindingTesting/cl_program_build.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_constants_KHR_fp64" purpose="Check if constants of WebCL function works in extension KHR_fp64" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_constants_KHR_fp64" purpose="Check if constants of WebCL function works in extension KHR_fp64">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp64/bindingTesting/cl_webcl_khr_fp64_constants_check.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLKernel_enqueueNDRangeKernel_KHR_fp64" purpose="Check if running a kernel to copy half value in KHR_fp64 extension works" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLKernel_enqueueNDRangeKernel_KHR_fp64" purpose="Check if running a kernel to copy half value in KHR_fp64 extension works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_fp64/functionalityTesting/buildingInExtnKHR_fp64.html</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="KHR_gl_sharing" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueAcquireGLObjects" purpose="Check if WebCLCommandQueue.enqueueAcquireGLObjects function works " subcase="13">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueAcquireGLObjects" purpose="Check if WebCLCommandQueue.enqueueAcquireGLObjects function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_commandQueue_enqueueAcquireGLObjects.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReleaseGLObjects" purpose="Check if WebCLCommandQueue.enqueueReleaseGLObjects function works " subcase="13">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReleaseGLObjects" purpose="Check if WebCLCommandQueue.enqueueReleaseGLObjects function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_commandQueue_enqueueReleaseGLObjects.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createFromGLBuffer" purpose="Check if WebCLContext.createFromGLBuffer function works " subcase="7">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createFromGLBuffer" purpose="Check if WebCLContext.createFromGLBuffer function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_context_createFromGLBuffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createFromGLRenderbuffer" purpose="Check if WebCLContext.createFromGLRenderbuffer function works " subcase="7">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createFromGLRenderbuffer" purpose="Check if WebCLContext.createFromGLRenderbuffer function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_context_createFromGLRenderbuffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createFromGLTexture" purpose="Check if WebCLContext.createFromGLTexture function works " subcase="28">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createFromGLTexture" purpose="Check if WebCLContext.createFromGLTexture function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_context_createFromGLTexture.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_getGLContext" purpose="Check if WebCLContext.getGLContext function works " subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_getGLContext" purpose="Check if WebCLContext.getGLContext function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_context_getGLContext.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLMemoryObject_getGLObjectInfo" purpose="Check if WebCLMemoryObject.getGLObjectInfo function works " subcase="15">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLMemoryObject_getGLObjectInfo" purpose="Check if WebCLMemoryObject.getGLObjectInfo function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_memoryObject_getGLObjectInfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_CLGL" purpose="Check if CLGL contants of WebCL is vaild" subcase="18">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_CLGL" purpose="Check if CLGL contants of WebCL is vaild">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_webcl_clgl_constants_check.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_createContext_WebGLRenderingContext" purpose="Check if WebCL.createContext with WebGLRenderingContext function works " subcase="23">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_createContext_WebGLRenderingContext" purpose="Check if WebCL.createContext with WebGLRenderingContext function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/bindingTesting/cl_webcl_createContext_with_WebGLRenderingContext.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_bufferFromGLBuffer" purpose="Check if bufferFromGLBuffer is valid " subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_bufferFromGLBuffer" purpose="Check if bufferFromGLBuffer is valid ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/KHR_gl_sharing/functionalityTesting/bufferFromGLBuffer.html</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="WEBCL_html_image" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBufferRect_Canvas" purpose="Check if WebCLCommandQueue.enqueueReadBufferRect with HTML Canvas element function works " subcase="46">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBufferRect_Canvas" purpose="Check if WebCLCommandQueue.enqueueReadBufferRect with HTML Canvas element function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueReadBufferRect_with_HTMLCanvasElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBuffer_Canvas" purpose="Check if WebCLCommandQueue.enqueueReadBuffer with HTML Canvas element function works " subcase="27">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadBuffer_Canvas" purpose="Check if WebCLCommandQueue.enqueueReadBuffer with HTML Canvas element function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueReadBuffer_with_HTMLCanvasElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadImage_Canvas" purpose="Check if WebCLCommandQueue.enqueueReadImage with HTML Canvas element function works " subcase="31">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueReadImage_Canvas" purpose="Check if WebCLCommandQueue.enqueueReadImage with HTML Canvas element function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueReadImage_with_HTMLCanvasElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect_Canvas" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect with HTML Canvas element function works " subcase="47">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect_Canvas" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect with HTML Canvas element function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteBufferRect_with_HTMLCanvasElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect_Image" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect with HTML Image element function works " subcase="47">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect_Image" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect with HTML Image element function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteBufferRect_with_HTMLImageElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect_imageData" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect with imageData function works " subcase="27">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBufferRect_imageData" purpose="Check if WebCLCommandQueue.enqueueWriteBufferRect with imageData function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteBufferRect_with_imageData.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer_Canvas" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer with HTML Canvas Element function works " subcase="47">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer_Canvas" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer with HTML Canvas Element function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteBuffer_with_HTMLCanvasElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer_Image" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer with HTML Image Element function works " subcase="47">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer_Image" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer with HTML Image Element function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteBuffer_with_HTMLImageElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer_ImageData" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer with imageData function works " subcase="27">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteBuffer_ImageData" purpose="Check if WebCLCommandQueue.enqueueWriteBuffer with imageData function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteBuffer_with_imageData.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_Canvas" purpose="Check if WebCLCommandQueue.enqueueWriteImage with canvas Element function works " subcase="27">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_Canvas" purpose="Check if WebCLCommandQueue.enqueueWriteImage with canvas Element function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteImage_with_HTMLCanvasElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_Image" purpose="Check if WebCLCommandQueue.enqueueWriteImage with imageElement function works " subcase="32">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_Image" purpose="Check if WebCLCommandQueue.enqueueWriteImage with imageElement function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteImage_with_HTMLImageElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_ImageData" purpose="Check if WebCLCommandQueue.enqueueWriteImage with imageData function works " subcase="32">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_ImageData" purpose="Check if WebCLCommandQueue.enqueueWriteImage with imageData function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_commandQueue_enqueueWriteImage_with_imageData.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_Canvas" purpose="Check if WebCLContext.createBuffer with HTMLCanvasElement function works " subcase="7">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_Canvas" purpose="Check if WebCLContext.createBuffer with HTMLCanvasElement function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_context_createBuffer_with_HTMLCanvasElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_Image" purpose="Check if WebCLContext.createBuffer with HTMLImageElement function works " subcase="9">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_Image" purpose="Check if WebCLContext.createBuffer with HTMLImageElement function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_context_createBuffer_with_HTMLImageElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_ImageData" purpose="Check if WebCLContext.createBuffer with imageData function works " subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_ImageData" purpose="Check if WebCLContext.createBuffer with imageData function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_context_createBuffer_with_imageData.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_Canvas" purpose="Check if WebCLContext.createImage with HTMLCanvasElement function works " subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_Canvas" purpose="Check if WebCLContext.createImage with HTMLCanvasElement function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_context_createImage_with_HTMLCanvasElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_Image" purpose="Check if WebCLContext.createImage with HTMLImageElement function works " subcase="10">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_Image" purpose="Check if WebCLContext.createImage with HTMLImageElement function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_context_createImage_with_HTMLImageElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_ImageData" purpose="Check if WebCLContext.createImage with imageData function works " subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_ImageData" purpose="Check if WebCLContext.createImage with imageData function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/cl_context_createImage_with_imageData.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_ImageTypes" purpose="Check if WebCLContext.createBuffer with html image types function works " subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_ImageTypes" purpose="Check if WebCLContext.createBuffer with html image types function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/createBufferValidation.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_ImageTypes" purpose="Check if WebCLContext.createImage with html image types function works " subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_ImageTypes" purpose="Check if WebCLContext.createImage with html image types function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_image/createImageValidation.html</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="WEBCL_html_video" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_Video" purpose="Check if WebCLCommandQueue.enqueueWriteImage with HTMLVideoElement function works " subcase="19">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLCommandQueue_enqueueWriteImage_Video" purpose="Check if WebCLCommandQueue.enqueueWriteImage with HTMLVideoElement function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_video/cl_commandQueue_enqueueWriteImage_with_HTMLVideoElement.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_Video" purpose="Check if WebCLContext.createImage with HTMLVideoElement function works " subcase="7">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createImage_Video" purpose="Check if WebCLContext.createImage with HTMLVideoElement function works ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/extension/WEBCL_html_video/cl_context_createImage_with_HTMLVideoElement.html</test_script_entry>
         </description>
       </testcase>
     </set>
     <set name="functionalityTesting" type="js">
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_function" purpose="Check if WebCLContext.createBuffer is functionality" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_function" purpose="Check if WebCLContext.createBuffer is functionality">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createBuffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_valid" purpose="Check if WebCLContext.createBuffer is valid " subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createBuffer_valid" purpose="Check if WebCLContext.createBuffer is valid ">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createBufferValidation.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateCommandQueue_function" purpose="Check if WebCLContext.CreateCommandQueue is functionality" subcase="8">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateCommandQueue_function" purpose="Check if WebCLContext.CreateCommandQueue is functionality">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createCommandQueue.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_CreateContext_function" purpose="Check if WebCL.CreateContext is functionality" subcase="17">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCL_CreateContext_function" purpose="Check if WebCL.CreateContext is functionality">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createContext.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateImage_function" purpose="Check if WebCLContext.CreateImage is functionality" subcase="49">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateImage_function" purpose="Check if WebCLContext.CreateImage is functionality">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createImage.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateImage_Valid" purpose="Check if WebCLContext.CreateImage is valid" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateImage_Valid" purpose="Check if WebCLContext.CreateImage is valid">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createImageValidation.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernelsInProgram_function" purpose="Check if WebCLProgram.createKernelsInProgram is functionality" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLProgram_createKernelsInProgram_function" purpose="Check if WebCLProgram.createKernelsInProgram is functionality">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createKernelsInProgram.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createProgram_function" purpose="Check if WebCLContext.createProgram is functionality" subcase="6">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_createProgram_function" purpose="Check if WebCLContext.createProgram is functionality">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createProgram.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateSampler_function" purpose="Check if WebCLContext.CreateSampler is functionality" subcase="12">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLContext_CreateSampler_function" purpose="Check if WebCLContext.CreateSampler is functionality">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/basics/createSampler.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLProgram_build_Callback" purpose="Check if webCLProgram.build with Callback function works" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLProgram_build_Callback" purpose="Check if webCLProgram.build with Callback function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/buildingAndRunning/buildCallback.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLProgram_getBuildInfo_Option" purpose="Check if webCLProgram.getBuildInfo with Option function works" subcase="12">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLProgram_getBuildInfo_Option" purpose="Check if webCLProgram.getBuildInfo with Option function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/buildingAndRunning/buildOptions.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg_basic" purpose="Check if WebCLKernel.setArg basic type is valid" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg_basic" purpose="Check if WebCLKernel.setArg basic type is valid">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/buildingAndRunning/setArg_basic.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg_local" purpose="Check if WebCLKernel.setArg with local type function works" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg_local" purpose="Check if WebCLKernel.setArg with local type function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/buildingAndRunning/setArg_local.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg_Vector" purpose="Check if WebCLKernel.setArg basic function works" subcase="50">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLKernel_setArg_Vector" purpose="Check if WebCLKernel.setArg basic function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/buildingAndRunning/setArg_Vector.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyBuffer_function" purpose="Check if webCLCommandQueue.enqueueCopyBuffer functionality works" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyBuffer_function" purpose="Check if webCLCommandQueue.enqueueCopyBuffer functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueCopyBuffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyBufferRect_function" purpose="Check if enqueueCopyBufferRect.enqueueCopyBuffer functionality works" subcase="12">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyBufferRect_function" purpose="Check if enqueueCopyBufferRect.enqueueCopyBuffer functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueCopyBufferRect.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyBufferToImage_function" purpose="Check if webCLCommandQueue.enqueueCopyBufferToImage functionality works" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyBufferToImage_function" purpose="Check if webCLCommandQueue.enqueueCopyBufferToImage functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueCopyBufferToImage.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyImage_function" purpose="Check if webCLCommandQueue.enqueueCopyImage functionality works" subcase="5">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyImage_function" purpose="Check if webCLCommandQueue.enqueueCopyImage functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueCopyImage.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyImageToBuffer_function" purpose="Check if webCLCommandQueue.enqueueCopyImageToBuffer functionality works" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueCopyImageToBuffer_function" purpose="Check if webCLCommandQueue.enqueueCopyImageToBuffer functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueCopyImageToBuffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueReadBuffer_function" purpose="Check if webCLCommandQueue.enqueueReadBuffer functionality works" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueReadBuffer_function" purpose="Check if webCLCommandQueue.enqueueReadBuffer functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueReadBuffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueReadBufferRect_function" purpose="Check if webCLCommandQueue.enqueueReadBufferRect functionality works" subcase="12">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueReadBufferRect_function" purpose="Check if webCLCommandQueue.enqueueReadBufferRect functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueReadBufferRect.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueReadImage_function" purpose="Check if webCLCommandQueue.enqueueReadImage functionality works" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueReadImage_function" purpose="Check if webCLCommandQueue.enqueueReadImage functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueReadImage.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueWriteBuffer_function" purpose="Check if webCLCommandQueue.enqueueWriteBuffer functionality works" subcase="3">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueWriteBuffer_function" purpose="Check if webCLCommandQueue.enqueueWriteBuffer functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueWriteBuffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueWriteBufferRect_function" purpose="Check if webCLCommandQueue.enqueueWriteBufferRect functionality works" subcase="12">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueWriteBufferRect_function" purpose="Check if webCLCommandQueue.enqueueWriteBufferRect functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueWriteBufferRect.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueWriteImage_function" purpose="Check if webCLCommandQueue.enqueueWriteImage functionality works" subcase="4">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_enqueueWriteImage_function" purpose="Check if webCLCommandQueue.enqueueWriteImage functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/enqueueWriteImage.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_finish_function" purpose="Check if webCLCommandQueue.finish functionality works" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="webCLCommandQueue_finish_function" purpose="Check if webCLCommandQueue.finish functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/enqueueOperations/finish.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback_function" purpose="Check if WebCLEvent.setCallback functionality works" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback_function" purpose="Check if WebCLEvent.setCallback functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/events/setCallback.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback_release" purpose="Check if WebCLEvent.setCallback and ReleaseEvent functionality works" subcase="1">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback_release" purpose="Check if WebCLEvent.setCallback and ReleaseEvent functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/events/setCallback_andReleaseEvent.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback_multipleCalls" purpose="Check if WebCLEvent.setCallback with multipleCalls functionality works" subcase="2">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLEvent_setCallback_multipleCalls" purpose="Check if WebCLEvent.setCallback with multipleCalls functionality works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/events/setCallback_multipleCalls.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLObject_release_function" purpose="Check if WebCLObject.release function works" subcase="9">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLObject_release_function" purpose="Check if WebCLObject.release function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/release/release.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLObject_releaseAll_function" purpose="Check if WebCLObject.releaseAll function works" subcase="9">
+      <testcase component="Supplementary APIs/Supplementary/WebCL - Khronos" execution_type="auto" id="WebCLObject_releaseAll_function" purpose="Check if WebCLObject.releaseAll function works">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-webcl-nonw3c-tests/webcl/khronos/conformance/functionalityTesting/release/releaseAll.html</test_script_entry>
         </description>

--- a/webapi/webapi-webcl-nonw3c-tests/webcl/khronos/resources/js-test-pre.js
+++ b/webapi/webapi-webcl-nonw3c-tests/webcl/khronos/resources/js-test-pre.js
@@ -32,7 +32,6 @@ function KhronosTest(name) {
 }
 
 var khronosTests = [];
-var khronosTestMsg = null;
 
 function Status() {
   this.status = null;
@@ -112,9 +111,31 @@ function getTestCaseCount() {
 
 function notifyFinishedToHarness() {
   if (window.parent.completion_callback) {
-    window.parent.completion_callback(khronosTests, statusObj);
+    var notifyResult = [];
+    var caseName = document.title;
+    if (caseName.length === 0) {
+      fileName = window.location.href;
+      arrUrl  = window.location.href.split('/');
+      caseName = arrUrl[arrUrl.length-1].split('\.')[0];
+    }
+    var ktestNotify = new KhronosTest(caseName);
+    ktestNotify.status = 0;
+    var msg = "[Message]";
+    for (var i=0;i<khronosTests.length;i++) {
+      var kt = khronosTests[i] ;
+      var ktStatus = kt.status;
+      if (ktStatus===1) {
+        ktestNotify.status = 1;
+        msg += "[assert]fail[message]*FAIL " + kt.message + "\n";
+      }
+      else {
+        msg += "[assert]pass[message]*PASS " + kt.message + "\n";
+      }
+    }
+    ktestNotify.message = msg;
+    notifyResult.push(ktestNotify);
+    window.parent.completion_callback(notifyResult, statusObj);
   }
-
   if (window.parent.webclTestHarness) {
     window.parent.webclTestHarness.notifyFinished(window.location.pathname);
   }

--- a/webapi/webapi-webgl-khronos-tests/webgl/khronos/COPYING
+++ b/webapi/webapi-webgl-khronos-tests/webgl/khronos/COPYING
@@ -6,148 +6,66 @@ unit.css
 -.ok {
  +.pass {
 
-unit.js
- var __testLog__;
-  var __backlog__ = [];
-  
- +var caseName = null;
- +var subcaseIndex = 0;
- +
- +function KhronosUnitTest(name) {
- +  this.name = name;
- +  this.status = null;
- +  this.message = null;
- +}
- +
- +var khronosUnitTests = [];
- +var khronosUnitTestMsg = null;
- +
- +function Status() {
- +  this.status = null;
- +  this.message = null;
- +}
- +
- +var statusObj = new Status();
- +statusObj.status = 0;
- +
-Object.toSource = function(a, seen){
-    if (a == null) return "null";
-    if (typeof a == 'boolean') return a ? "true" : "false";
-      __testLog__ = document.createElement('div');
-      __testSuccess__ = true;
-      try {
- +      caseName = i;
- +      subcaseIndex = 1;
- +
-        doTestNotify (i);
-        var args = setup_args;
-        if (Tests.setup != null)
-  }
-  
-  function testFailed(assertName, name) {
- +  var kutest = new KhronosUnitTest(caseName + "/" + subcaseIndex);
- +  kutest.status = 1;
- +  kutest.message = name;
- +  khronosUnitTests.push(kutest);
- +  subcaseIndex += 1;
- +
-    var d = document.createElement('div');
-    var h = document.createElement('h3');
-    var d1 = document.createElement("span");
-  }
-function testPassed(assertName, name) {
- +  var kutest = new KhronosUnitTest(caseName + "/" + subcaseIndex);
- +  kutest.status = 0;
- +  kutest.message = name;
- +  khronosUnitTests.push(kutest);
- +  subcaseIndex += 1;
- +
-    var d = document.createElement('div');
-    var h = document.createElement('h3');
-    var d1 = document.createElement("span");
-    h.appendChild(document.createTextNode(
-        name==null ? assertName : name + " (in " + assertName + ")"));
-    d.appendChild(h);
- +  kutest.message = name==null ? assertName : name + " (in " + assertName + ")";
-    var args = []
-    for (var i=2; i<arguments.length; i++) {
-      var a = arguments[i];
-      var p = document.createElement('p');
-      p.style.whiteSpace = 'pre';
-      p.textContent = (a == null) ? "null" :
-                      (typeof a == 'boolean' || typeof a == 'string') ? a : Object.toSource(a);
- +    kutest.message += "\n" + p.textContent;
-      args.push(p.textContent);
-      d.appendChild(p);
-    }
-  function printTestStatus(testsRun) {
-    var status = document.getElementById('test-status');
-    if (testsRun) {
- -    status.className = checkTestSuccess() ? 'ok' : 'fail';
- +    status.className = checkTestSuccess() ? 'pass' : 'fail';
-      status.textContent = checkTestSuccess() ? "PASS" : "FAIL";
-    } else {
-      status.className = 'fail';
-     status.textContent = "NO TESTS FOUND";
-   }
- }
+Add completion_callback handle to:
 
+webgl/khronos/conformance/more/unit.js
+webgl/khronos/resources/js-test-pre.js
 
 Remove unused WebGL test cases:
 
-webgl\khronos\conformance\glsl\functions\glsl-function-lessThan.html
-webgl\khronos\conformance\glsl\functions\glsl-function-refract.html
-webgl\khronos\conformance\glsl\misc\glsl-2types-of-textures-on-same-unit.html
-webgl\khronos\conformance\glsl\misc\shader-with-illegal-default-precision.frag.html
-webgl\khronos\conformance\glsl\misc\shader-with-illegal-default-precision.vert.html
-webgl\khronos\conformance\manual\angle-instanced-arrays-state-leakage.html
-webgl\khronos\conformance\manual\canvas-clear-on-zero-count-draw.html
-webgl\khronos\conformance\manual\canvas-no-clear-on-readpixels.html
-webgl\khronos\conformance\manual\canvas-no-clear-on-unsuccessful-draw.html
-webgl\khronos\conformance\manual\framebuffers-keep-contents-exiting-fullscreen-mode.html
-webgl\khronos\conformance\more\conformance\badArgsArityLessThanArgc.html
-webgl\khronos\conformance\more\conformance\fuzzTheAPI.html
-webgl\khronos\conformance\more\conformance\quickCheckAPIBadArgs.html
-webgl\khronos\conformance\more\demos\opengl_web.html
-webgl\khronos\conformance\more\demos\video.html
-webgl\khronos\conformance\more\glsl\longLoops.html
-webgl\khronos\conformance\more\glsl\unusedAttribsUniforms.html
-webgl\khronos\conformance\more\performance\bandwidth.html
-webgl\khronos\conformance\more\performance\CPUvsGPU.html
-webgl\khronos\conformance\more\performance\jsGCPause.html
-webgl\khronos\conformance\more\performance\jsMatrixMult.html
-webgl\khronos\conformance\more\performance\jsToGLOverhead.html
-webgl\khronos\conformance\more\all_tests.html
-webgl\khronos\conformance\more\all_tests_linkonly.html
-webgl\khronos\conformance\more\all_tests_sequential.html
-webgl\khronos\conformance\more\index.html
-webgl\khronos\conformance\rendering\vertex-texture-fetch.html
-webgl\khronos\conformance\uniforms\gl-uniform-struct-unused.html
-webgl\khronos\conformance\uniforms\gl-uniform-unused-array-elements-get-truncated.html
-webgl\khronos\extra\big-fbos-example.html
-webgl\khronos\extra\buffer-gc-stress.html
-webgl\khronos\extra\buffer-sizes.html
-webgl\khronos\extra\canvas-compositing-test.html
-webgl\khronos\extra\context-creation-and-destruction-stress.html
-webgl\khronos\extra\fbo-lost-context.html
-webgl\khronos\extra\lots-of-polys-example.html
-webgl\khronos\extra\lots-of-polys-shader-example.html
-webgl\khronos\extra\multisample-corruption-stress.html
-webgl\khronos\extra\offscreen-issue.html
-webgl\khronos\extra\out-of-bounds-uniform-array-access.html
-webgl\khronos\extra\out-of-memory.html
-webgl\khronos\extra\out-of-resources.html
-webgl\khronos\extra\out-of-vram.html
-webgl\khronos\extra\point-no-attributes-stress.html
-webgl\khronos\extra\readpixels-after-alert.html
-webgl\khronos\extra\simulated-attrib-0-bug-test.html
-webgl\khronos\extra\slow-shader-example.html
-webgl\khronos\extra\tex-image-with-video-test.html
-webgl\khronos\extra\webgl-drawelements-validation.html
-webgl\khronos\extra\webgl-info.html
-webgl\khronos\extra\webgl-translate-shader.html
-webgl\khronos\misc\program-test-1.html
-webgl\khronos\webgl-conformance-tests.html
+webgl/khronos/conformance/glsl/functions/glsl-function-lessThan.html
+webgl/khronos/conformance/glsl/functions/glsl-function-refract.html
+webgl/khronos/conformance/glsl/misc/glsl-2types-of-textures-on-same-unit.html
+webgl/khronos/conformance/glsl/misc/shader-with-illegal-default-precision.frag.html
+webgl/khronos/conformance/glsl/misc/shader-with-illegal-default-precision.vert.html
+webgl/khronos/conformance/manual/angle-instanced-arrays-state-leakage.html
+webgl/khronos/conformance/manual/canvas-clear-on-zero-count-draw.html
+webgl/khronos/conformance/manual/canvas-no-clear-on-readpixels.html
+webgl/khronos/conformance/manual/canvas-no-clear-on-unsuccessful-draw.html
+webgl/khronos/conformance/manual/framebuffers-keep-contents-exiting-fullscreen-mode.html
+webgl/khronos/conformance/more/conformance/badArgsArityLessThanArgc.html
+webgl/khronos/conformance/more/conformance/fuzzTheAPI.html
+webgl/khronos/conformance/more/conformance/quickCheckAPIBadArgs.html
+webgl/khronos/conformance/more/demos/opengl_web.html
+webgl/khronos/conformance/more/demos/video.html
+webgl/khronos/conformance/more/glsl/longLoops.html
+webgl/khronos/conformance/more/glsl/unusedAttribsUniforms.html
+webgl/khronos/conformance/more/performance/bandwidth.html
+webgl/khronos/conformance/more/performance/CPUvsGPU.html
+webgl/khronos/conformance/more/performance/jsGCPause.html
+webgl/khronos/conformance/more/performance/jsMatrixMult.html
+webgl/khronos/conformance/more/performance/jsToGLOverhead.html
+webgl/khronos/conformance/more/all_tests.html
+webgl/khronos/conformance/more/all_tests_linkonly.html
+webgl/khronos/conformance/more/all_tests_sequential.html
+webgl/khronos/conformance/more/index.html
+webgl/khronos/conformance/rendering/vertex-texture-fetch.html
+webgl/khronos/conformance/uniforms/gl-uniform-struct-unused.html
+webgl/khronos/conformance/uniforms/gl-uniform-unused-array-elements-get-truncated.html
+webgl/khronos/extra/big-fbos-example.html
+webgl/khronos/extra/buffer-gc-stress.html
+webgl/khronos/extra/buffer-sizes.html
+webgl/khronos/extra/canvas-compositing-test.html
+webgl/khronos/extra/context-creation-and-destruction-stress.html
+webgl/khronos/extra/fbo-lost-context.html
+webgl/khronos/extra/lots-of-polys-example.html
+webgl/khronos/extra/lots-of-polys-shader-example.html
+webgl/khronos/extra/multisample-corruption-stress.html
+webgl/khronos/extra/offscreen-issue.html
+webgl/khronos/extra/out-of-bounds-uniform-array-access.html
+webgl/khronos/extra/out-of-memory.html
+webgl/khronos/extra/out-of-resources.html
+webgl/khronos/extra/out-of-vram.html
+webgl/khronos/extra/point-no-attributes-stress.html
+webgl/khronos/extra/readpixels-after-alert.html
+webgl/khronos/extra/simulated-attrib-0-bug-test.html
+webgl/khronos/extra/slow-shader-example.html
+webgl/khronos/extra/tex-image-with-video-test.html
+webgl/khronos/extra/webgl-drawelements-validation.html
+webgl/khronos/extra/webgl-info.html
+webgl/khronos/extra/webgl-translate-shader.html
+webgl/khronos/misc/program-test-1.html
+webgl/khronos/webgl-conformance-tests.html
 
 
 These tests are copyright by the Khronos Group under MIT License:

--- a/webapi/webapi-webgl-khronos-tests/webgl/khronos/conformance/more/unit.js
+++ b/webapi/webapi-webgl-khronos-tests/webgl/khronos/conformance/more/unit.js
@@ -80,7 +80,6 @@ function KhronosUnitTest(name) {
 }
 
 var khronosUnitTests = [];
-var khronosUnitTestMsg = null;
 
 function Status() {
   this.status = null;
@@ -936,9 +935,31 @@ function reportTestResultsToHarness(success, msg) {
 
 function notifyFinishedToHarness() {
   if (window.parent.completion_callback) {
-    window.parent.completion_callback(khronosUnitTests, statusObj);
+    var notifyResult = [];
+    var caseName = document.title;
+    if (caseName.length === 0) {
+      fileName = window.location.href;
+      arrUrl  = window.location.href.split('/');
+      caseName = arrUrl[arrUrl.length-1].split('\.')[0];
+    }
+    var ktestNotify = new KhronosUnitTest(caseName);
+    ktestNotify.status = 0;
+    var msg = "[Message]";
+    for (var i=0;i<khronosUnitTests.length;i++) {
+      var kt = khronosUnitTests[i] ;
+      var ktStatus = kt.status;
+      if (ktStatus===1) {
+        ktestNotify.status = 1;
+        msg += "[assert]fail[message]*FAIL " + kt.message + "\n";
+      }
+      else {
+        msg += "[assert]pass[message]*PASS " + kt.message + "\n";
+      }
+    }
+    ktestNotify.message = msg;
+    notifyResult.push(ktestNotify);
+    window.parent.completion_callback(notifyResult, statusObj);
   }
-
   if (window.parent.webglTestHarness) {
     window.parent.webglTestHarness.notifyFinished(window.location.pathname);
   }

--- a/webapi/webapi-webgl-khronos-tests/webgl/khronos/resources/js-test-pre.js
+++ b/webapi/webapi-webgl-khronos-tests/webgl/khronos/resources/js-test-pre.js
@@ -30,7 +30,6 @@ function KhronosTest(name) {
 }
 
 var khronosTests = [];
-var khronosTestMsg = null;
 
 function Status() {
   this.status = null;
@@ -98,7 +97,30 @@ function reportTestResultsToHarness(success, msg) {
 
 function notifyFinishedToHarness() {
   if (window.parent.completion_callback) {
-    window.parent.completion_callback(khronosTests, statusObj);
+    var notifyResult = [];
+    var caseName = document.title;
+    if (caseName.length === 0) {
+      fileName = window.location.href;
+      arrUrl  = window.location.href.split('/');
+      caseName = arrUrl[arrUrl.length-1].split('\.')[0];
+    }
+    var ktestNotify = new KhronosTest(caseName);
+    ktestNotify.status = 0;
+    var msg = "[Message]";
+    for (var i=0;i<khronosTests.length;i++) {
+      var kt = khronosTests[i] ;
+      var ktStatus = kt.status;
+      if (ktStatus===1) {
+        ktestNotify.status = 1;
+        msg += "[assert]fail[message]*FAIL " + kt.message + "\n";
+      }
+      else {
+        msg += "[assert]pass[message]*PASS " + kt.message + "\n";
+      }
+    }
+    ktestNotify.message = msg;
+    notifyResult.push(ktestNotify);
+    window.parent.completion_callback(notifyResult, statusObj);
   }
   if (window.parent.webglTestHarness) {
     window.parent.webglTestHarness.notifyFinished(window.location.pathname);


### PR DESCRIPTION
[WebAPI] Make the test results' numbers of webapi-webcl-nonw3c-tests &
webapi-webgl-khronos-tests on WTS be consistent with the ones by testkit-lite.
Format webapi/webapi-webgl-khronos-tests/webgl/khronos/conformance/more/unit.js
by unix mode.
Remove subcase attribute from testcase node in
  webapi/webapi-webcl-nonw3c-tests/tests.xml
  webapi/webapi-webcl-nonw3c-tests/tests.full.xml .
BUG=CTS-1716