### PR TITLE
[lint-tool] Fix lint error in cordova tests

### DIFF
--- a/cordova/cordova-api-ios-tests/tests.full.xml
+++ b/cordova/cordova-api-ios-tests/tests.full.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite category="Crosswalk Cordova" name="cordova-api-ios-tests">
     <set name="cordovaapi" type="iosuiauto">
-    	<testcase component="Cordova Features/Mobile Spec" execution_type="auto" id="CrossWalk_Cordova_Mobile_Spec_Run" priority="P0" purpose="Validate 'cordova_mobile_spec' app can be run successfully" status="approved" type="Functional">
+      <testcase component="Cordova Features/Mobile Spec" execution_type="auto" id="CrossWalk_Cordova_Mobile_Spec_Run" priority="P0" purpose="Validate 'cordova_mobile_spec' app can be run successfully" status="approved" type="Functional">
         <description>
           <test_script_entry>/opt/cordova-api-ios-tests/cordovaapi/mobilespec_test.py</test_script_entry>
         </description>

--- a/cordova/cordova-api-ios-tests/tests.xml
+++ b/cordova/cordova-api-ios-tests/tests.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite category="Crosswalk Cordova" name="cordova-api-ios-tests">
     <set name="cordova" type="iosuiauto">
-    	<testcase component="Cordova Features/Mobile Spec" execution_type="auto" id="CrossWalk_Cordova_Mobile_Spec_Run" purpose="Validate 'cordova_mobile_spec' app can be run successfully">
+      <testcase component="Cordova Features/Mobile Spec" execution_type="auto" id="CrossWalk_Cordova_Mobile_Spec_Run" purpose="Validate 'cordova_mobile_spec' app can be run successfully">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/cordova-api-ios-tests/cordovaapi/mobilespec_test.py</test_script_entry>
         </description>

--- a/cordova/cordova-feature-android-tests/feature/CrossWalk_Cordova_Remote_Debug_Pack.html
+++ b/cordova/cordova-feature-android-tests/feature/CrossWalk_Cordova_Remote_Debug_Pack.html
@@ -44,7 +44,7 @@ Authors:
       <li>unzip crosswalk-cordova-version-arm</li>
       <li>Execute 'cd crosswalk-cordova-version-arm'</li>
       <li>Execute './bin/create remotedebugging com.example.remotedebugging RD'</li>
-	 <li>Execute 'cd remotedebugging'</li>
+      <li>Execute 'cd remotedebugging'</li>
       <li>Execute './cordova/build -debug'.</li>
     </ol>
     <p>


### PR DESCRIPTION
Replace tab space with whitespace using:
 grep "  " -rl * |grep ".html"|xargs -I% sed -i 's/    /    /g' %
 grep "  " -rl * |grep ".xml"|xargs -I% sed -i 's/    /    /g' %

https://crosswalk-project.org/jira/browse/CTS-1438