### PR TITLE
[Crosswalk-21][Embeddingapi]Add tests for setCacheMode API in XWalkSettings

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -1529,4 +1529,43 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
+
+    protected void loadUrlSyncAndExpectError(final String url) throws Exception {
+        CallbackHelper onPageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
+        CallbackHelper onReceivedErrorHelper = mTestHelperBridge.getOnReceivedErrorHelper();
+        int onErrorCallCount = onReceivedErrorHelper.getCallCount();
+        int onFinishedCallCount = onPageFinishedHelper.getCallCount();
+        loadUrlAsync(url);
+        onReceivedErrorHelper.waitForCallback(onErrorCallCount, 1, WAIT_TIMEOUT_MS,
+                TimeUnit.MILLISECONDS);
+        onPageFinishedHelper.waitForCallback(onFinishedCallCount, 1, WAIT_TIMEOUT_MS,
+                TimeUnit.MILLISECONDS);
+    }
+
+    protected void setCacheMode(final int value) throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.getSettings().setCacheMode(value);
+            }
+        });
+    }
+
+    protected int getCacheMode() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception{
+                return mXWalkView.getSettings().getCacheMode();
+            }
+        });
+    }
+
+    protected void setBlockNetworkLoads(final boolean value) throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.getSettings().setBlockNetworkLoads(value);
+            }
+        });
+    }
 }

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v7/XWalkSettingTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v7/XWalkSettingTest.java
@@ -1,15 +1,12 @@
 package org.xwalk.embedding.test.v7;
 
+import android.test.suitebuilder.annotation.MediumTest;
 import android.test.suitebuilder.annotation.SmallTest;
+
+import org.xwalk.core.XWalkSettings;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 
 public class XWalkSettingTest extends XWalkViewTestBase {
-
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-    }
-
 
     @SmallTest
     public void testLoadWithOverviewModeWithTwoViews() {
@@ -39,6 +36,81 @@ public class XWalkSettingTest extends XWalkViewTestBase {
                             views.getView0(), views.getBridge0(), true),
                     new XWalkSettingsLoadWithOverviewModeTestHelper(
                             views.getView1(), views.getBridge1(), true));
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @MediumTest
+    public void testCacheMode() {
+        try {
+            final String htmlPath = "/testCacheMode.html";
+            final String url = mWebServer.setResponse(htmlPath, "response", null);
+            final String htmlNotInCachePath = "/testCacheMode-not-in-cache.html";
+            final String urlNotInCache = mWebServer.setResponse(htmlNotInCachePath, "", null);
+
+            clearCacheOnUiThread(true);
+            assertEquals(XWalkSettings.LOAD_DEFAULT, getCacheMode());
+
+            setCacheMode(XWalkSettings.LOAD_CACHE_ELSE_NETWORK);
+            loadUrlSync(url);
+            assertEquals(1, mWebServer.getRequestCount(htmlPath));
+            loadUrlSync(url);
+            assertEquals(1, mWebServer.getRequestCount(htmlPath));
+
+            setCacheMode(XWalkSettings.LOAD_NO_CACHE);
+            loadUrlSync(url);
+            assertEquals(2, mWebServer.getRequestCount(htmlPath));
+            loadUrlSync(url);
+            assertEquals(3, mWebServer.getRequestCount(htmlPath));
+
+            setCacheMode(XWalkSettings.LOAD_CACHE_ONLY);
+            loadUrlSync(url);
+            assertEquals(3, mWebServer.getRequestCount(htmlPath));
+            loadUrlSync(url);
+            assertEquals(3, mWebServer.getRequestCount(htmlPath));
+
+            loadUrlSyncAndExpectError(urlNotInCache);
+            assertEquals(0, mWebServer.getRequestCount(htmlNotInCachePath));
+
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @MediumTest
+    public void testCacheModeWithBlockedNetworkLoads() {
+        try {
+            final String htmlPath = "/testCacheModeWithBlockedNetworkLoads.html";
+            final String url = mWebServer.setResponse(htmlPath, "response", null);
+
+            clearCacheOnUiThread(true);
+            assertEquals(XWalkSettings.LOAD_DEFAULT, getCacheMode());
+
+            setBlockNetworkLoads(true);
+            loadUrlSyncAndExpectError(url);
+            assertEquals(0, mWebServer.getRequestCount(htmlPath));
+
+            setCacheMode(XWalkSettings.LOAD_CACHE_ELSE_NETWORK);
+            loadUrlSyncAndExpectError(url);
+            assertEquals(0, mWebServer.getRequestCount(htmlPath));
+
+            setCacheMode(XWalkSettings.LOAD_NO_CACHE);
+            loadUrlSyncAndExpectError(url);
+            assertEquals(0, mWebServer.getRequestCount(htmlPath));
+
+            setCacheMode(XWalkSettings.LOAD_CACHE_ONLY);
+            loadUrlSyncAndExpectError(url);
+            assertEquals(0, mWebServer.getRequestCount(htmlPath));
+
         } catch (Exception e) {
             assertTrue(false);
             e.printStackTrace();

--- a/embeddingapi/embedding-api-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-api-android-tests/tests.full.xml
@@ -153,7 +153,7 @@
           <test_script_entry>org.xwalk.embedding.test.v7.XWalkViewTest</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTest" platform="android" priority="P1" purpose="Check if the methods of XWalkSetting interface can be executed correctly." status="approved" type="functional_positive" subcase="2">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTest" platform="android" priority="P1" purpose="Check if the methods of XWalkSetting interface can be executed correctly." status="approved" type="functional_positive" subcase="4">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v7.XWalkSettingTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-api-android-tests/tests_v7.xml
+++ b/embeddingapi/embedding-api-android-tests/tests_v7.xml
@@ -8,7 +8,7 @@
           <test_script_entry>org.xwalk.embedding.test.v7.XWalkViewTest</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTest" purpose="Check if the methods of XWalkSetting interface can be executed correctly."  subcase="2">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTest" purpose="Check if the methods of XWalkSetting interface can be executed correctly."  subcase="4">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v7.XWalkSettingTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/asynctest/v7/XWalkSettingTestAsync.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/asynctest/v7/XWalkSettingTestAsync.java
@@ -1,15 +1,12 @@
 package org.xwalk.embedding.asynctest.v7;
 
+import android.test.suitebuilder.annotation.MediumTest;
 import android.test.suitebuilder.annotation.SmallTest;
+
+import org.xwalk.core.XWalkSettings;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 
 public class XWalkSettingTestAsync extends XWalkViewTestBase {
-
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-    }
-
 
     @SmallTest
     public void testLoadWithOverviewModeWithTwoViews() {
@@ -39,6 +36,81 @@ public class XWalkSettingTestAsync extends XWalkViewTestBase {
                             views.getView0(), views.getBridge0(), true),
                     new XWalkSettingsLoadWithOverviewModeTestHelper(
                             views.getView1(), views.getBridge1(), true));
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @MediumTest
+    public void testCacheMode() {
+        try {
+            final String htmlPath = "/testCacheMode.html";
+            final String url = mWebServer.setResponse(htmlPath, "response", null);
+            final String htmlNotInCachePath = "/testCacheMode-not-in-cache.html";
+            final String urlNotInCache = mWebServer.setResponse(htmlNotInCachePath, "", null);
+
+            clearCacheOnUiThread(true);
+            assertEquals(XWalkSettings.LOAD_DEFAULT, getCacheMode());
+
+            setCacheMode(XWalkSettings.LOAD_CACHE_ELSE_NETWORK);
+            loadUrlSync(url);
+            assertEquals(1, mWebServer.getRequestCount(htmlPath));
+            loadUrlSync(url);
+            assertEquals(1, mWebServer.getRequestCount(htmlPath));
+
+            setCacheMode(XWalkSettings.LOAD_NO_CACHE);
+            loadUrlSync(url);
+            assertEquals(2, mWebServer.getRequestCount(htmlPath));
+            loadUrlSync(url);
+            assertEquals(3, mWebServer.getRequestCount(htmlPath));
+
+            setCacheMode(XWalkSettings.LOAD_CACHE_ONLY);
+            loadUrlSync(url);
+            assertEquals(3, mWebServer.getRequestCount(htmlPath));
+            loadUrlSync(url);
+            assertEquals(3, mWebServer.getRequestCount(htmlPath));
+
+            loadUrlSyncAndExpectError(urlNotInCache);
+            assertEquals(0, mWebServer.getRequestCount(htmlNotInCachePath));
+
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @MediumTest
+    public void testCacheModeWithBlockedNetworkLoads() {
+        try {
+            final String htmlPath = "/testCacheModeWithBlockedNetworkLoads.html";
+            final String url = mWebServer.setResponse(htmlPath, "response", null);
+
+            clearCacheOnUiThread(true);
+            assertEquals(XWalkSettings.LOAD_DEFAULT, getCacheMode());
+
+            setBlockNetworkLoads(true);
+            loadUrlSyncAndExpectError(url);
+            assertEquals(0, mWebServer.getRequestCount(htmlPath));
+
+            setCacheMode(XWalkSettings.LOAD_CACHE_ELSE_NETWORK);
+            loadUrlSyncAndExpectError(url);
+            assertEquals(0, mWebServer.getRequestCount(htmlPath));
+
+            setCacheMode(XWalkSettings.LOAD_NO_CACHE);
+            loadUrlSyncAndExpectError(url);
+            assertEquals(0, mWebServer.getRequestCount(htmlPath));
+
+            setCacheMode(XWalkSettings.LOAD_CACHE_ONLY);
+            loadUrlSyncAndExpectError(url);
+            assertEquals(0, mWebServer.getRequestCount(htmlPath));
+
         } catch (Exception e) {
             assertTrue(false);
             e.printStackTrace();

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -1497,4 +1497,43 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
+
+    protected void loadUrlSyncAndExpectError(final String url) throws Exception {
+        CallbackHelper onPageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
+        CallbackHelper onReceivedErrorHelper = mTestHelperBridge.getOnReceivedErrorHelper();
+        int onErrorCallCount = onReceivedErrorHelper.getCallCount();
+        int onFinishedCallCount = onPageFinishedHelper.getCallCount();
+        loadUrlAsync(url);
+        onReceivedErrorHelper.waitForCallback(onErrorCallCount, 1, WAIT_TIMEOUT_MS,
+                TimeUnit.MILLISECONDS);
+        onPageFinishedHelper.waitForCallback(onFinishedCallCount, 1, WAIT_TIMEOUT_MS,
+                TimeUnit.MILLISECONDS);
+    }
+
+    protected void setCacheMode(final int value) throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.getSettings().setCacheMode(value);
+            }
+        });
+    }
+
+    protected int getCacheMode() throws Exception {
+        return runTestOnUiThreadAndGetResult(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception{
+                return mXWalkView.getSettings().getCacheMode();
+            }
+        });
+    }
+
+    protected void setBlockNetworkLoads(final boolean value) throws Exception {
+        getInstrumentation().runOnMainSync(new Runnable() {
+            @Override
+            public void run() {
+                mXWalkView.getSettings().setBlockNetworkLoads(value);
+            }
+        });
+    }
 }

--- a/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
@@ -153,7 +153,7 @@
           <test_script_entry>org.xwalk.embedding.asynctest.v7.XWalkViewTestAsync</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTestAsync" platform="android" priority="P1" purpose="Check if the methods of XWalkSetting interface can be executed correctly." subcase="2">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTestAsync" platform="android" priority="P1" purpose="Check if the methods of XWalkSetting interface can be executed correctly." subcase="4">
         <description>
           <test_script_entry>org.xwalk.embedding.asynctest.v7.XWalkSettingTestAsync</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/tests_v7.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests_v7.xml
@@ -8,7 +8,7 @@
           <test_script_entry>org.xwalk.embedding.asynctest.v7.XWalkViewTestAsync</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTestAsync" purpose="Check if the methods of XWalkSetting interface can be executed correctly." subcase="2">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTestAsync" purpose="Check if the methods of XWalkSetting interface can be executed correctly." subcase="4">
         <description>
           <test_script_entry>org.xwalk.embedding.asynctest.v7.XWalkSettingTestAsync</test_script_entry>
         </description>


### PR DESCRIPTION
Test APIs:
set/getCacheMode
set/getBlockNetworkLoads

Impacted tests(approved): new 4, update 0, delete 0
Unit test platform: Crosswalk for Android 21.51.548.0
Unit test result summary: pass 4, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/CTS-1822