### PR TITLE
[lint] Update setuptools for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 before_script:
   - sudo apt-get install python-demjson
   - sudo apt-get install libxml2-utils
+  - pip install --upgrade setuptools
   - pip install html5lib
   - easy_install demjson
 


### PR DESCRIPTION
Update Python setuptools so the Travis-CI will not fail to
install some recent Python packages.