### PR TITLE
Add onerror event to fix browing context timeout bug.

### DIFF
--- a/webapi/webapi-sensors-w3c-tests/sensors/resources/generic-sensor-tests.js
+++ b/webapi/webapi-sensors-w3c-tests/sensors/resources/generic-sensor-tests.js
@@ -122,6 +122,9 @@ function runGenericSensorBrowsingContext(sensorType) {
       win.close();
       sensor.stop();
     });
+    sensor.onerror = t.step_func_done(event => {
+      assert_unreached(event.error.name + ":" + event.error.message);
+    });
   }, "sensor readings can not be fired on the background tab");
 }
 


### PR DESCRIPTION
Impacted tests(approved): new 0, update 4, delete 0
Unit test platform: Chrome Canary 57.0.2942.0/Google Nexus 9 for Android
Unit test result summary: pass 4, fail 0, block 0