### PR TITLE
[app-tools] Update duplicated case id in apptools-windows-tests

### DIFF
--- a/apptools/apptools-windows-tests/apptools/create_package.py
+++ b/apptools/apptools-windows-tests/apptools/create_package.py
@@ -467,7 +467,7 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         self.assertEquals(return_code, 0)
         self.assertEquals(apkLength, 1)
 
-    def test_create_package_release_without_argument(self):
+    def test_create_package_release_without_argument_check_locale(self):
         comm.setUp()
         os.chdir(comm.XwalkPath)
         comm.clear("org.xwalk.test")


### PR DESCRIPTION
Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: Crosswalk Project for Windows 20.50.533.1
Unit test result summary: pass 1, fail 0, block 0

BUG=CTS-1760