### PR TITLE
[Embeddeding] Remove useless class for Crosswalk 23.52.564.0

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewInternalTestBase.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewInternalTestBase.java
@@ -8,15 +8,8 @@ package org.xwalk.embedding.base;
 import android.app.Activity;
 import android.test.ActivityInstrumentationTestCase2;
 import android.util.Log;
-import android.view.Gravity;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.WindowManager;
-import android.widget.FrameLayout;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 
 import org.chromium.content.browser.ContentViewCore;
@@ -26,7 +19,6 @@ import org.chromium.content.browser.test.util.CriteriaHelper;
 import org.xwalk.core.internal.XWalkResourceClientInternal;
 import org.xwalk.core.internal.XWalkUIClientInternal;
 import org.xwalk.core.internal.XWalkViewInternal;
-import org.xwalk.core.internal.XWalkWebChromeClient;
 import static org.chromium.base.test.util.ScalableTimeout.scaleTimeout;
 
 public class XWalkViewInternalTestBase
@@ -93,61 +85,6 @@ public class XWalkViewInternalTestBase
         }
     }
 
-    class TestXWalkWebChromeClientBase extends XWalkWebChromeClient {
-        private CallbackHelper mOnShowCustomViewCallbackHelper = new CallbackHelper();
-        private CallbackHelper mOnHideCustomViewCallbackHelper = new CallbackHelper();
-
-        private Activity mActivity = getActivity();
-        private View mCustomView;
-        private XWalkWebChromeClient.CustomViewCallback mExitCallback;
-
-        public TestXWalkWebChromeClientBase() {
-            super(mXWalkViewInternal);
-        }
-
-        @Override
-        public void onShowCustomView(View view, XWalkWebChromeClient.CustomViewCallback callback) {
-            mCustomView = view;
-            mExitCallback = callback;
-            mActivity.getWindow().setFlags(
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN);
-
-            mActivity.getWindow().addContentView(view,
-                    new FrameLayout.LayoutParams(
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            Gravity.CENTER));
-            mOnShowCustomViewCallbackHelper.notifyCalled();
-        }
-
-        @Override
-        public void onHideCustomView() {
-            mActivity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-            mOnHideCustomViewCallbackHelper.notifyCalled();
-        }
-
-        public XWalkWebChromeClient.CustomViewCallback getExitCallback() {
-            return mExitCallback;
-        }
-
-        public View getCustomView() {
-            return mCustomView;
-        }
-
-        public boolean wasCustomViewShownCalled() {
-            return mOnShowCustomViewCallbackHelper.getCallCount() > 0;
-        }
-
-        public void waitForCustomViewShown() throws TimeoutException, InterruptedException {
-            mOnShowCustomViewCallbackHelper.waitForCallback(0, 1, WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        }
-
-        public void waitForCustomViewHidden() throws InterruptedException, TimeoutException {
-            mOnHideCustomViewCallbackHelper.waitForCallback(0, 1, WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        }
-    }
-
     void setUIClient(final XWalkUIClientInternal client) {
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
@@ -162,15 +99,6 @@ public class XWalkViewInternalTestBase
             @Override
             public void run() {
                 getXWalkView().setResourceClient(client);
-            }
-        });
-    }
-
-    void setXWalkWebChromeClient(final TestXWalkWebChromeClientBase client) {
-        getInstrumentation().runOnMainSync(new Runnable() {
-            @Override
-            public void run() {
-                mXWalkViewInternal.setXWalkWebChromeClient(client);
             }
         });
     }

--- a/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewInternalTestBase.java
+++ b/embeddingapi/embedding-asyncapi-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewInternalTestBase.java
@@ -8,15 +8,8 @@ package org.xwalk.embedding.base;
 import android.app.Activity;
 import android.test.ActivityInstrumentationTestCase2;
 import android.util.Log;
-import android.view.Gravity;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.WindowManager;
-import android.widget.FrameLayout;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 
 import org.chromium.content.browser.ContentViewCore;
@@ -26,7 +19,6 @@ import org.chromium.content.browser.test.util.CriteriaHelper;
 import org.xwalk.core.internal.XWalkResourceClientInternal;
 import org.xwalk.core.internal.XWalkUIClientInternal;
 import org.xwalk.core.internal.XWalkViewInternal;
-import org.xwalk.core.internal.XWalkWebChromeClient;
 import static org.chromium.base.test.util.ScalableTimeout.scaleTimeout;
 
 public class XWalkViewInternalTestBase
@@ -93,60 +85,6 @@ public class XWalkViewInternalTestBase
         }
     }
 
-    class TestXWalkWebChromeClientBase extends XWalkWebChromeClient {
-        private CallbackHelper mOnShowCustomViewCallbackHelper = new CallbackHelper();
-        private CallbackHelper mOnHideCustomViewCallbackHelper = new CallbackHelper();
-
-        private Activity mActivity = getActivity();
-        private View mCustomView;
-        private XWalkWebChromeClient.CustomViewCallback mExitCallback;
-
-        public TestXWalkWebChromeClientBase() {
-            super(mXWalkViewInternal);
-        }
-
-        @Override
-        public void onShowCustomView(View view, XWalkWebChromeClient.CustomViewCallback callback) {
-            mCustomView = view;
-            mExitCallback = callback;
-            mActivity.getWindow().setFlags(
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN);
-
-            mActivity.getWindow().addContentView(view,
-                    new FrameLayout.LayoutParams(
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            Gravity.CENTER));
-            mOnShowCustomViewCallbackHelper.notifyCalled();
-        }
-
-        @Override
-        public void onHideCustomView() {
-            mActivity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-            mOnHideCustomViewCallbackHelper.notifyCalled();
-        }
-
-        public XWalkWebChromeClient.CustomViewCallback getExitCallback() {
-            return mExitCallback;
-        }
-
-        public View getCustomView() {
-            return mCustomView;
-        }
-
-        public boolean wasCustomViewShownCalled() {
-            return mOnShowCustomViewCallbackHelper.getCallCount() > 0;
-        }
-
-        public void waitForCustomViewShown() throws TimeoutException, InterruptedException {
-            mOnShowCustomViewCallbackHelper.waitForCallback(0, 1, WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        }
-
-        public void waitForCustomViewHidden() throws InterruptedException, TimeoutException {
-            mOnHideCustomViewCallbackHelper.waitForCallback(0, 1, WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        }
-    }
 
     void setUIClient(final XWalkUIClientInternal client) {
         getInstrumentation().runOnMainSync(new Runnable() {
@@ -162,15 +100,6 @@ public class XWalkViewInternalTestBase
             @Override
             public void run() {
                 getXWalkView().setResourceClient(client);
-            }
-        });
-    }
-
-    void setXWalkWebChromeClient(final TestXWalkWebChromeClientBase client) {
-        getInstrumentation().runOnMainSync(new Runnable() {
-            @Override
-            public void run() {
-                mXWalkViewInternal.setXWalkWebChromeClient(client);
             }
         });
     }


### PR DESCRIPTION
After Crosswalk 23.52.564.0, class XWalkWebChromeClient has been removed,
cannot use it anymore. Remove related code.

Impacted tests(approved): new 0, update 0, delete 0
Unit test platform: Crosswalk for Android 23.52.564.0
Unit test result summary: pass 44, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/CTS-1884