### PR TITLE
[Crosswalk-20][Embeddingapi] Fix the v7.XWalkViewTestAsync block issue

### DIFF
--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v7/XWalkViewTestAsync.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/test/v7/XWalkViewTestAsync.java
@@ -13,7 +13,7 @@ import android.annotation.SuppressLint;
 import android.test.suitebuilder.annotation.SmallTest;
 
 @SuppressLint("NewApi")
-public class XWalkViewTestAsnyc extends XWalkViewTestBase {
+public class XWalkViewTestAsync extends XWalkViewTestBase {
 
     @Override
     public void setUp() throws Exception {


### PR DESCRIPTION
Impacted tests(approved): new 0, update 0, delete 0
Unit test platform: Crosswalk Project for Android 21.50.537.0
Unit test result summary: pass 12, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/CTS-1768