### PR TITLE
[Embeddingapi] Add tests for setDatabaseEnable API in XWalkSettings

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/AndroidManifest.xml
@@ -737,6 +737,15 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".setting.XWalkViewSettingDatabaseEnabledAsync"
+            android:label="@string/title_activity_xwalk_view_setting_database_enabled_async"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Setting" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".setting.XWalkViewSettingDomStorageEnabledAsync"
             android:label="@string/title_activity_xwalk_view_setting_dom_storage_enabled_async"
             android:parentActivityName=".XWalkEmbeddedAPISample" >

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/database_enable.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/assets/database_enable.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2016 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<html>
+    <body onload='checkDatabase()'>
+        Database Storage: <span id="result">N/A</span>
+    </body>
+    <script>
+        var logDiv = document.getElementById("result");
+        function checkDatabase() {
+            try {
+                var db;
+                if ('openDatabase' in window) {
+                    db = window.openDatabase('test', '1.0', 'results', 1*1024*1024);
+                }
+                logDiv.innerHTML = db ? "Enabled" : "Disabled";
+            }catch(e) {
+                if (e.name == "SecurityError") {
+                    logDiv.innerHTML = "Disabled";
+                } else {
+                    logDiv.innerHTML = e;
+                }
+            }
+        }
+    </script>
+</html>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_setting_database_enable_async.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/layout/activity_xwalk_view_setting_database_enable_async.xml
@@ -1,0 +1,35 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.sample.setting.XWalkViewSettingDatabaseEnabledAsync">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Check that XWalkView can enable/disable Database storage. Click the button to enable/disable Database storage."
+        android:id="@+id/textView" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/message_tv"
+        android:textColor="#00ff00"
+        android:layout_below="@+id/textView"/>
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/switch_al"
+        android:layout_below="@+id/message_tv"
+        android:layout_alignParentStart="true" />
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/switch_al" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/res/values/strings.xml
@@ -109,6 +109,7 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_setting_default_fixed_font_size_async">
         XWalkViewSettingDefaultFixedFontSizeAsync
     </string>
+    <string name="title_activity_xwalk_view_setting_database_enabled_async">XWalkViewSettingDatabaseEnabledAsync</string>
     <string name="title_activity_xwalk_view_setting_dom_storage_enabled_async">XWalkViewSettingDomStorageEnabledAsync</string>
     <string name="title_activity_xwalk_view_setting_save_form_data_async">XWalkViewSettingSaveFormDataAsync</string>
     <string name="title_activity_xwalk_view_setting_javascript_enabled_async">XWalkViewSettingJavaScriptEnabledAsync</string>

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/README.md
@@ -944,3 +944,11 @@ This usecase covers following interface and methods:
 
 * XWalkSettings interface: setJavaScriptCanOpenWindowsAutomatically, getJavaScriptCanOpenWindowsAutomatically
 
+### 92. The [XWalkViewSettingDatabaseEnabledAsync](setting/XWalkViewSettingDatabaseEnabledAsync.java) sample check XWalkView can enable/disable Database storage, include:
+
+* XWalkView can enable Database storage
+* XWalkView can disable Database storage
+
+This usecase covers following interface and methods:
+
+* XWalkSettings interface: setDatabaseEnabled, getDatabaseEnabled

--- a/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/setting/XWalkViewSettingDatabaseEnabledAsync.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi-async/src/org/xwalk/embedded/api/asyncsample/setting/XWalkViewSettingDatabaseEnabledAsync.java
@@ -1,0 +1,92 @@
+package org.xwalk.embedded.api.asyncsample.setting;
+
+import org.xwalk.core.XWalkInitializer;
+import org.xwalk.core.XWalkView;
+import org.xwalk.embedded.api.asyncsample.R;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+public class XWalkViewSettingDatabaseEnabledAsync extends Activity implements XWalkInitializer.XWalkInitListener {
+
+    private XWalkInitializer mXWalkInitializer;
+
+    public final static String ENABLE_BT = "Enable Database storage";
+    public final static String DISABLE_BT = "Disable Database storage";
+    public final static String MESSAGE_TITLE = "Database storage Enabled: ";
+
+
+    private XWalkView mXWalkView;
+    private TextView mMessage;
+    private Button mButton;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mXWalkInitializer = new XWalkInitializer(this, this);
+        mXWalkInitializer.initAsync();
+    }
+
+    @Override
+    public void onXWalkInitCancelled() {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void onXWalkInitFailed() {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void onXWalkInitStarted() {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void onXWalkInitCompleted() {
+        setContentView(R.layout.activity_xwalk_view_setting_database_enable_async);
+
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+                .append("Check if XWalkView can enable/disable Database storage.\n\n")
+                .append("Expected Result:\n\n")
+                .append("Test passes if Database storage can be enabled/disabled");
+        new  AlertDialog.Builder(this)
+                .setTitle("Info")
+                .setMessage(mess.toString())
+                .setPositiveButton("confirm", null)
+                .show();
+
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mMessage = (TextView) findViewById(R.id.message_tv);
+        mButton = (Button) findViewById(R.id.switch_al);
+        boolean defaultDatabase = mXWalkView.getSettings().getDatabaseEnabled();
+        if (defaultDatabase) {
+            mButton.setText(DISABLE_BT);
+        }else{
+            mButton.setText(ENABLE_BT);
+        }
+        mMessage.setText(MESSAGE_TITLE + defaultDatabase + "(Default)");
+        mXWalkView.load("file:///android_asset/database_enable.html", null);
+
+        mButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (ENABLE_BT.equals(mButton.getText())) {
+                    mXWalkView.getSettings().setDatabaseEnabled(true);
+                    mButton.setText(DISABLE_BT);
+                } else {
+                    mXWalkView.getSettings().setDatabaseEnabled(false);
+                    mButton.setText(ENABLE_BT);
+                }
+                mMessage.setText(MESSAGE_TITLE + mXWalkView.getSettings().getDatabaseEnabled());
+                mXWalkView.load("file:///android_asset/database_enable.html", null);
+            }
+        });
+    }
+}

--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -738,6 +738,15 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".setting.XWalkViewSettingDatabaseEnabled"
+            android:label="@string/title_activity_xwalk_view_setting_database_enabled"
+            android:parentActivityName=".XWalkEmbeddedAPISample" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="XWalkView.Setting" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".setting.XWalkViewSettingDomStorageEnabled"
             android:label="@string/title_activity_xwalk_view_setting_dom_storage_enabled"
             android:parentActivityName=".XWalkEmbeddedAPISample" >

--- a/usecase/usecase-embedding-android-tests/embeddingapi/assets/database_enable.html
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/assets/database_enable.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2016 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+<html>
+    <body onload='checkDatabase()'>
+        Database Storage: <span id="result">N/A</span>
+    </body>
+    <script>
+        var logDiv = document.getElementById("result");
+        function checkDatabase() {
+            try {
+                var db;
+                if ('openDatabase' in window) {
+                    db = window.openDatabase('test', '1.0', 'results', 1*1024*1024);
+                }
+                logDiv.innerHTML = db ? "Enabled" : "Disabled";
+            }catch(e) {
+                if (e.name == "SecurityError") {
+                    logDiv.innerHTML = "Disabled";
+                } else {
+                    logDiv.innerHTML = e;
+                }
+            }
+        }
+    </script>
+</html>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_setting_database_enable.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/layout/activity_xwalk_view_setting_database_enable.xml
@@ -1,0 +1,35 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.xwalk.embedded.api.sample.setting.XWalkViewSettingDatabaseEnabled">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Check that XWalkView can enable/disable Database storage. Click the button to enable/disable Database storage."
+        android:id="@+id/textView" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/message_tv"
+        android:textColor="#00ff00"
+        android:layout_below="@+id/textView"/>
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/switch_al"
+        android:layout_below="@+id/message_tv"
+        android:layout_alignParentStart="true" />
+
+    <org.xwalk.core.XWalkView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/xwalk_view"
+        android:layout_below="@+id/switch_al" />
+
+</RelativeLayout>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/res/values/strings.xml
@@ -98,6 +98,7 @@ found in the LICENSE file.
     <string name="title_activity_xwalk_view_setting_accept_language">
         XWalkViewSettingAcceptLanguage
     </string>
+    <string name="title_activity_xwalk_view_setting_database_enabled">XWalkViewSettingDatabaseEnabled</string>
     <string name="title_activity_xwalk_view_setting_dom_storage_enabled">XWalkViewSettingDomStorageEnabled</string>
     <string name="title_activity_xwalk_view_setting_save_form_data">XWalkViewSettingSaveFormData</string>
     <string name="title_activity_xwalk_view_setting_javascript_enabled">XWalkViewSettingJavaScriptEnabled</string>

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/README.md
@@ -943,3 +943,12 @@ This usecase covers following interface and methods:
 
 * XWalkSettings interface: setJavaScriptCanOpenWindowsAutomatically, getJavaScriptCanOpenWindowsAutomatically
 
+### 92. The [XWalkViewSettingDatabaseEnabled](setting/XWalkViewSettingDatabaseEnabled.java) sample check XWalkView can enable/disable Database storage, include:
+
+* XWalkView can enable Database storage
+* XWalkView can disable Database storage
+
+This usecase covers following interface and methods:
+
+* XWalkSettings interface: setDatabaseEnabled, getDatabaseEnabled
+

--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/setting/XWalkViewSettingDatabaseEnabled.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/setting/XWalkViewSettingDatabaseEnabled.java
@@ -1,0 +1,69 @@
+package org.xwalk.embedded.api.sample.setting;
+
+import org.xwalk.core.XWalkActivity;
+import org.xwalk.core.XWalkView;
+import org.xwalk.embedded.api.sample.R;
+
+import android.app.AlertDialog;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+public class XWalkViewSettingDatabaseEnabled extends XWalkActivity {
+
+    public final static String ENABLE_BT = "Enable Database storage";
+    public final static String DISABLE_BT = "Disable Database storage";
+    public final static String MESSAGE_TITLE = "Database storage Enabled: ";
+
+    private XWalkView mXWalkView;
+    private TextView mMessage;
+    private Button mButton;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_xwalk_view_setting_database_enable);
+    }
+
+    @Override
+    protected void onXWalkReady() {
+        StringBuffer mess = new StringBuffer();
+        mess.append("Test Purpose: \n\n")
+                .append("Check if XWalkView can enable/disable Database storage.\n\n")
+                .append("Expected Result:\n\n")
+                .append("Test passes if Database storage can be enabled/disabled");
+        new  AlertDialog.Builder(this)
+                .setTitle("Info")
+                .setMessage(mess.toString())
+                .setPositiveButton("confirm", null)
+                .show();
+
+        mXWalkView = (XWalkView) findViewById(R.id.xwalk_view);
+        mMessage = (TextView) findViewById(R.id.message_tv);
+        mButton = (Button) findViewById(R.id.switch_al);
+        boolean defaultDatabase = mXWalkView.getSettings().getDatabaseEnabled();
+        if (defaultDatabase) {
+            mButton.setText(DISABLE_BT);
+        }else{
+            mButton.setText(ENABLE_BT);
+        }
+        mMessage.setText(MESSAGE_TITLE + defaultDatabase + "(Default)");
+        mXWalkView.load("file:///android_asset/database_enable.html", null);
+
+        mButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (ENABLE_BT.equals(mButton.getText())) {
+                    mXWalkView.getSettings().setDatabaseEnabled(true);
+                    mButton.setText(DISABLE_BT);
+                } else {
+                    mXWalkView.getSettings().setDatabaseEnabled(false);
+                    mButton.setText(ENABLE_BT);
+                }
+                mMessage.setText(MESSAGE_TITLE + mXWalkView.getSettings().getDatabaseEnabled());
+                mXWalkView.load("file:///android_asset/database_enable.html", null);
+            }
+        });
+    }
+}

--- a/usecase/usecase-embedding-android-tests/tests.android.xml
+++ b/usecase/usecase-embedding-android-tests/tests.android.xml
@@ -173,6 +173,8 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingTextZoomForCss3" purpose="XWalkViewSettingTextZoomForCss3 Test With XWalkActivity">
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingDatabaseEnabled" purpose="XWalkViewSettingDatabaseEnabled Test With XWalkActivity">
+      </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingDomStorageEnabled" purpose="XWalkViewSettingDomStorageEnabled Test With XWalkActivity">
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingSaveFormData" purpose="XWalkViewSettingSaveFormData Test With XWalkActivity">
@@ -352,6 +354,8 @@
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithGetContentHeightAsync" purpose="XWalkViewWithGetContentHeightAsync Test With XWalkInitializer">
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingTextZoomForCss3Async" purpose="XWalkViewSettingTextZoomForCss3Async Test With XWalkInitializer">
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingDatabaseEnabledAsync" purpose="XWalkViewSettingDatabaseEnabledAsync Test With XWalkInitializer">
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingDomStorageEnabledAsync" purpose="XWalkViewSettingDomStorageEnabledAsync Test With XWalkInitializer">
       </testcase>

--- a/usecase/usecase-embedding-android-tests/tests.full.xml
+++ b/usecase/usecase-embedding-android-tests/tests.full.xml
@@ -179,6 +179,8 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingTextZoomForCss3" platform="android" priority="P0" purpose="XWalkViewSettingTextZoomForCss3 Test With XWalkActivity" status="approved" type="functional_positive">
       </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingDatabaseEnabled" platform="android" priority="P0" purpose="XWalkViewSettingDatabaseEnabled Test With XWalkActivity" status="approved" type="functional_positive">
+      </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingDomStorageEnabled" platform="android" priority="P0" purpose="XWalkViewSettingDomStorageEnabled Test With XWalkActivity" status="approved" type="functional_positive">
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingSaveFormData" platform="android" priority="P0" purpose="XWalkViewSettingSaveFormData Test With XWalkActivity" status="approved" type="functional_positive">
@@ -352,6 +354,8 @@
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewWithGetContentHeightAsync" platform="android" priority="P0" purpose="XWalkViewWithGetContentHeightAsync Test With XWalkInitializer" status="approved" type="functional_positive">
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingTextZoomForCss3Async" platform="android" priority="P0" purpose="XWalkViewSettingTextZoomForCss3Async Test With XWalkInitializer" status="approved" type="functional_positive">
+      </testcase>
+      <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingDatabaseEnabledAsync" platform="android" priority="P0" purpose="XWalkViewSettingDatabaseEnabledAsync Test With XWalkInitializer" status="approved" type="functional_positive">
       </testcase>
       <testcase component="Crosswalk Use Cases/Embedding API" execution_type="manual" id="XWalkViewSettingDomStorageEnabledAsync" platform="android" priority="P0" purpose="XWalkViewSettingDomStorageEnabledAsync Test With XWalkInitializer" status="approved" type="functional_positive">
       </testcase>


### PR DESCRIPTION
Test APIs:
set/getDatabaseEnable

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: Crosswalk for Android 22.52.561.0
Unit test result summary: pass 2, fail 0, block 0

https://crosswalk-project.org/jira/browse/CTS-1841