### PR TITLE
[Test Release] Add docroot-only options to reduce the size of webapi-…

### DIFF
--- a/misc/webapi-service-docroot-tests/pack.sh
+++ b/misc/webapi-service-docroot-tests/pack.sh
@@ -53,9 +53,9 @@ cp -arf $SRC_ROOT/* $BUILD_ROOT/
 for list in $LIST;do
     list_dir=`find $SRC_ROOT/../.. -type d -name $list`
     if [ $pack_type == "cordova" ]; then
-        python $SRC_ROOT/../../tools/build/pack.py -t ${pack_type}-aio -m $pack_mode -d $BUILD_DEST/opt/$core_name -s $list_dir
+        python $SRC_ROOT/../../tools/build/pack.py -t ${pack_type}-aio -m $pack_mode --docroot-only -d $BUILD_DEST/opt/$core_name -s $list_dir
     else
-        python $SRC_ROOT/../../tools/build/pack.py -t ${pack_type}-aio -m $pack_mode -a $arch -d $BUILD_DEST/opt/$core_name -s $list_dir
+        python $SRC_ROOT/../../tools/build/pack.py -t ${pack_type}-aio -m $pack_mode -a $arch --docroot-only -d $BUILD_DEST/opt/$core_name -s $list_dir
     fi
 done
 

--- a/tools/build/pack.py
+++ b/tools/build/pack.py
@@ -373,6 +373,9 @@ def buildPKG(build_json=None):
     if not buildSRC(BUILD_ROOT_SRC, BUILD_ROOT_PKG, build_json):
         return False
 
+    if BUILD_PARAMETERS.docrootonly:
+        return True
+
     if "subapp-list" in build_json:
         for i_sub_app in build_json["subapp-list"].keys():
             if not buildSubAPP(
@@ -460,6 +463,17 @@ def main():
             dest="bnotdebug",
             action="store_true",
             help="specify the packed pkg is not debug mode")
+        opts_parser.add_option(
+            "--resource-only",
+            dest="resourceonly",
+            action="store_true",
+            help="only restore resources to project root")
+        opts_parser.add_option(
+            "--docroot-only",
+            dest = "docrootonly",
+            action = "store_true",
+            default = False,
+            help = "pack docroot only for webtestingservice")
 
         if len(sys.argv) == 1:
             sys.argv.append("-h")


### PR DESCRIPTION
…service-docroot-tests

Apks built in webapi-service-docroot-tests are not used at all. So skip the
apk build when packing this test suite. docroot-only option was add to statisfy
this request.

Verified that the test suite can be built successfully for docroot.

BUG=https://crosswalk-project.org/jira/browse/CTS-1741