### PR TITLE
[Cordova] Remove minSdkVersion parameter.

### DIFF
--- a/cordova/cordova-feature-android-tests/feature/comm.py
+++ b/cordova/cordova-feature-android-tests/feature/comm.py
@@ -248,7 +248,7 @@ def build(appname, isDebug, self, isCopy=False, isMultipleApk=True):
         cmd_mode = "--release"
         apk_name_mode = "release-unsigned"
 
-    cmd = "cordova build android %s -- --gradleArg=-PcdvBuildArch=%s --minSdkVersion=16" % (cmd_mode, pack_arch_tmp)
+    cmd = "cordova build android %s -- --gradleArg=-PcdvBuildArch=%s" % (cmd_mode, pack_arch_tmp)
 
     print cmd
     buildstatus = commands.getstatusoutput(cmd)
@@ -288,7 +288,7 @@ def checkApkExist(appname, self, isCopy=False, isMultipleApk=True, apk_name_mode
 def run(appname, self):
     os.chdir(os.path.join(tool_path, appname))
     print "Run project %s ----------------> START" % appname
-    cmd = "cordova run android -- --minSdkVersion=16"
+    cmd = "cordova run android"
     print cmd
     runstatus = commands.getstatusoutput(cmd)
     self.assertEquals(0, runstatus[0])

--- a/cordova/cordova-sampleapp-android-tests/sampleapp/comm.py
+++ b/cordova/cordova-sampleapp-android-tests/sampleapp/comm.py
@@ -254,7 +254,7 @@ def build(appname, isDebug, self, isCopy=False, isMultipleApk=True):
         cmd_mode = "--release"
         apk_name_mode = "release-unsigned"
 
-    cmd = "cordova build android %s -- --gradleArg=-PcdvBuildArch=%s --minSdkVersion=16" % (cmd_mode, pack_arch_tmp)
+    cmd = "cordova build android %s -- --gradleArg=-PcdvBuildArch=%s" % (cmd_mode, pack_arch_tmp)
 
     print cmd
     buildstatus = commands.getstatusoutput(cmd)
@@ -294,7 +294,7 @@ def checkApkExist(appname, self, isCopy=False, isMultipleApk=True, apk_name_mode
 def run(appname, self):
     os.chdir(os.path.join(tool_path, appname))
     print "Run project %s ----------------> START" % appname
-    cmd = "cordova run android -- --minSdkVersion=16"
+    cmd = "cordova run android"
     print cmd
     runstatus = commands.getstatusoutput(cmd)
     self.assertEquals(0, runstatus[0])

--- a/cordova/cordova-sampleapp-android-tests/sampleapp/res/GoogleMapsPlugin/google-maps-plugin.py
+++ b/cordova/cordova-sampleapp-android-tests/sampleapp/res/GoogleMapsPlugin/google-maps-plugin.py
@@ -119,7 +119,7 @@ def buildHelloMap(key):
     else:
         pack_arch = ARCH
 
-    os.system('cordova build android -- --gradleArg=-PcdvBuildArch=%s --minSdkVersion=16' % pack_arch)
+    os.system('cordova build android -- --gradleArg=-PcdvBuildArch=%s' % pack_arch)
     time.sleep(5)
     files = glob.glob(os.path.join(build_src + "/platforms/android/build/outputs/apk", "*-debug.apk"))
     if len(files) == 0:

--- a/cordova/cordova-webapp-android-tests/webapp/comm.py
+++ b/cordova/cordova-webapp-android-tests/webapp/comm.py
@@ -248,7 +248,7 @@ def build(appname, isDebug, self, isCopy=False, isMultipleApk=True):
         cmd_mode = "--release"
         apk_name_mode = "release-unsigned"
 
-    cmd = "cordova build android %s -- --gradleArg=-PcdvBuildArch=%s --minSdkVersion=16" % (cmd_mode, pack_arch_tmp)
+    cmd = "cordova build android %s -- --gradleArg=-PcdvBuildArch=%s" % (cmd_mode, pack_arch_tmp)
 
     print cmd
     buildstatus = commands.getstatusoutput(cmd)
@@ -288,7 +288,7 @@ def checkApkExist(appname, self, isCopy=False, isMultipleApk=True, apk_name_mode
 def run(appname, self):
     os.chdir(os.path.join(tool_path, appname))
     print "Run project %s ----------------> START" % appname
-    cmd = "cordova run android -- --minSdkVersion=16"
+    cmd = "cordova run android"
     print cmd
     runstatus = commands.getstatusoutput(cmd)
     self.assertEquals(0, runstatus[0])

--- a/usecase/usecase-cordova-android-tests/res/comm.py
+++ b/usecase/usecase-cordova-android-tests/res/comm.py
@@ -180,7 +180,7 @@ def removeWebviewPlugin():
 
 def build(appname, pkgarch="arm"):
     print "Build project %s ----------------> START" % appname
-    cmd = "cordova build android -- --gradleArg=-PcdvBuildArch=%s --minSdkVersion=16" % pkgarch
+    cmd = "cordova build android -- --gradleArg=-PcdvBuildArch=%s" % pkgarch
     print cmd
     buildstatus = os.system(cmd)
     print "\nBuild project %s ----------------> OK\n" % appname
@@ -201,7 +201,7 @@ def checkApkRun(pkg_name):
 
 def run(app_name):
     print "Run project %s ----------------> START" % app_name
-    cmd = "cordova run android -- --minSdkVersion=16"
+    cmd = "cordova run android"
     print cmd
     os.system(cmd)
     print "\nRun project %s ----------------> OK\n" % app_name

--- a/usecase/usecase-cordova-android-tests/samples/CordovaPackage/res/test.py
+++ b/usecase/usecase-cordova-android-tests/samples/CordovaPackage/res/test.py
@@ -115,9 +115,6 @@ for node in preferences:
 
 
 pack_arch_opt = ""
-#https://crosswalk-project.org/jira/browse/CTS-1831
-#Upgrade the value of minSdkVersion parameter from 14(default) to 16 
-min_sdk_version = "-- --minSdkVersion=16"
 if BUILD_PARAMETERS.pkgarch and BUILD_PARAMETERS.pkgmode == "embedded":
     pack_arch_type = BUILD_PARAMETERS.pkgarch
     if BUILD_PARAMETERS.pkgarch == "x86":
@@ -129,11 +126,9 @@ if BUILD_PARAMETERS.pkgarch and BUILD_PARAMETERS.pkgmode == "embedded":
     elif BUILD_PARAMETERS.pkgarch == "arm64":
         pack_arch_type = "armv7 --xwalk64bit"
     pack_arch_opt = "-- --gradleArg=-PcdvBuildArch=%s" % pack_arch_type
-    min_sdk_version = "--minSdkVersion=16"
 
-
-os.system("cordova build android %s %s" % (pack_arch_opt, min_sdk_version))
-os.system("cordova run android %s %s" % (pack_arch_opt, min_sdk_version))
+os.system("cordova build android %s" % pack_arch_opt)
+os.system("cordova run android %s" % pack_arch_opt)
 
 comm.checkApkExist("./platforms/android/build/outputs/apk/*.apk")
 comm.checkApkRun(pkg_name)

--- a/usecase/usecase-cordova-android-tests/samples/Database/res/test.py
+++ b/usecase/usecase-cordova-android-tests/samples/Database/res/test.py
@@ -36,7 +36,7 @@ os.system("cordova create database org.xwalk.database database")
 os.chdir("./database")
 os.system("cordova platform add android")
 os.system("cp -r ../database_source/* www/")
-os.system("cordova build android -- --minSdkVersion=16")
+os.system("cordova build android")
 lsstatus = commands.getstatusoutput("ls ./platforms/android/build/outputs/apk/android-debug.apk &>/dev/null")
 if lsstatus[0] == 0:
     os.system("cp ./platforms/android/build/outputs/apk/android-debug.apk ../../../database_upstream.apk")

--- a/usecase/usecase-cordova-android-tests/samples/DefaultCrosswalkVersion/index.html
+++ b/usecase/usecase-cordova-android-tests/samples/DefaultCrosswalkVersion/index.html
@@ -61,7 +61,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         (1. For npm release testing, plugin should be https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview#release-testing)<br/>
         (2. No need build shared mode for default version, only for embedded mode)</li>
     <li>Build test app<br/>
-        $ cordova build android -- --minSdkVersion=16</li>
+        $ cordova build android</li>
     <li>Find test app in foo/platforms/android/build/outputs/apk</li>
     <li>Install correct version apk for test device</li>
  </li>


### PR DESCRIPTION
Since bug CTS-1831 has been fixed by cordova-plugin-crosswalk-webview supporting minSdkVersion to be 16 as default,
no need workaround to add minSdkVersion parameter for cordova build/run commands.
@haoxli PTAL