### PR TITLE
[Embeddingapi] Correct subcase number in v7.XWalkSettingTest

### DIFF
--- a/embeddingapi/embedding-api-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-api-android-tests/tests.full.xml
@@ -153,7 +153,7 @@
           <test_script_entry>org.xwalk.embedding.test.v7.XWalkViewTest</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTest" platform="android" priority="P1" purpose="Check if the methods of XWalkSetting interface can be executed correctly." status="approved" type="functional_positive" subcase="13">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTest" platform="android" priority="P1" purpose="Check if the methods of XWalkSetting interface can be executed correctly." status="approved" type="functional_positive" subcase="11">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v7.XWalkSettingTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-api-android-tests/tests_v7.xml
+++ b/embeddingapi/embedding-api-android-tests/tests_v7.xml
@@ -8,7 +8,7 @@
           <test_script_entry>org.xwalk.embedding.test.v7.XWalkViewTest</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTest" purpose="Check if the methods of XWalkSetting interface can be executed correctly."  subcase="13">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTest" purpose="Check if the methods of XWalkSetting interface can be executed correctly."  subcase="11">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v7.XWalkSettingTest</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests.full.xml
@@ -153,7 +153,7 @@
           <test_script_entry>org.xwalk.embedding.asynctest.v7.XWalkViewTestAsync</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTestAsync" platform="android" priority="P1" purpose="Check if the methods of XWalkSetting interface can be executed correctly." subcase="13">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTestAsync" platform="android" priority="P1" purpose="Check if the methods of XWalkSetting interface can be executed correctly." subcase="11">
         <description>
           <test_script_entry>org.xwalk.embedding.asynctest.v7.XWalkSettingTestAsync</test_script_entry>
         </description>

--- a/embeddingapi/embedding-asyncapi-android-tests/tests_v7.xml
+++ b/embeddingapi/embedding-asyncapi-android-tests/tests_v7.xml
@@ -8,7 +8,7 @@
           <test_script_entry>org.xwalk.embedding.asynctest.v7.XWalkViewTestAsync</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTestAsync" purpose="Check if the methods of XWalkSetting interface can be executed correctly." subcase="13">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v7.XWalkSettingTestAsync" purpose="Check if the methods of XWalkSetting interface can be executed correctly." subcase="11">
         <description>
           <test_script_entry>org.xwalk.embedding.asynctest.v7.XWalkSettingTestAsync</test_script_entry>
         </description>


### PR DESCRIPTION
There should be 11 subcases in v7.XWalkSettingTest(7 new tests
 added by commit fb02b606f52c242ea9a9c202205734935d5801b4)

https://crosswalk-project.org/jira/browse/CTS-1819