### PR TITLE
[release] Fix cca build issue with --minSdkVersion=16

### DIFF
--- a/tools/build/pack_cordova_sample.py
+++ b/tools/build/pack_cordova_sample.py
@@ -548,9 +548,9 @@ def packGoogleApp(app_name=None):
     if BUILD_PARAMETERS.pkgarch and BUILD_PARAMETERS.pkgarch != "arm":
         apk_name_arch = BUILD_PARAMETERS.pkgarch
 
-    build_cmd = "cca build android"
+    build_cmd = "cca build android --android-minSdkVersion=16"
     if BUILD_PARAMETERS.pkgarch == "x86_64" or BUILD_PARAMETERS.pkgarch == "arm64":
-        build_cmd = "cca build android --xwalk64bit"
+        build_cmd = "cca build android --xwalk64bit --android-minSdkVersion=16"
 
     if not doCMD(build_cmd, DEFAULT_CMD_TIMEOUT * 2):
         os.chdir(orig_dir)


### PR DESCRIPTION
Fix the cca build that can't recoginzed --minSdkVersion=16.
The solution for cca build is to use option --android-minSdkVersion=16

BUG=https://crosswalk-project.org/jira/browse/XWALK-7101