### PR TITLE
[WebAPI] Modify the test case to avoid testharness Uncaught Error

### DIFF
--- a/webapi/webapi-iap-xwalk-tests/iap/Navigator_iap_queryProductsInfo_opererror.html
+++ b/webapi/webapi-iap-xwalk-tests/iap/Navigator_iap_queryProductsInfo_opererror.html
@@ -36,33 +36,37 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <script src="options.js"></script>
 <div id="log"></div>
 <script>
-  var at = async_test("Check if queryProductsInfo throw OperationError with the wrong productId", {timeout: 10000});
+  var t = async_test("Check if queryProductsInfo throw OperationError with the wrong productId", {timeout: 10000});
   if (options.channel == "Google") {
     navigator.iap.init(options).then(function() {
-      at.step(function() {
-        var productsId  = ["org.apple"];
-        navigator.iap.queryProductsInfo(productsId).then(function(products) {
-          assert_unreached("Here should neve be reached!");
-          at.done();
-        }).catch(function(e) {
+      var productsId  = ["org.apple"];
+      navigator.iap.queryProductsInfo(productsId).then(function(products) {
+        t.step(function() {
+          assert_unreached("Here should neve be reached! Query return with wrong productId");
+          t.done();
+        });
+      }).catch(function(e) {
+        t.step(function() {
           assert_equals(e.name, "OperationError", "an error occurs during query raises an OperationError");
-          at.done();
-        }); // navigator.iap.queryProdcutsInfo ends
-      }); // at.step ends
+          t.done();
+        });
+      }); // navigator.iap.queryProdcutsInfo ends
     }).catch(function(e) {
-      assert_unreached("Should not be here, otherwise init failed!");
-      at.done();
+      t.step(function() {
+        assert_unreached("Should not be here, otherwise init failed!");
+        t.done();
+      });
     }); // navigator.iap.init ends
   } else if (options.channel == "XiaoMi") {
     navigator.iap.init(options).then(function() {
-      at.step(function() {
-        navigator.iap.queryProductsInfo("com.demo").then(
-          at.step_func(function() {
+      t.step(function() {
+        navigator.iap.queryProductsInfo("com.demo_1").then(
+          t.step_func(function() {
             assert_unreached("IAP API on Xiaomi Store does not support queryProductsInfo!");
-            at.done();
+            t.done();
           }),
-          at.step_func(function(e) {
-            at.done();
+          t.step_func(function(e) {
+            t.done();
           })
         );
       });


### PR DESCRIPTION
Modify the Navigator_iap_queryProductsInfo_opererror.html
Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android: 20.50.532.0
Unit test result summary: pass 0, fail 1, block 0
The case fail due to the Google Play doesn't follow the spec.
Coverity test no issue.
Related bug: XWALK-6932