### PR TITLE
[WebAPI] Add web audo test cases for chromium 51

### DIFF
--- a/webapi/tct-webaudio-w3c-tests/tests.full.xml
+++ b/webapi/tct-webaudio-w3c-tests/tests.full.xml
@@ -2106,6 +2106,30 @@
           </spec>
         </specs>
       </testcase>
+      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="offlineaudiocontext_length_exists" priority="P1" purpose="Check if OfflineAudioContext.length attribute exists" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_length_exists.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="Tizen W3C API Specifications" element_name="length" element_type="method" interface="OfflineAudioContext" section="Media" specification="Web Audio API" />
+            <spec_url>https://webaudio.github.io/web-audio-api/#idl-def-OfflineAudioContext</spec_url>
+            <spec_statement />
+          </spec>
+        </specs>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="offlineaudiocontext_length" priority="P1" purpose="Check if OfflineAudioContext.length is readonly and same as the value in the constructor" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_length.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="Tizen W3C API Specifications" element_name="length" element_type="method" interface="OfflineAudioContext" section="Media" specification="Web Audio API" />
+            <spec_url>https://webaudio.github.io/web-audio-api/#idl-def-OfflineAudioContext</spec_url>
+            <spec_statement />
+          </spec>
+        </specs>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="offlineaudiocontext_suspend_and_resume" priority="P1" purpose="Check if an audio context can be suspended and resumed" status="approved" type="compliance" subcase="4">
         <description>
           <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_suspend_and_resume.html</test_script_entry>

--- a/webapi/tct-webaudio-w3c-tests/tests.full.xml
+++ b/webapi/tct-webaudio-w3c-tests/tests.full.xml
@@ -2118,7 +2118,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="offlineaudiocontext_length" priority="P1" purpose="Check if OfflineAudioContext.length is readonly and same as the value in the constructor" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="offlineaudiocontext_length" priority="P1" purpose="Check if OfflineAudioContext.length is readonly and same as the value in the constructor" status="approved" type="compliance" subcase="2">
         <description>
           <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_length.html</test_script_entry>
         </description>

--- a/webapi/tct-webaudio-w3c-tests/tests.xml
+++ b/webapi/tct-webaudio-w3c-tests/tests.xml
@@ -882,6 +882,16 @@
           <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_startRendering_exists.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="offlineaudiocontext_length_exists" purpose="Check if OfflineAudioContext.length attribute exists">
+        <description>
+          <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_length_exists.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="offlineaudiocontext_length" purpose="Check if OfflineAudioContext.length is readonly and same as the value in the constructor">
+        <description>
+          <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_length.html</test_script_entry>
+        </description>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="offlineaudiocontext_suspend_and_resume" purpose="Check if an audio context can be suspended and resumed" subcase="4">
         <description>
           <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_suspend_and_resume.html</test_script_entry>

--- a/webapi/tct-webaudio-w3c-tests/tests.xml
+++ b/webapi/tct-webaudio-w3c-tests/tests.xml
@@ -887,7 +887,7 @@
           <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_length_exists.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="offlineaudiocontext_length" purpose="Check if OfflineAudioContext.length is readonly and same as the value in the constructor">
+      <testcase component="W3C_HTML5 APIs/Media/Web Audio API" execution_type="auto" id="offlineaudiocontext_length" purpose="Check if OfflineAudioContext.length is readonly and same as the value in the constructor" subcase="2">
         <description>
           <test_script_entry>/opt/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_length.html</test_script_entry>
         </description>

--- a/webapi/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_length.html
+++ b/webapi/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_length.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2016 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        He Yue <yue.he@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebAudio Test: offlineaudiocontext_length</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="https://webaudio.github.io/web-audio-api/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+
+var offlineAudioContext = new webkitOfflineAudioContext(1, 256, 44100);
+test(function () {
+  assert_readonly(offlineAudioContext, "length", "the attribute length is readonly");
+}, "Check if The type of OfflineAudioContext.length is readonly");
+
+test(function () {
+  assert_equals(offlineAudioContext.length, 256, "the length is same as the length value in the constructor");
+}, "Check the length value is same as the value in the constructor");
+</script>

--- a/webapi/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_length_exists.html
+++ b/webapi/tct-webaudio-w3c-tests/webaudio/offlineaudiocontext_length_exists.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2016 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        He Yue <yue.he@intel.com>
+
+-->
+
+<html>
+  <head>
+    <title>WebAudio Test: offlineaudiocontext_length_exists</title>
+    <link rel="author" title="Intel" href="http://www.intel.com" />
+    <link rel="help" href="https://webaudio.github.io/web-audio-api/#the-offlineaudiocontext-interface" />
+    <meta name="flags" content="" />
+    <meta name="assert" content="Check if OfflineAudioContext.length attribute exists" />
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script type="text/javascript">
+        test(function () {
+            var offlineAudioContext = new webkitOfflineAudioContext(1, 256, 44100);
+            assert_true("length" in offlineAudioContext, "Check if OfflineAudioContext.length attribute exists");
+        }, document.title);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Chromium 51 add the length attribute.
add test cases to check length attribute exist, is readonly and the value is same as the the value in the constructor

Imapcted tests(approved): new 3, update 0, delete 0
Unit test platform: Crosswalk Project for Android 21.51.541.0
Unit test result summary: pass 3, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/CTS-1777