### PR TITLE
Modify the sensors and add timeStamp/frequency cases.

### DIFF
--- a/webapi/webapi-sensors-w3c-tests/sensors/Accelerometer.https.html
+++ b/webapi/webapi-sensors-w3c-tests/sensors/Accelerometer.https.html
@@ -47,6 +47,22 @@ function arr_sensor_reading(reading) {
   return new Array(reading.x, reading.y, reading.z);
 }
 
+async_test(t => {
+  let sensor1 = new Accelerometer();
+  let sensor2 = new Accelerometer({includeGravity: false});
+  sensor1.start();
+  sensor2.start();
+  sensor1.onactivate = t.step_func_done(() => {
+    assert_not_equals(sensor1.reading, sensor2.reading);
+    sensor1.stop();
+    sensor2.stop();
+  });
+  sensor1.onerror = t.step_func_done(event => {
+    assert_unreached(event.error.name + ":" + event.error.message);
+  });
+}, "Test that when construct Accelerometer with includeGravity that is set to false, the reading is different from the one with default Accelerometer..");
+
+runSensorFrequency(Accelerometer);
 runGenericSensorTests(Accelerometer, AccelerometerReading, verify_sensor_reading, arr_sensor_reading);
 
 </script>

--- a/webapi/webapi-sensors-w3c-tests/sensors/Gyroscope.https.html
+++ b/webapi/webapi-sensors-w3c-tests/sensors/Gyroscope.https.html
@@ -38,15 +38,16 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <script>
 
 function verify_sensor_reading(reading) {
-  return reading.x != 0 ||
-         reading.y != 0 ||
-         reading.z != 0;
+  return typeof(reading.x) == "number" &&
+         typeof(reading.y) == "number" &&
+         typeof(reading.z) == "number";
 }
 
 function arr_sensor_reading(reading) {
   return new Array(reading.x, reading.y, reading.z);
 }
 
+runSensorFrequency(Gyroscope);
 runGenericSensorTests(Gyroscope, GyroscopeReading, verify_sensor_reading, arr_sensor_reading);
 
 </script>

--- a/webapi/webapi-sensors-w3c-tests/sensors/Magnetometer.https.html
+++ b/webapi/webapi-sensors-w3c-tests/sensors/Magnetometer.https.html
@@ -47,6 +47,7 @@ function arr_sensor_reading(reading) {
   return new Array(reading.x, reading.y, reading.z);
 }
 
+runSensorFrequency(Magnetometer);
 runGenericSensorTests(Magnetometer, MagnetometerReading, verify_sensor_reading, arr_sensor_reading);
 
 </script>


### PR DESCRIPTION
Impacted tests(approved): new 10, update 12, delete 4
Unit test platform: Chrome Canary 57.0.2943.3/Google Nexus 9
Unit test result summary: pass 22, fail 0, block 0

Unit test delete reason: merge it to the case "Test that sensor reading is correct."