### PR TITLE
[ATIP] Add new step to fix incompatibility issue

### DIFF
--- a/tools/atip/atip/android/steps.py
+++ b/tools/atip/atip/android/steps.py
@@ -141,6 +141,17 @@ def click_view(context, params_kw):
     assert context.android.clickObject(ob[0])
 
 
+@step(u'I click app "{app_name}" from task manager')
+def click_app_from_task_manager(context, app_name):
+    kw_prefix = "description="
+    # On Xiaomi Pad2, app should be clicked by text
+    if context.android.productName == "latte":
+        kw_prefix = "text="
+    ob = context.android.selectObjectBy(kw_prefix + app_name)
+    assert ob.exists
+    assert context.android.clickObject(ob[0])
+
+
 # get the saved ui object from key and if exists then click it.
 @step(u'I click saved object "{key}"')
 def click_object(context, key):

--- a/wrt/wrt-uxmanu-tests/wrt-ux-app/testscripts/Crosswalk_WebApp_Integration_Switch.feature
+++ b/wrt/wrt-uxmanu-tests/wrt-ux-app/testscripts/Crosswalk_WebApp_Integration_Switch.feature
@@ -6,7 +6,7 @@ Feature: wrt-ux-app
     And launch "wrt-ux-app"
    Then I should see title "test"
     And I press "recent" hardware key
-    And I click view "description=touch_gesture_click"
+    And I click app "touch_gesture_click" from task manager
    Then I should see view "description=World Wide Web Consortium (W3C)" in 30 seconds
     And I click view "description=PARTICIPATE"
    Then I should see view "description=Participate - W3C" in 60 seconds


### PR DESCRIPTION
  in clicking app from task manager between Xiaomi Pad2 and other devices

  Impacted tests(approved): new 0, update 1, delete 0
  Unit test platform: [Xiaomi Pad2][Memo8]
  Unit test result summary: pass 1, fail 0, block 0
  BUG=https://crosswalk-project.org/jira/browse/CTS-150