### PR TITLE
[release] Remove the workaround of XWALK-7083

### DIFF
--- a/tools/build/build_cordova.py
+++ b/tools/build/build_cordova.py
@@ -166,7 +166,7 @@ def packCordova(
         elif BUILD_PARAMETERS.pkgarch == "arm64":
             pack_arch_tmp = "arm --xwalk64bit"
 
-    pack_cmd = "cordova build android -- --gradleArg=-PcdvBuildArch=%s --minSdkVersion=16" % pack_arch_tmp
+    pack_cmd = "cordova build android -- --gradleArg=-PcdvBuildArch=%s" % pack_arch_tmp
 
     if not utils.doCMD(pack_cmd, DEFAULT_CMD_TIMEOUT):
         os.chdir(orig_dir)

--- a/tools/build/pack_cordova_sample.py
+++ b/tools/build/pack_cordova_sample.py
@@ -393,7 +393,7 @@ def buildCordovaCliApk(app_name, orig_dir):
         elif BUILD_PARAMETERS.pkgarch == "arm64":
             pack_arch_tmp = "arm --xwalk64bit"
 
-    pack_cmd = "cordova build android -- --gradleArg=-PcdvBuildArch=%s --minSdkVersion=16" % pack_arch_tmp
+    pack_cmd = "cordova build android -- --gradleArg=-PcdvBuildArch=%s" % pack_arch_tmp
 
     cmd_mode = ""
     apk_name_mode = "debug"
@@ -402,7 +402,7 @@ def buildCordovaCliApk(app_name, orig_dir):
     if checkContains(app_name, "SAMPLERELEASE"):
         cmd_mode = "--release"
         apk_name_mode = "release-unsigned"
-    pack_cmd = "cordova build android %s -- --gradleArg=-PcdvBuildArch=%s --minSdkVersion=16" % (cmd_mode, pack_arch_tmp)
+    pack_cmd = "cordova build android %s -- --gradleArg=-PcdvBuildArch=%s" % (cmd_mode, pack_arch_tmp)
 
     if not doCMD(pack_cmd, DEFAULT_CMD_TIMEOUT * 5):
         os.chdir(orig_dir)


### PR DESCRIPTION
Bug XWALK-7083 has been fixed in the cordova-plugin-crosswalk-webview.
So remove the workaround in the scripts.