### PR TITLE
[Cordova] Restore minSdkVersion to 14 for Cordova Lite tests

### DIFF
--- a/cordova/cordova-lite-android-tests/lite/comm.py
+++ b/cordova/cordova-lite-android-tests/lite/comm.py
@@ -248,7 +248,7 @@ def build(appname, isDebug, self, isCopy=False, isMultipleApk=True):
         cmd_mode = "--release"
         apk_name_mode = "release-unsigned"
 
-    cmd = "cordova build android %s -- --gradleArg=-PcdvBuildArch=%s --minSdkVersion=16" % (cmd_mode, pack_arch_tmp)
+    cmd = "cordova build android %s -- --gradleArg=-PcdvBuildArch=%s" % (cmd_mode, pack_arch_tmp)
 
     print cmd
     buildstatus = commands.getstatusoutput(cmd)
@@ -288,7 +288,7 @@ def checkApkExist(appname, self, isCopy=False, isMultipleApk=True, apk_name_mode
 def run(appname, self):
     os.chdir(os.path.join(tool_path, appname))
     print "Run project %s ----------------> START" % appname
-    cmd = "cordova run android -- --minSdkVersion=16"
+    cmd = "cordova run android"
     print cmd
     runstatus = commands.getstatusoutput(cmd)
     self.assertEquals(0, runstatus[0])


### PR DESCRIPTION
Restore minSdkVersion changes for Cordova Lite tests in https://github.com/crosswalk-project/crosswalk-test-suite/pull/3702, keep using minSdkVersion=14, because Crosswalk lite still use Crosswalk 17 as default version, and minSdkVersion=16 is effective from Crosswalk 20.

https://crosswalk-project.org/jira/browse/CTS-1831