### PR TITLE
Improve inst.py for IoT platform

### DIFF
--- a/misc/webapi-service-docroot-tests/inst.iot.py
+++ b/misc/webapi-service-docroot-tests/inst.iot.py
@@ -35,22 +35,18 @@ def doCMD(cmd):
 
 def instPKGs():
     action_status = True
-
+    
     testsuite = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
     pwd = os.path.dirname(os.path.abspath(__file__))
+    docroot = os.path.join(pwd, "docroot")
 
-    pkg_app_dir = os.path.join(pwd, testsuite)
-    if os.path.exists(pkg_app_dir):
-        cmd = "scp -r %s %s:/opt" % (pkg_app_dir, PARAMETERS.device)
-        (return_code, output) = doCMD(cmd)
-        for line in output:
-            if "Failure" in line:
-                action_status = False
-                break
-    
-    sub_app_dir = os.path.join(pwd, "sub-app")
-    if os.path.exists(sub_app_dir):
-        cmd = "scp -r %s %s:/opt/%s" % (sub_app_dir, PARAMETERS.device, testsuite)
+    if not os.path.exists(docroot):
+        os.system("unzip -q %s -d %s" % (docroot, pwd))
+
+    uninstPKGs()
+
+    if os.path.exists(docroot):
+        cmd = "scp -r %s %s:/opt/%s" % (docroot, PARAMETERS.device, "docroot")
         (return_code, output) = doCMD(cmd)
         for line in output:
             if "Failure" in line:
@@ -61,10 +57,9 @@ def instPKGs():
 
 def uninstPKGs():
     action_status = True
-    
-    testsuite = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
 
-    cmd = 'ssh %s "rm -rf /opt/%s"' % (PARAMETERS.device, testsuite)
+    docroot = "docroot"
+    cmd = 'ssh %s "rm -rf /opt/%s"' % (PARAMETERS.device, docroot)
     (return_code, output) = doCMD(cmd)
     for line in output:
         if "Failure" in line:

--- a/misc/webapi-service-docroot-tests/pack.sh
+++ b/misc/webapi-service-docroot-tests/pack.sh
@@ -95,7 +95,11 @@ if [ $? -ne 0 ];then
     exit 1
 fi
 rm -rf $BUILD_DEST/opt
-cp -ar $BUILD_ROOT/inst.py $BUILD_DEST/inst.py
+if [ $pack_type == "iot" ]; then
+    cp -ar $BUILD_ROOT/inst.iot.py $BUILD_DEST/inst.py     
+else
+    cp -ar $BUILD_ROOT/inst.py $BUILD_DEST/inst.py
+fi
 cd /tmp
 mkdir $path_flag
 cp -a $BUILD_DEST $path_flag/${name}

--- a/tools/resources/inst/inst.iot.py
+++ b/tools/resources/inst/inst.iot.py
@@ -61,7 +61,7 @@ def instPKGs():
 
 def uninstPKGs():
     action_status = True
-    
+
     testsuite = os.path.basename(os.path.dirname(os.path.abspath(__file__)))
 
     cmd = 'ssh %s "rm -rf /opt/%s"' % (PARAMETERS.device, testsuite)


### PR DESCRIPTION
Update:
1. Use abspath when scp packages
2. Add a new inst.py for docroot on IoT