### PR TITLE
[Embeddingapi] Fix the testNotCalledForExistingContentUrl fail issue

### DIFF
--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/AndroidManifest.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/AndroidManifest.xml
@@ -39,7 +39,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <provider android:name="org.xwalk.embedding.base.AsynctestContentProvider" android:authorities="org.xwalk.embedding.base.AsynctestContentProvider" />
+        <provider android:name="org.xwalk.embedding.base.TestContentProvider" android:authorities="org.xwalk.embedding.base.TestContentProvider" />
 
         <uses-library android:name="android.test.runner" />
     </application>

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/asynctest/v6/ShouldInterceptLoadRequestTestAsync.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/asynctest/v6/ShouldInterceptLoadRequestTestAsync.java
@@ -17,7 +17,7 @@ import org.chromium.content.browser.test.util.TestCallbackHelperContainer.OnRece
 
 import org.xwalk.embedding.base.OnLoadStartedHelper;
 import org.xwalk.embedding.base.ShouldInterceptLoadRequestHelper2;
-import org.xwalk.embedding.base.AsynctestContentProvider;
+import org.xwalk.embedding.base.TestContentProvider;
 import org.xwalk.embedding.base.TestXWalkResourceClientBase;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 import org.xwalk.embedding.util.CommonResources;
@@ -376,13 +376,13 @@ public class ShouldInterceptLoadRequestTestAsync extends XWalkViewTestBase {
  @Feature({"ShouldInterceptLoadRequest"})
  public void testNotCalledForExistingContentUrl() throws Throwable {
      final String contentResourceName = "target";
-     final String existingContentUrl = AsynctestContentProvider.createContentUrl(contentResourceName);
-     AsynctestContentProvider.resetResourceRequestCount(
+     final String existingContentUrl = TestContentProvider.createContentUrl(contentResourceName);
+     TestContentProvider.resetResourceRequestCount(
              getInstrumentation().getTargetContext(), contentResourceName);
 
      notCalledForUrlTemplate(existingContentUrl);
 
-     int contentRequestCount = AsynctestContentProvider.getResourceRequestCount(
+     int contentRequestCount = TestContentProvider.getResourceRequestCount(
              getInstrumentation().getTargetContext(), contentResourceName);
      assertEquals(1, contentRequestCount);
  }

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestContentProvider.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestContentProvider.java
@@ -16,7 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 // Note: if you move this class, make sure you have also updated AndroidManifest.xml
-public class AsynctestContentProvider extends ContentProvider {
+public class TestContentProvider extends ContentProvider {
     private static final String AUTHORITY =
             "org.xwalk.embedding.base.TestContentProvider";
     private static final String CONTENT_SCHEME = "content://";
@@ -54,7 +54,7 @@ public class AsynctestContentProvider extends ContentProvider {
         context.getContentResolver().query(uri, null, null, null, null);
     }
 
-    public AsynctestContentProvider() {
+    public TestContentProvider() {
         super();
         mResourceRequestCount = new HashMap<String, Integer>();
     }

--- a/tools/build/pack.py
+++ b/tools/build/pack.py
@@ -250,12 +250,6 @@ def packAPP(build_json=None, app_src=None, app_dest=None, app_name=None):
                     '<provider android:name=\"org.xwalk.embedding.base.TestContentProvider\"' +
                     ' android:authorities=\"org.xwalk.embedding.base.TestContentProvider\" />',
                     "")
-                utils.replaceUserString(
-                    app_src,
-                    'AndroidManifest.xml',
-                    '<provider android:name=\"org.xwalk.embedding.base.AsynctestContentProvider\"' +
-                    ' android:authorities=\"org.xwalk.embedding.base.AsynctestContentProvider\" />',
-                    "")
             main_dest = os.path.join(app_src, "src/org/xwalk/embedding")
             utils.replaceUserString(
                 main_dest,


### PR DESCRIPTION
Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android 21.50.537.0
Unit test result summary: pass 1, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/CTS-1784