### PR TITLE
[WebAPI] Add 3 IAP query test cases

### DIFF
--- a/webapi/webapi-iap-xwalk-tests/iap/Navigator_iap_queryProductsInfo_invalidaccess.html
+++ b/webapi/webapi-iap-xwalk-tests/iap/Navigator_iap_queryProductsInfo_invalidaccess.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2016 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<meta charset="utf-8">
+<title>WebAPI: IAP</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="He Yue" href="mailto:yue.he@intel.com">
+<link rel="help" href="http://www.w3.org/TR/IAP-api/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="options.js"></script>
+<div id="log"></div>
+<script>
+  var at = async_test("Check if queryProductsInfo throw InvalidAccessError when the productId is undefine", {timeout: 10000});
+  if (options.channel == "Google") {
+    navigator.iap.init(options).then(function() {
+      at.step(function() {
+        navigator.iap.queryProductsInfo().then(function(products) {
+          assert_unreached("Here should neve be reached!");
+          at.done();
+        }).catch(function(e) {
+          assert_equals(e.name, "InvalidAccessError", "an error occurs during query raises an InvalidAccessError");
+          at.done();
+        }); // navigator.iap.queryProdcutsInfo ends
+      }); // at.step ends
+    }).catch(function(e) {
+      assert_unreached("Should not be here, otherwise init failed!");
+      at.done();
+    }); // navigator.iap.init ends
+  } else if (options.channel == "XiaoMi") {
+    navigator.iap.init(options).then(function() {
+      at.step(function() {
+        navigator.iap.queryProductsInfo().then(
+          at.step_func(function() {
+            assert_unreached("IAP API on Xiaomi Store does not support queryProductsInfo!");
+            at.done();
+          }),
+          at.step_func(function(e) {
+            at.done();
+          })
+        );
+      });
+    }).catch(function(e) {
+    });
+  }
+</script>

--- a/webapi/webapi-iap-xwalk-tests/iap/Navigator_iap_queryProductsInfo_invalidstate.html
+++ b/webapi/webapi-iap-xwalk-tests/iap/Navigator_iap_queryProductsInfo_invalidstate.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2016 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<meta charset="utf-8">
+<title>WebAPI: IAP</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="He Yue" href="mailto:yue.he@intel.com">
+<link rel="help" href="http://www.w3.org/TR/IAP-api/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="options.js"></script>
+<div id="log"></div>
+<script>
+  var at = async_test("Check if queryProductsInfo throw InvalidStateError if iap not init", {timeout: 10000});
+  if (options.channel == "Google") {
+    at.step(function() {
+      var productsId  = ["org.xwalk.apple"];
+      navigator.iap.queryProductsInfo(productsId).then(function(products) {
+        assert_unreached("Here should neve be reached!");
+        at.done();
+      }).catch(function(e) {
+        assert_equals(e.name, "InvalidStateError", "an error occurs during query raises an InvalidStateError");
+        at.done();
+      }); // navigator.iap.queryProdcutsInfo ends
+    }); // at.step ends
+  } else if (options.channel == "XiaoMi") {
+    at.step(function() {
+      navigator.iap.queryProductsInfo("com.demo_1").then(
+        at.step_func(function() {
+          assert_unreached("IAP API on Xiaomi Store does not support queryProductsInfo!");
+          at.done();
+        }),
+        at.step_func(function(e) {
+          at.done();
+        })
+      );
+    });
+  }
+</script>

--- a/webapi/webapi-iap-xwalk-tests/iap/Navigator_iap_queryProductsInfo_opererror.html
+++ b/webapi/webapi-iap-xwalk-tests/iap/Navigator_iap_queryProductsInfo_opererror.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2016 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<meta charset="utf-8">
+<title>WebAPI: IAP</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="He Yue" href="mailto:yue.he@intel.com">
+<link rel="help" href="http://www.w3.org/TR/IAP-api/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="options.js"></script>
+<div id="log"></div>
+<script>
+  var at = async_test("Check if queryProductsInfo throw OperationError when the productId is undefine", {timeout: 10000});
+  if (options.channel == "Google") {
+    navigator.iap.init(options).then(function() {
+      at.step(function() {
+        var productsId  = ["org.apple"];
+        navigator.iap.queryProductsInfo(productsId).then(function(products) {
+          assert_unreached("Here should neve be reached!");
+          at.done();
+        }).catch(function(e) {
+          assert_equals(e.name, "OperationError", "an error occurs during query raises an OperationError");
+          at.done();
+        }); // navigator.iap.queryProdcutsInfo ends
+      }); // at.step ends
+    }).catch(function(e) {
+      assert_unreached("Should not be here, otherwise init failed!");
+      at.done();
+    }); // navigator.iap.init ends
+  } else if (options.channel == "XiaoMi") {
+    navigator.iap.init(options).then(function() {
+      at.step(function() {
+        navigator.iap.queryProductsInfo("com.demo").then(
+          at.step_func(function() {
+            assert_unreached("IAP API on Xiaomi Store does not support queryProductsInfo!");
+            at.done();
+          }),
+          at.step_func(function(e) {
+            at.done();
+          })
+        );
+      });
+    }).catch(function(e) {
+    });
+  }
+</script>

--- a/webapi/webapi-iap-xwalk-tests/iap/Navigator_iap_queryProductsInfo_opererror.html
+++ b/webapi/webapi-iap-xwalk-tests/iap/Navigator_iap_queryProductsInfo_opererror.html
@@ -36,7 +36,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <script src="options.js"></script>
 <div id="log"></div>
 <script>
-  var at = async_test("Check if queryProductsInfo throw OperationError when the productId is undefine", {timeout: 10000});
+  var at = async_test("Check if queryProductsInfo throw OperationError with the wrong productId", {timeout: 10000});
   if (options.channel == "Google") {
     navigator.iap.init(options).then(function() {
       at.step(function() {

--- a/webapi/webapi-iap-xwalk-tests/tests.full.xml
+++ b/webapi/webapi-iap-xwalk-tests/tests.full.xml
@@ -63,9 +63,45 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo" priority="P1" purpose="Test Navigator iap init method" status="approved" type="compliance" subcase="6">
+      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo" priority="P1" purpose="Test Navigator iap query method" status="approved" type="compliance" subcase="6">
         <description>
           <test_script_entry>/iap/Navigator_iap_queryProductsInfo.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="W3C API Specifications" element_name="iap" element_type="property" interface="Navigator" section="Networking" specification="IAP"/>
+            <spec_url>https://github.com/crosswalk-project/ios-extensions-crosswalk/blob/master/extensions/InAppPurchase/spec/iap.html</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>        
+      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_invalidstate" priority="P1" purpose="Test Navigator iap query method" status="approved" type="compliance" subcase="1">
+        <description>
+          <test_script_entry>/iap/Navigator_iap_queryProductsInfo_invalidstate.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="W3C API Specifications" element_name="iap" element_type="property" interface="Navigator" section="Networking" specification="IAP"/>
+            <spec_url>https://github.com/crosswalk-project/ios-extensions-crosswalk/blob/master/extensions/InAppPurchase/spec/iap.html</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>        
+      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_opererror" priority="P1" purpose="Test Navigator iap query method" status="approved" type="compliance" subcase="1">
+        <description>
+          <test_script_entry>/iap/Navigator_iap_queryProductsInfo_opererror.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="W3C API Specifications" element_name="iap" element_type="property" interface="Navigator" section="Networking" specification="IAP"/>
+            <spec_url>https://github.com/crosswalk-project/ios-extensions-crosswalk/blob/master/extensions/InAppPurchase/spec/iap.html</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>        
+      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_invalidaccess" priority="P1" purpose="Test Navigator iap query method" status="approved" type="compliance" subcase="1">
+        <description>
+          <test_script_entry>/iap/Navigator_iap_queryProductsInfo_invalidaccess.html</test_script_entry>
         </description>
         <specs>
           <spec>

--- a/webapi/webapi-iap-xwalk-tests/tests.full.xml
+++ b/webapi/webapi-iap-xwalk-tests/tests.full.xml
@@ -75,7 +75,7 @@
           </spec>
         </specs>
       </testcase>        
-      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_invalidstate" priority="P1" purpose="Test Navigator iap query method" status="approved" type="compliance" subcase="1">
+      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_invalidstate" priority="P1" purpose="Test Navigator iap query method if iap not init" status="approved" type="compliance">
         <description>
           <test_script_entry>/iap/Navigator_iap_queryProductsInfo_invalidstate.html</test_script_entry>
         </description>
@@ -87,7 +87,7 @@
           </spec>
         </specs>
       </testcase>        
-      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_opererror" priority="P1" purpose="Test Navigator iap query method" status="approved" type="compliance" subcase="1">
+      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_opererror" priority="P1" purpose="Test Navigator iap query method with the wrong productID" status="approved" type="compliance">
         <description>
           <test_script_entry>/iap/Navigator_iap_queryProductsInfo_opererror.html</test_script_entry>
         </description>
@@ -99,7 +99,7 @@
           </spec>
         </specs>
       </testcase>        
-      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_invalidaccess" priority="P1" purpose="Test Navigator iap query method" status="approved" type="compliance" subcase="1">
+      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_invalidaccess" priority="P1" purpose="Test Navigator iap query method when the productId is undefine" status="approved" type="compliance">
         <description>
           <test_script_entry>/iap/Navigator_iap_queryProductsInfo_invalidaccess.html</test_script_entry>
         </description>

--- a/webapi/webapi-iap-xwalk-tests/tests.xml
+++ b/webapi/webapi-iap-xwalk-tests/tests.xml
@@ -33,17 +33,17 @@
           <test_script_entry>/iap/Navigator_iap_queryProductsInfo.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_invalidstate" priority="P1" purpose="Test Navigator iap queryProductsInfo method" status="approved" type="compliance" subcase="1">
+      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_invalidstate" priority="P1" purpose="Test Navigator iap query method if iap not init" status="approved" type="compliance" >
         <description>
           <test_script_entry>/iap/Navigator_iap_queryProductsInfo_invalidstate.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_opererror" priority="P1" purpose="Test Navigator iap queryProductsInfo method" status="approved" type="compliance" subcase="1">
+      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_opererror" priority="P1" purpose="Test Navigator iap query method with the wrong productId name" status="approved" type="compliance" >
         <description>
           <test_script_entry>/iap/Navigator_iap_queryProductsInfo_opererror.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_invalidaccess" priority="P1" purpose="Test Navigator iap queryProductsInfo method" status="approved" type="compliance" subcase="1">
+      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_invalidaccess" priority="P1" purpose="Test Navigator iap query method when the productId is undefine" status="approved" type="compliance" >
         <description>
           <test_script_entry>/iap/Navigator_iap_queryProductsInfo_invalidaccess.html</test_script_entry>
         </description>

--- a/webapi/webapi-iap-xwalk-tests/tests.xml
+++ b/webapi/webapi-iap-xwalk-tests/tests.xml
@@ -33,6 +33,21 @@
           <test_script_entry>/iap/Navigator_iap_queryProductsInfo.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_invalidstate" priority="P1" purpose="Test Navigator iap queryProductsInfo method" status="approved" type="compliance" subcase="1">
+        <description>
+          <test_script_entry>/iap/Navigator_iap_queryProductsInfo_invalidstate.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_opererror" priority="P1" purpose="Test Navigator iap queryProductsInfo method" status="approved" type="compliance" subcase="1">
+        <description>
+          <test_script_entry>/iap/Navigator_iap_queryProductsInfo_opererror.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="auto" id="Navigator_iap_queryProductsInfo_invalidaccess" priority="P1" purpose="Test Navigator iap queryProductsInfo method" status="approved" type="compliance" subcase="1">
+        <description>
+          <test_script_entry>/iap/Navigator_iap_queryProductsInfo_invalidaccess.html</test_script_entry>
+        </description>
+      </testcase>
       <testcase component="Crosswalk APIs/Experimental/InApp Payment API" execution_type="manual" id="Navigator_iap_purchase" priority="P1" purpose="Test Navigator iap purchase result" status="approved" type="compliance">
         <description>
           <test_script_entry>/iap/Navigator_iap_purchase.html</test_script_entry>


### PR DESCRIPTION
Add 3 IAP query test cases and modify the tests.xml and tests.full.xml accordingly.

Impacted tests(approved): new 3, update 0, delete 0
Unit test platform: Crosswalk Project for Android 20.50.528.0
Unit test result summary: Pass 1, Fail 2, Block 0
Coverity scan result: no issue related to the 3 html files.
Related bug: XWALK-6931, XWALK-6932

BUG=https://crosswalk-project.org/jira/browse/CTS-41