### PR TITLE
[Crosswalk-22][Cordova] Update Cordova default version to 1.0.0

### DIFF
--- a/tools/build/build_cordova.py
+++ b/tools/build/build_cordova.py
@@ -94,7 +94,7 @@ def packCordova(
         utils.replaceUserString(
             project_root,
             'config.xml',
-            'id="org.xwalk.%s" version="0.0.1"' % app_name,
+            'id="org.xwalk.%s" version="1.0.0"' % app_name,
             'id="org.xwalk.%s" version="%s"' %
             (app_name, version_opt))
 

--- a/usecase/usecase-cordova-android-tests/suite.json
+++ b/usecase/usecase-cordova-android-tests/suite.json
@@ -41,15 +41,14 @@
             "extra_plugins/cordova-plugin-crosswalk-webview-tests": "PACK-TOOL-ROOT/extra_plugins/cordova-plugin-crosswalk-webview-tests",
             "extra_plugins/cordova-screenshot": "PACK-TOOL-ROOT/extra_plugins/cordova-screenshot",
             "samples/cordova-incl.js": "cordova-incl.js"
-          },
-          "install-path": "./"
+          }
         },
         "samples/Database/res/database_source": {
           "app-name": "database",
+          "apk-version-opt": "2.0.0",
           "copylist": {
             "PACK-TOOL-ROOT/bootstrap-fw/js/jquery-2.1.3.min.js": "./js/jquery.js"
-          },
-          "install-path": "./"
+          }
         }
       }
     }


### PR DESCRIPTION
Failure Analysis:
XWALK-7368 Not able to migrate the existing webview data (localstorage/websql) to crosswalk

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android 22.52.561.0
Unit test result summary: pass 0, fail 1, block 0

https://crosswalk-project.org/jira/browse/XWALK-6767