### PR TITLE
Update assertions after app-tools change

### DIFF
--- a/apptools/apptools-android-tests/apptools/CI/crosswalk_pkg_basic.py
+++ b/apptools/apptools-android-tests/apptools/CI/crosswalk_pkg_basic.py
@@ -90,7 +90,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             self.assertEquals(apkLength, 1)
         comm.run(self)
         comm.clear("org.xwalk.test")
-        self.assertIn("target android", output)
+        self.assertIn("Loading 'android' platform backend", output)
         self.assertNotIn("candle", output)
         self.assertNotIn("light", output)
 

--- a/apptools/apptools-android-tests/apptools/create_package_abbreviated_command.py
+++ b/apptools/apptools-android-tests/apptools/create_package_abbreviated_command.py
@@ -71,7 +71,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertEquals(return_code, 0)
-        self.assertIn("target android", output[0])
+        self.assertIn("Loading 'android' platform backend", output[0])
         self.assertNotIn("candle", output[0])
         self.assertNotIn("light", output[0])
         self.assertIn(version, output[0])

--- a/apptools/apptools-android-tests/apptools/manifest_xwalk_target_platforms.py
+++ b/apptools/apptools-android-tests/apptools/manifest_xwalk_target_platforms.py
@@ -66,8 +66,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertEquals(return_code, 0)
-        self.assertIn("target android", output[0])
-        self.assertNotIn("target windows", output[0])
+        self.assertIn("Loading 'android' platform backend", output[0])
+        self.assertNotIn("Loading 'windows' platform backend", output[0])
 
     def test_without_platforms(self):
         comm.setUp()
@@ -100,7 +100,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertEquals(return_code, 0)
-        self.assertIn("target android", output[0])
+        self.assertIn("Loading 'android' platform backend", output[0])
 
     def test_with_target_platforms(self):
         comm.setUp()
@@ -133,7 +133,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertEquals(return_code, 0)
-        self.assertIn("target android", output[0])
+        self.assertIn("Loading 'android' platform backend", output[0])
 
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-ios-tests/apptools/manifest_xwalk_target_platforms.py
+++ b/apptools/apptools-ios-tests/apptools/manifest_xwalk_target_platforms.py
@@ -52,7 +52,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(packstatus[0], 0)
         self.assertEquals(ipaLength, 1)
         self.assertIn("target ios", packstatus[1])
-        self.assertNotIn("target android", packstatus[1])
+        self.assertNotIn("Loading 'android' platform backend", packstatus[1])
 
     def test_update_target_platforms(self):
         comm.setUp()
@@ -71,7 +71,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(packstatus[0], 0)
         self.assertEquals(ipaLength, 1)
         self.assertIn("target ios", packstatus[1])
-        self.assertNotIn("target android", packstatus[1])
+        self.assertNotIn("Loading 'android' platform backend", packstatus[1])
 
     def test_without_platforms(self):
         comm.setUp()
@@ -96,7 +96,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(apkLength, 2)
         self.assertEquals(ipaLength, 0)
         self.assertNotIn("target ios", packstatus[1])
-        self.assertIn("target android", packstatus[1])
+        self.assertIn("Loading 'android' platform backend", packstatus[1])
 
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-linux-tests/apptools/manifest_xwalk_target_platforms.py
+++ b/apptools/apptools-linux-tests/apptools/manifest_xwalk_target_platforms.py
@@ -53,7 +53,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(packstatus[0], 0)
         self.assertEquals(debLength, 1)
         self.assertIn("target deb", packstatus[1])
-        self.assertNotIn("target android", packstatus[1])
+        self.assertNotIn("Loading 'android' platform backend", packstatus[1])
 
     def test_update_target_platforms(self):
         comm.setUp()
@@ -73,7 +73,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(packstatus[0], 0)
         self.assertEquals(debLength, 1)
         self.assertIn("target deb", packstatus[1])
-        self.assertNotIn("target android", packstatus[1])
+        self.assertNotIn("Loading 'android' platform backend", packstatus[1])
 
     def test_without_platforms(self):
         comm.setUp()
@@ -99,7 +99,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(apkLength, 2)
         self.assertEquals(debLength, 0)
         self.assertNotIn("target deb", packstatus[1])
-        self.assertIn("target android", packstatus[1])
+        self.assertIn("Loading 'android' platform backend", packstatus[1])
 
 if __name__ == '__main__':
     unittest.main()

--- a/apptools/apptools-windows-tests/apptools/CI/crosswalk_pkg_basic.py
+++ b/apptools/apptools-windows-tests/apptools/CI/crosswalk_pkg_basic.py
@@ -83,7 +83,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(return_code, 0)
         self.assertIn("candle", output[0])
         self.assertIn("light", output[0])
-        self.assertNotIn("target android", output[0])
+        self.assertNotIn("Loading 'android' platform backend", output[0])
         self.assertEquals(apkLength, 1)
 
     def test_crosswalk_canary(self):

--- a/apptools/apptools-windows-tests/apptools/create_package.py
+++ b/apptools/apptools-windows-tests/apptools/create_package.py
@@ -255,7 +255,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(return_code, 0)
         self.assertIn("candle", output[0])
         self.assertIn("light", output[0])
-        self.assertNotIn("target android", output[0])
+        self.assertNotIn("Loading 'android' platform backend", output[0])
         self.assertNotIn("armeabi-v7a,x86", output[0])
         self.assertEquals(apkLength, 1)
 

--- a/apptools/apptools-windows-tests/apptools/manifest_xwalk_target_platforms.py
+++ b/apptools/apptools-windows-tests/apptools/manifest_xwalk_target_platforms.py
@@ -52,8 +52,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.clear("org.xwalk.test")
         self.assertEquals(return_code, 0)
         self.assertEquals(msiLength, 1)
-        self.assertIn("target windows", output[0])
-        self.assertNotIn("target android", output[0])
+        self.assertIn("Loading 'windows' platform backend", output[0])
+        self.assertNotIn("Loading 'android' platform backend", output[0])
 
     def test_update_target_platforms(self):
         comm.setUp()
@@ -72,8 +72,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.clear("org.xwalk.test")
         self.assertEquals(return_code, 0)
         self.assertEquals(msiLength, 1)
-        self.assertIn("target windows", output[0])
-        self.assertNotIn("target android", output[0])
+        self.assertIn("Loading 'windows' platform backend", output[0])
+        self.assertNotIn("Loading 'android' platform backend", output[0])
 
     def test_without_platforms(self):
         comm.setUp()
@@ -98,8 +98,8 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(return_code, 0)
         self.assertEquals(apkLength, 2)
         self.assertEquals(msiLength, 0)
-        self.assertNotIn("target windows", output[0])
-        self.assertIn("target android", output[0])
+        self.assertNotIn("Loading 'windows' platform backend", output[0])
+        self.assertIn("Loading 'android' platform backend", output[0])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Host setup check is now disabled by default in app-tools when not running
in an interactive terminal (APPTOOLS-303). So the build output changed,
and the string search asserts looking for which platform is build also
have to be updated.

BUG=CTS-1732